### PR TITLE
Separate package publishing into its own workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,8 +37,9 @@ jobs:
         run: dotnet build --configuration Release --no-restore --nologo
         shell: bash
 
-      # Upload the packages so the publish job can download them
-      - uses: actions/upload-artifact@v4
+      # Upload the packages so the release.yaml workflow can pick them up
+      - if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
         with:
           name: nuget
           if-no-files-found: error
@@ -89,27 +90,4 @@ jobs:
 
       - name: Format!
         run: bin/fmt --check
-        shell: bash
-
-  publish:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    steps:
-      # Download the NuGet packages created in the build job
-      - uses: actions/download-artifact@v4
-        with:
-          name: nuget
-          path: ${{ env.PackageDirectory }}
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      # Publish all NuGet packages to NuGet.org
-      # Use --skip-duplicate to prevent errors if a package with the same version already exists.
-      # If you retry a failed workflow, already published packages will be skipped without error.
-      - name: Publish NuGet package
-        run: bin/publish ${{ env.PackageDirectory }} ${{ secrets.NUGET_API_KEY }}
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Publish Package to NuGet
+on:
+  release:
+    types: [created]
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  PackageDirectory: ${{ github.workspace }}/build/packages/Release
+  DOTNET_VERSION: 9.0.101
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Download the NuGet packages created in the build job
+      - uses: actions/download-artifact@v4
+        with:
+          name: nuget
+          path: ${{ env.PackageDirectory }}
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # Publish all NuGet packages to NuGet.org
+      # Use --skip-duplicate to prevent errors if a package with the same version already exists.
+      # If you retry a failed workflow, already published packages will be skipped without error.
+      - name: Publish NuGet package
+        run: bin/publish ${{ env.PackageDirectory }} ${{ secrets.NUGET_API_KEY }}
+        shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 name: Publish Package to NuGet
 on:
+  workflow_dispatch:
   release:
     types: [created]
 

--- a/PostHog.sln
+++ b/PostHog.sln
@@ -49,6 +49,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\stale-labeller.yaml = .github\workflows\stale-labeller.yaml
 		.github\workflows\main.yaml = .github\workflows\main.yaml
+		.github\workflows\release.yaml = .github\workflows\release.yaml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "problemMatchers", "problemMatchers", "{DE86ACE8-2A13-4B5C-A715-1BA6412DA314}"


### PR DESCRIPTION
Also, handle the release `create` event.