### PR TITLE
Disable geoip enrichment

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.2</Version>
+        <Version>0.0.3</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/PostHog/Api/CapturedEvent.cs
+++ b/src/PostHog/Api/CapturedEvent.cs
@@ -30,6 +30,7 @@ public class CapturedEvent
         Properties["distinct_id"] = distinctId;
         Properties["$lib"] = PostHogApiClient.LibraryName;
         Properties["$lib_version"] = VersionConstants.Version;
+        Properties["$geoip_disable"] = true;
     }
 
     /// <summary>

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -134,6 +134,7 @@ public sealed class PostHogApiClient : IPostHogApiClient
         {
             properties["$lib"] = LibraryName;
             properties["$lib_version"] = VersionConstants.Version;
+            properties["$geoip_disable"] = true;
         }
 
         payload["timestamp"] = _timeProvider.GetUtcNow(); // ISO 8601

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "0.0.2";
+    public const string Version = "0.0.3";
 }

--- a/tests/UnitTests/Api/PostHogApiClientTests.cs
+++ b/tests/UnitTests/Api/PostHogApiClientTests.cs
@@ -39,7 +39,8 @@ public class PostHogApiClientTests
                                "properties": {
                                  "distinct_id": "some-distinct-id",
                                  "$lib": "posthog-dotnet",
-                                 "$lib_version": "{{client.Version}}"
+                                 "$lib_version": "{{client.Version}}",
+                                 "$geoip_disable": true
                                },
                                "timestamp": "2024-01-21T19:08:23\u002B00:00"
                              }


### PR DESCRIPTION
When sending an event to PostHog, the server will "enrich" that event with GeoIP location data. However, for client libraries like this that are meant to be used on the server, that doesn't make much sense since it'll always be the location data of the server hosting this client.

This sets the `$geoip_disable` property to `true` which makes reading information about captured events from this library much easier.

If someone wants GeoIP enrichment, they can open an issue and I'll consider it.
356d70b
