### PR TITLE
Fix sending the $lib property when capturing batches

### DIFF
--- a/src/PostHog/Api/CapturedEvent.cs
+++ b/src/PostHog/Api/CapturedEvent.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using PostHog.Versioning;
 
@@ -10,6 +8,13 @@ namespace PostHog.Api;
 /// </summary>
 public class CapturedEvent
 {
+    /// <summary>
+    /// Creates a <see cref="CapturedEvent"/>.
+    /// </summary>
+    /// <param name="eventName">The name of the event.</param>
+    /// <param name="distinctId">The identifier for the user.</param>
+    /// <param name="properties">The properties to associate with the event.</param>
+    /// <param name="timestamp">The ISO 8601 timestamp.</param>
     public CapturedEvent(
         string eventName,
         string distinctId,
@@ -17,12 +22,12 @@ public class CapturedEvent
         DateTimeOffset timestamp)
     {
         EventName = eventName;
-        DistinctId = distinctId;
         Timestamp = timestamp;
 
         Properties = properties;
 
         // Every event has to have these properties.
+        Properties["distinct_id"] = distinctId;
         Properties["$lib"] = PostHogApiClient.LibraryName;
         Properties["$lib_version"] = VersionConstants.Version;
     }
@@ -32,12 +37,6 @@ public class CapturedEvent
     /// </summary>
     [JsonPropertyName("event")]
     public string EventName { get; }
-
-    /// <summary>
-    /// The distinct identifier.
-    /// </summary>
-    [JsonPropertyName("distinct_id")]
-    public string DistinctId { get; private set; }
 
     /// <summary>
     /// The properties to send with the event.

--- a/src/PostHog/Api/CapturedEvent.cs
+++ b/src/PostHog/Api/CapturedEvent.cs
@@ -1,32 +1,51 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using PostHog.Versioning;
 
 namespace PostHog.Api;
 
 /// <summary>
 /// A captured event that will be sent as part of a batch.
 /// </summary>
-/// <param name="eventName">The name of the event</param>
-public class CapturedEvent(
-    string eventName,
-    string distinctId,
-    Dictionary<string, object> properties,
-    DateTimeOffset timestamp)
+public class CapturedEvent
 {
-    [JsonPropertyName("event")]
-    public string EventName => eventName;
+    public CapturedEvent(
+        string eventName,
+        string distinctId,
+        Dictionary<string, object> properties,
+        DateTimeOffset timestamp)
+    {
+        EventName = eventName;
+        DistinctId = distinctId;
+        Timestamp = timestamp;
 
+        Properties = properties;
+
+        // Every event has to have these properties.
+        Properties["$lib"] = PostHogApiClient.LibraryName;
+        Properties["$lib_version"] = VersionConstants.Version;
+    }
+
+    /// <summary>
+    /// The event name.
+    /// </summary>
+    [JsonPropertyName("event")]
+    public string EventName { get; }
+
+    /// <summary>
+    /// The distinct identifier.
+    /// </summary>
     [JsonPropertyName("distinct_id")]
-    public string DistinctId => distinctId;
+    public string DistinctId { get; private set; }
 
     /// <summary>
     /// The properties to send with the event.
     /// </summary>
-    public Dictionary<string, object> Properties => properties;
+    public Dictionary<string, object> Properties { get; }
 
     /// <summary>
     /// The timestamp of the event.
     /// </summary>
-    public DateTimeOffset Timestamp => timestamp;
+    public DateTimeOffset Timestamp { get; }
 }

--- a/src/PostHog/Api/IPostHogApiClient.cs
+++ b/src/PostHog/Api/IPostHogApiClient.cs
@@ -33,4 +33,9 @@ public interface IPostHogApiClient : IDisposable
         Dictionary<string, object>? personProperties,
         GroupCollection? groupProperties,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The version of the client.
+    /// </summary>
+    Version Version { get; }
 }

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -72,11 +72,10 @@ public sealed class PostHogApiClient : IPostHogApiClient
 
         var payload = new Dictionary<string, object>
         {
+            ["api_key"] = ProjectApiKey,
             ["historical_migrations"] = false,
             ["batch"] = events.ToReadOnlyList()
         };
