### PR TITLE
Only publish on tag and release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,8 +2,6 @@ name: Build PostHog .NET SDK
 
 on:
   push:
-    tags:
-      - v*
     branches:
       - main
   pull_request:
@@ -39,18 +37,11 @@ jobs:
         run: dotnet build --configuration Release --no-restore --nologo
         shell: bash
 
-      # Retrieve the release tag, if this is a tag push
-      - if: startsWith(github.ref, 'refs/tags/')
-        name: Get release tag
-        id: get_tag
-        run: echo "RELEASE_TAG=${{ github.ref }}" >> $GITHUB_ENV
-
-      # Upload the packages so the release.yaml workflow can pick them up, if this is a tag push
-      - if: startsWith(github.ref, 'refs/tags/') # Only upload packages for tags
-        name: Upload NuGet Package Artifacts
+      # Upload the package using the SHA in the name
+      - name: Upload NuGet Package Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: nuget-${{ env.RELEASE_TAG }}
+          name: nuget-${{ github.sha }}
           if-no-files-found: error
           retention-days: 7
           path: ${{ env.PackageDirectory }}/*.nupkg

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,6 +2,8 @@ name: Build PostHog .NET SDK
 
 on:
   push:
+    tags:
+      - v*
     branches:
       - main
   pull_request:
@@ -37,11 +39,18 @@ jobs:
         run: dotnet build --configuration Release --no-restore --nologo
         shell: bash
 
-      # Upload the packages so the release.yaml workflow can pick them up
-      - if: github.ref == 'refs/heads/main'
+      # Retrieve the release tag, if this is a tag push
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Get release tag
+        id: get_tag
+        run: echo "RELEASE_TAG=${{ github.ref }}" >> $GITHUB_ENV
+
+      # Upload the packages so the release.yaml workflow can pick them up, if this is a tag push
+      - if: startsWith(github.ref, 'refs/tags/') # Only upload packages for tags
+        name: Upload NuGet Package Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: nuget
+          name: nuget-${{ env.RELEASE_TAG }}
           if-no-files-found: error
           retention-days: 7
           path: ${{ env.PackageDirectory }}/*.nupkg

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,24 +1,28 @@
 name: Publish Package to NuGet
 on:
-  workflow_dispatch:
   release:
     types: [created]
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  PackageDirectory: ${{ github.workspace }}/build/packages/Release
   DOTNET_VERSION: 9.0.101
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Retrieve the release tag
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Get release tag
+        id: get_tag
+        run: echo "RELEASE_TAG=${{ github.ref }}" >> $GITHUB_ENV
+
       # Download the NuGet packages created in the build job
       - uses: actions/download-artifact@v4
         with:
-          name: nuget
-          path: ${{ env.PackageDirectory }}
+          name: nuget-${{ env.RELEASE_TAG }}
+          path: .
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
@@ -29,5 +33,5 @@ jobs:
       # Use --skip-duplicate to prevent errors if a package with the same version already exists.
       # If you retry a failed workflow, already published packages will be skipped without error.
       - name: Publish NuGet package
-        run: bin/publish ${{ env.PackageDirectory }} ${{ secrets.NUGET_API_KEY }}
+        run: bin/publish . ${{ secrets.NUGET_API_KEY }}
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,16 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      # Retrieve the release tag
-      - if: startsWith(github.ref, 'refs/tags/')
-        name: Get release tag
-        id: get_tag
-        run: echo "RELEASE_TAG=${{ github.ref }}" >> $GITHUB_ENV
-
-      # Download the NuGet packages created in the build job
+      # Download the NuGet packages created in the build job for this tagged commit.
       - uses: actions/download-artifact@v4
         with:
-          name: nuget-${{ env.RELEASE_TAG }}
+          name: nuget-${{ github.sha }}
           path: .
 
       - name: Setup .NET Core


### PR DESCRIPTION
When we tag a release using the pattern `v*`, we'll upload the build artifacts. The release job will grab those artifacts and publish.