### PR TITLE
fix: be a more tolerant reader of decide response

### DIFF
--- a/src/PostHog/Api/FeatureFlagApiResult.cs
+++ b/src/PostHog/Api/FeatureFlagApiResult.cs
@@ -6,26 +6,17 @@ using PostHog.Json;
 
 namespace PostHog.Api;
 
+/**
+ * This is a subset of the total possible properties on a response to remoteconfig/decide
+ * Some properties are unnecessary for a backend SDK and are ignored
+ */
 public class FeatureFlagsApiResult
 {
     public FeatureFlagsConfig Config { get; set; } = new(false);
-    public ReadOnlyDictionary<string, object> ToolbarParams { get; set; } = new(new Dictionary<string, object>());
     public bool IsAuthenticated { get; set; }
-    public ReadOnlyCollection<string> SupportedCompression { get; set; } = new(Array.Empty<string>());
     public ReadOnlyDictionary<string, StringOrValue<bool>> FeatureFlags { get; set; } = new(new Dictionary<string, StringOrValue<bool>>());
-    public bool SessionRecording { get; set; }
-    public bool CaptureDeadClicks { get; set; }
-    public CapturePerformance CapturePerformance { get; set; } = new(false, false, null);
-
-    [JsonPropertyName("autocapture_opt_out")]
-    public bool AutocaptureOptOut { get; set; }
-    public bool AutocaptureExceptions { get; set; }
     public Analytics Analytics { get; set; } = new(string.Empty);
-    public bool ElementsChainAsString { get; set; }
-    public bool Surveys { get; set; }
-    public bool Heatmaps { get; set; }
     public bool DefaultIdentifiedOnly { get; set; }
-    public ReadOnlyCollection<object> SiteApps { get; set; } = new(Array.Empty<object>());
     public bool ErrorsWhileComputingFlags { get; set; }
     public ReadOnlyDictionary<string, string> FeatureFlagPayloads { get; set; } = new(new Dictionary<string, string>());
 }
@@ -34,21 +25,6 @@ public class FeatureFlagsConfig(bool enableCollectEverything)
 {
     [JsonPropertyName("enable_collect_everything")]
     public bool EnableCollectEverything => enableCollectEverything;
-}
-
-public class CapturePerformance(
-    bool networkTiming,
-    bool webVitals,
-    object? webVitalsAllowedMetrics)
-{
-    [JsonPropertyName("network_timing")]
-    public bool NetworkTiming => networkTiming;
-
-    [JsonPropertyName("web_vitals")]
-    public bool WebVitals => webVitals;
-
-    [JsonPropertyName("web_vitals_allowed_metrics")]
-    public object? WebVitalsAllowedMetrics => webVitalsAllowedMetrics;
 }
 
 public class Analytics(string endpoint)

--- a/tests/UnitTests/Json/JsonSerializerHelperTests.cs
+++ b/tests/UnitTests/Json/JsonSerializerHelperTests.cs
@@ -34,28 +34,15 @@ public class JsonSerializerHelperTests
             // Assert
             Assert.NotNull(result);
             Assert.True(result.Config.EnableCollectEverything);
-            Assert.Empty(result.ToolbarParams);
             Assert.False(result.IsAuthenticated);
-            Assert.Equal(["gzip", "gzip-js"], result.SupportedCompression);
             Assert.Equal(new Dictionary<string, StringOrValue<bool>>()
             {
                 ["hogtied_got_character"] = "danaerys",
                 ["hogtied-homepage-user"] = true,
                 ["hogtied-homepage-bonanza"] = true
             }, result.FeatureFlags);
-            Assert.False(result.SessionRecording);
-            Assert.False(result.CaptureDeadClicks);
-            Assert.True(result.CapturePerformance.NetworkTiming);
-            Assert.True(result.CapturePerformance.WebVitals);
-            Assert.Null(result.CapturePerformance.WebVitalsAllowedMetrics);
-            Assert.False(result.AutocaptureOptOut);
-            Assert.False(result.AutocaptureExceptions);
             Assert.Equal("/i/v0/e/", result.Analytics.Endpoint);
-            Assert.True(result.ElementsChainAsString);
-            Assert.False(result.Surveys);
-            Assert.True(result.Heatmaps);
             Assert.True(result.DefaultIdentifiedOnly);
-            Assert.Empty(result.SiteApps);
             Assert.False(result.ErrorsWhileComputingFlags);
             Assert.Equal(new Dictionary<string, string>
             {
@@ -77,28 +64,15 @@ public class JsonSerializerHelperTests
             // Assert
             Assert.NotNull(result);
             Assert.False(result.Config.EnableCollectEverything);
-            Assert.Empty(result.ToolbarParams);
             Assert.True(result.IsAuthenticated);
-            Assert.Equal(["gzip", "gzip-js"], result.SupportedCompression);
             Assert.Equal(new Dictionary<string, StringOrValue<bool>>()
             {
                 ["hogtied_got_character"] = false,
                 ["hogtied-homepage-user"] = false,
                 ["hogtied-homepage-bonanza"] = false
             }, result.FeatureFlags);
-            Assert.True(result.SessionRecording);
-            Assert.True(result.CaptureDeadClicks);
-            Assert.False(result.CapturePerformance.NetworkTiming);
-            Assert.False(result.CapturePerformance.WebVitals);
-            Assert.NotNull(result.CapturePerformance.WebVitalsAllowedMetrics);
-            Assert.True(result.AutocaptureOptOut);
-            Assert.True(result.AutocaptureExceptions);
             Assert.Equal("/i/v0/e/", result.Analytics.Endpoint);
-            Assert.False(result.ElementsChainAsString);
-            Assert.True(result.Surveys);
-            Assert.False(result.Heatmaps);
             Assert.False(result.DefaultIdentifiedOnly);
-            Assert.Empty(result.SiteApps);
             Assert.True(result.ErrorsWhileComputingFlags);
             Assert.Empty(result.FeatureFlagPayloads);
         }


### PR DESCRIPTION
When starting the example app pointing at my local instance (but it would have been true of most any instance of PostHog)

The application was exploding because the client was trying to deserialize the `sessionRecording` property of the `decide` response into a `boolean` but it is only `boolean` when `False` otherrwise it's an object.

Since the web SDK is the closest we have to a reference SDK it is relatively common for us to both implicitly and explicitly rely on the type of things being `boolean | BlahConfig` for example https://github.com/PostHog/posthog-js/blob/e0c4ba4f3610c17480b8b250c9b3a11cc160cc3e/src/types.ts#L532

Since properties that are `boolean` today could change to be `boolean | BlahConfig` in future I opted to remove properties that looked mostly front-end specific. To avoid them exploding

I don't _think_ we can support web sdk things like heatmaps and session recording in this SDK

And can add them back when we need them if we can support them here