-
-        PrepareAndMutatePayload(payload);
 
         return await _httpClient.PostJsonAsync<ApiResult>(endpointUrl, payload, cancellationToken)
                ?? new ApiResult(0);
@@ -129,13 +128,14 @@ public sealed class PostHogApiClient : IPostHogApiClient
 
     void PrepareAndMutatePayload(Dictionary<string, object> payload)
     {
+        payload["api_key"] = ProjectApiKey;
+
         if (payload.GetValueOrDefault("properties") is Dictionary<string, object> properties)
         {
             properties["$lib"] = LibraryName;
             properties["$lib_version"] = VersionConstants.Version;
         }
 
-        payload["api_key"] = ProjectApiKey;
         payload["timestamp"] = _timeProvider.GetUtcNow(); // ISO 8601
     }
 

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -9,12 +9,33 @@ namespace PostHog.Api;
 /// <inheritdoc cref="IPostHogApiClient" />
 public sealed class PostHogApiClient : IPostHogApiClient
 {
-    const string LibraryName = "posthog-dotnet";
+    internal const string LibraryName = "posthog-dotnet";
 
     readonly TimeProvider _timeProvider;
     readonly HttpClient _httpClient;
-    readonly LoggingHttpMessageHandler _loggingHandler;
     readonly IOptions<PostHogOptions> _options;
+
+    /// <summary>
+    /// Initialize a new PostHog client
+    /// </summary>
+    /// <param name="httpClient">The <see cref="HttpClient"/> used to make requests.</param>
+    /// <param name="options">The options used to configure this client.</param>
+    /// <param name="timeProvider"></param>
+    /// <param name="logger">The logger.</param>
+    public PostHogApiClient(
+        HttpClient httpClient,
+        IOptions<PostHogOptions> options,
+        TimeProvider timeProvider,
+        ILogger<PostHogApiClient> logger)
+    {
+        _options = options;
+
+        _timeProvider = timeProvider;
+
+        _httpClient = httpClient;
+
+        logger.LogTraceApiClientCreated(HostUrl);
+    }
 
     /// <summary>
     /// Initialize a new PostHog client
@@ -26,18 +47,15 @@ public sealed class PostHogApiClient : IPostHogApiClient
         IOptions<PostHogOptions> options,
         TimeProvider timeProvider,
         ILogger<PostHogApiClient> logger)
+        : this(
+#pragma warning disable CA2000
+            // LoggingHttpMessageHandler is disposed when we dispose the HttpClient
+            new HttpClient(new LoggingHttpMessageHandler(logger)
+            {
+                InnerHandler = new HttpClientHandler()
+            }), options, timeProvider, logger)
+#pragma warning restore CA2000
     {
-        _options = options;
-
-        _timeProvider = timeProvider;
-        _loggingHandler = new LoggingHttpMessageHandler(logger)
-        {
-            InnerHandler = new HttpClientHandler()
-        };
-
-        _httpClient = new HttpClient(_loggingHandler);
-
-        logger.LogTraceApiClientCreated(HostUrl);
     }
 
     Uri HostUrl => _options.Value.HostUrl;
@@ -106,6 +124,9 @@ public sealed class PostHogApiClient : IPostHogApiClient
                ?? new FeatureFlagsApiResult();
     }
 
+    /// <inheritdoc/>
+    public Version Version => new(VersionConstants.Version);
+
     void PrepareAndMutatePayload(Dictionary<string, object> payload)
     {
         if (payload.GetValueOrDefault("properties") is Dictionary<string, object> properties)
@@ -115,17 +136,13 @@ public sealed class PostHogApiClient : IPostHogApiClient
         }
 
         payload["api_key"] = ProjectApiKey;
-        payload["timestamp"] = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
+        payload["timestamp"] = _timeProvider.GetUtcNow(); // ISO 8601
     }
 
     /// <summary>
     /// Dispose of HttpClient
     /// </summary>
-    public void Dispose()
-    {
-        _loggingHandler.Dispose();
-        _httpClient.Dispose();
-    }
+    public void Dispose() => _httpClient.Dispose();
 }
 
 internal static partial class PostHogApiClientLoggerExtensions

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "0.0.1";
+    public const string Version = "0.0.2";
 }

--- a/src/PostHog/IPostHogClient.cs
+++ b/src/PostHog/IPostHogClient.cs
@@ -86,4 +86,9 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/>.</returns>
     Task FlushAsync();
+
+    /// <summary>
+    /// The version of this library.
+    /// </summary>
+    Version Version { get; }
 }

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -104,7 +104,7 @@ public sealed class PostHogClient : IPostHogClient
             eventName,
             distinctId,
             properties,
-            _timeProvider.GetUtcNow().DateTime);
+            timestamp: _timeProvider.GetUtcNow());
 
         _asyncBatchHandler.Enqueue(capturedEvent);
 

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -6,6 +6,7 @@ using PostHog.Config;
 using PostHog.Features;
 using PostHog.Json;
 using PostHog.Library;
+using PostHog.Versioning;
 
 namespace PostHog;
 
@@ -146,6 +147,9 @@ public sealed class PostHogClient : IPostHogClient
 
     /// <inheritdoc/>
     public async Task FlushAsync() => await _asyncBatchHandler.FlushAsync();
+
+    /// <inheritdoc/>
+    public Version Version => _apiClient.Version;
 
     /// <inheritdoc/>
     public void Dispose() => DisposeAsync().AsTask().Wait();

--- a/tests/UnitTests/Api/PostHogApiClientTests.cs
+++ b/tests/UnitTests/Api/PostHogApiClientTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using PostHog.Api;
+using PostHog.Config;
+
+public class PostHogApiClientTests
+{
+    public class TheCaptureBatchAsyncMethod
+    {
+        [Fact]
+        public async Task SendsBatchToCaptureEndpoint()
+        {
+            using var messageHandler = new FakeHttpMessageHandler();
+            var timeProvider = new FakeTimeProvider();
+            timeProvider.SetUtcNow(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var requestHandler = messageHandler.AddResponse(
+                new Uri("https://us.i.posthog.com/batch"),
+                HttpMethod.Post,
+                responseBody: new { status = 1 });
+            using var httpClient = new HttpClient(messageHandler);
+            using var client = new PostHogApiClient(
+                httpClient,
+                new PostHogOptions { ProjectApiKey = "test" },
+                timeProvider,
+                new NullLogger<PostHogApiClient>());
+
+            await client.CaptureBatchAsync([
+                new CapturedEvent("some_event", "some-distinct-id", new Dictionary<string, object>(), timeProvider.GetUtcNow())
+            ], CancellationToken.None);
+
+            var received = requestHandler.GetReceivedRequestBody(indented: true);
+            Assert.Equal($$"""
+                         {
+                           "historical_migrations": false,
+                           "batch": [
+                             {
+                               "event": "some_event",
+                               "distinct_id": "some-distinct-id",
+                               "properties": {
+                                 "$lib": "{{PostHogApiClient.LibraryName}}",
+                                 "$lib_version": "{{client.Version}}"
+                               },
+                               "timestamp": "1999-12-31T16:00:00-08:00"
+                             }
+                           ],
+                           "api_key": "test",
+                           "timestamp": "1999-12-31T16:00:00-08:00"
+                         }
+                         """, received);
+        }
+    }
+}

--- a/tests/UnitTests/Api/PostHogApiClientTests.cs
+++ b/tests/UnitTests/Api/PostHogApiClientTests.cs
@@ -12,7 +12,7 @@ public class PostHogApiClientTests
         {
             using var messageHandler = new FakeHttpMessageHandler();
             var timeProvider = new FakeTimeProvider();
-            timeProvider.SetUtcNow(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            timeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 21, 19, 08, 23, TimeSpan.Zero));
             var requestHandler = messageHandler.AddResponse(
                 new Uri("https://us.i.posthog.com/batch"),
                 HttpMethod.Post,
@@ -31,20 +31,19 @@ public class PostHogApiClientTests
             var received = requestHandler.GetReceivedRequestBody(indented: true);
             Assert.Equal($$"""
                          {
+                           "api_key": "test",
                            "historical_migrations": false,
                            "batch": [
                              {
                                "event": "some_event",
-                               "distinct_id": "some-distinct-id",
                                "properties": {
-                                 "$lib": "{{PostHogApiClient.LibraryName}}",
+                                 "distinct_id": "some-distinct-id",
+                                 "$lib": "posthog-dotnet",
                                  "$lib_version": "{{client.Version}}"
                                },
-                               "timestamp": "1999-12-31T16:00:00-08:00"
+                               "timestamp": "2024-01-21T19:08:23\u002B00:00"
                              }
-                           ],
-                           "api_key": "test",
-                           "timestamp": "1999-12-31T16:00:00-08:00"
+                           ]
                          }
                          """, received);
         }

--- a/tests/UnitTests/Fakes/FakeHttpMessageHandler.cs
+++ b/tests/UnitTests/Fakes/FakeHttpMessageHandler.cs
@@ -1,0 +1,181 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
+
+/// <summary>
+/// Useful class for testing HTTP clients.
+/// </summary>
+public class FakeHttpMessageHandler : HttpMessageHandler
+{
+    readonly List<RequestHandler> _handlers = [];
+
+    public static HttpResponseMessage CreateResponse<TResponseBody>(TResponseBody responseBody, string contentType = "application/json")
+        => CreateResponse(JsonConvert.SerializeObject(responseBody), contentType);
+
+    public static HttpResponseMessage CreateResponse(string responseBody, string contentType) =>
+        new()
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseBody, Encoding.UTF8, contentType)
+        };
+
+    public RequestHandler AddResponse(Uri url, HttpResponseMessage responseMessage) =>
+        AddResponse(url, HttpMethod.Get, responseMessage);
+
+    public RequestHandler AddResponseException(Uri url, HttpMethod httpMethod, Exception responseException)
+    {
+        var handler = new RequestHandler(url, httpMethod, responseException);
+        _handlers.Add(handler);
+        return handler;
+    }
+
+    public RequestHandler AddResponse(Uri url, HttpMethod httpMethod, HttpResponseMessage responseMessage)
+    {
+        var handler = new RequestHandler(url, httpMethod, responseMessage);
+        _handlers.Add(handler);
+        return handler;
+    }
+
+    public RequestHandler AddResponse(Uri url, HttpMethod httpMethod, string responseBody, string contentType)
+    {
+#pragma warning disable CA2000
+        var responseMessage = CreateResponse(responseBody, contentType);
+#pragma warning restore CA2000
+        var handler = new RequestHandler(url, httpMethod, responseMessage);
+        _handlers.Add(handler);
+        return handler;
+    }
+
+    public RequestHandler AddResponse<TResponseBody>(
+        Uri url,
+        HttpMethod httpMethod,
+        TResponseBody responseBody,
+        string contentType = "application/json")
+    {
+        var json = JsonConvert.SerializeObject(responseBody);
+        return AddResponse(url, httpMethod, json, contentType);
+    }
+
+    public RequestHandler AddResponse(Uri url, HttpMethod httpMethod, Func<Task<HttpResponseMessage>> responseHandler)
+    {
+        var handler = new RequestHandler(url, httpMethod, responseHandler);
+        _handlers.Add(handler);
+        return handler;
+    }
+
+    public RequestHandler AddStreamResponse(Func<HttpRequestMessage, Task<bool>> requestPredicate, Stream responseStream)
+    {
+        var content = new StreamContent(responseStream);
+#pragma warning disable CA2000
+        var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = content
+        };
+#pragma warning restore CA2000
+        var handler = new RequestHandler(requestPredicate, responseMessage);
+        _handlers.Add(handler);
+        return handler;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        foreach (var handler in _handlers)
+        {
+            if (await handler.IsMatch(request))
+            {
+                _handlers.Remove(handler); // Pop the handler so we can simulate multiple requests with different responses.
+                return await handler.Respond(request);
+            }
+        }
+
+        return new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
+    }
+
+    public class RequestHandler
+    {
+        readonly Func<HttpRequestMessage, Task<bool>> _requestPredicate;
+        readonly List<HttpRequestMessage> _receivedRequests = new();
+        readonly List<string> _receivedBodiesJson = new();
+        readonly Func<Task<HttpResponseMessage>> _responseHandler;
+
+        /// <summary>
+        /// Constructs a <see cref="RequestHandler"/> that throws an exception when the specified url
+        /// is requested.
+        /// </summary>
+        /// <param name="uri">The URL to request.</param>
+        /// <param name="httpMethod">The HTTP Method.</param>
+        /// <param name="exception">The exception to throw.</param>
+        public RequestHandler(Uri uri, HttpMethod httpMethod, Exception exception)
+            : this(CreateRequestPredicate(uri, httpMethod), () => throw exception)
+        {
+        }
+
+        public RequestHandler(Uri uri, HttpResponseMessage responseMessage)
+            : this(CreateRequestPredicate(uri, HttpMethod.Get), responseMessage)
+        {
+        }
+
+        public RequestHandler(Uri uri, HttpMethod httpMethod, HttpResponseMessage responseMessage)
+            : this(CreateRequestPredicate(uri, httpMethod), responseMessage)
+        {
+        }
+
+        public RequestHandler(Uri uri, Func<Task<HttpResponseMessage>> responseHandler)
+            : this(CreateRequestPredicate(uri, HttpMethod.Get), responseHandler)
+        {
+        }
+
+        public RequestHandler(Uri uri, HttpMethod httpMethod, Func<Task<HttpResponseMessage>> responseHandler)
+            : this(CreateRequestPredicate(uri, httpMethod), responseHandler)
+        {
+        }
+
+        public RequestHandler(
+            Func<HttpRequestMessage, Task<bool>> requestPredicate,
+            HttpResponseMessage responseMessage)
+            : this(requestPredicate, () => Task.FromResult(responseMessage))
+        {
+        }
+
+        public RequestHandler(
+            Func<HttpRequestMessage, Task<bool>> requestPredicate,
+            Func<Task<HttpResponseMessage>> responseHandler)
+        {
+            _requestPredicate = requestPredicate;
+            _responseHandler = responseHandler;
+        }
+
+        static Func<HttpRequestMessage, Task<bool>> CreateRequestPredicate(Uri uri, HttpMethod httpMethod)
+        {
+            return request => Task.FromResult(request.RequestUri == uri && request.Method == httpMethod);
+        }
+
+        public Task<bool> IsMatch(HttpRequestMessage requestMessage) => _requestPredicate(requestMessage);
+
+        public async Task<HttpResponseMessage> Respond(HttpRequestMessage requestMessage)
+        {
+            Debug.Assert(requestMessage != null, nameof(requestMessage) + " != null");
+            _receivedRequests.Add(requestMessage);
+            if (requestMessage.Content is not null)
+            {
+                _receivedBodiesJson.Add(await requestMessage.Content.ReadAsStringAsync());
+            }
+
+            return await _responseHandler();
+        }
+
+        public IReadOnlyList<HttpRequestMessage> ReceivedRequests => _receivedRequests;
+
+        public HttpRequestMessage ReceivedRequest => _receivedRequests.Single();
+
+        public string GetReceivedRequestBody(bool indented = false)
+        {
+            var json = _receivedBodiesJson.Single();
+            return indented
+                ? JsonConvert.SerializeObject(JsonConvert.DeserializeObject(json), Formatting.Indented)
+                : json;
+        }
+    }
+}


### PR DESCRIPTION
I think capturing events was broken prior to this PR. But now it's fixed.

Fixes #27