### PR TITLE
Rename methods to match other libraries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.0-beta.2</Version>
+        <Version>1.0.0-beta.3</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ When you create the Release, the [`main.yml`](../.github/.workflow.release.yml) 
 Inject the `IPostHogClient` interface into your controller or page:
 
 ```csharp
-posthogClient.CaptureEvent(userId, "user signed up", new() { ["plan"] = "pro" });
+posthogClient.Capture(userId, "user signed up", new() { ["plan"] = "pro" });
 }
 ```
 
@@ -134,7 +134,7 @@ await posthogClient.AliasAsync(sessionId, userId);
 Note that capturing events is designed to be fast and done in the background. You can configure how often batches are sent to the PostHog API using the `FlushAt` and `FlushInterval` settings.
 
 ```csharp
-posthogClient.CaptureEvent(userId, "user signed up", new() { ["plan"] = "pro" });
+posthogClient.Capture(userId, "user signed up", new() { ["plan"] = "pro" });
 ```
 
 #### Capture a Page View

--- a/samples/HogTied.Web/Pages/Index.cshtml.cs
+++ b/samples/HogTied.Web/Pages/Index.cshtml.cs
@@ -58,7 +58,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
             // Identify the current user if they're authenticated.
             if (User.Identity?.IsAuthenticated == true)
             {
-                await posthog.IdentifyPersonAsync(
+                await posthog.IdentifyAsync(
                     UserId,
                     email: User.FindFirst(ClaimTypes.Email)?.Value,
                     name: User.FindFirst(ClaimTypes.Name)?.Value,
@@ -116,7 +116,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
         }
 
         // Send a custom event
-        posthog.CaptureEvent(
+        posthog.Capture(
             UserId,
             eventName: EventName ?? "plan_purchased",
             properties: new()
@@ -139,7 +139,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
         }
 
         // Identify a group
-        var result = await posthog.IdentifyGroupAsync(
+        var result = await posthog.GroupIdentifyAsync(
             Group.Type,
             Group.Key,
             Group.Name,

--- a/samples/HogTied.Web/Program.cs
+++ b/samples/HogTied.Web/Program.cs
@@ -37,7 +37,7 @@ builder.AddPostHog()
                     if (user is not null)
                     {
                         // This stores information about the user in PostHog.
-                        await postHogClient.IdentifyPersonAsync(
+                        await postHogClient.IdentifyAsync(
                             userId,
                             user.Email,
                             user.UserName,

--- a/src/PostHog.AspNetCore/README.md
+++ b/src/PostHog.AspNetCore/README.md
@@ -75,7 +75,7 @@ public class HomeController(IPostHogClient posthogClient) : Controller
     public IActionResult SignUpComplete()
     {
         var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-        posthogClient.CaptureEvent(userId, "user signed up", new() { ["plan"] = "pro" });
+        posthogClient.Capture(userId, "user signed up", new() { ["plan"] = "pro" });
         return View();
     }
 }
@@ -130,7 +130,7 @@ await posthogClient.AliasAsync(sessionId, userId);
 Note that capturing events is designed to be fast and done in the background. You can configure how often batches are sent to the PostHog API using the `FlushAt` and `FlushInterval` settings.
 
 ```csharp
-posthogClient.CaptureEvent(userId, "user signed up", new() { ["plan"] = "pro" });
+posthogClient.Capture(userId, "user signed up", new() { ["plan"] = "pro" });
 ```
 
 #### Capture a Page View

--- a/src/PostHog/Api/PostHogApiClientExtensions.cs
+++ b/src/PostHog/Api/PostHogApiClientExtensions.cs
@@ -18,7 +18,7 @@ internal static class PostHogApiClientExtensions
     /// </param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
-    public static async Task<ApiResult> IdentifyPersonAsync(
+    public static async Task<ApiResult> IdentifyAsync(
         this PostHogApiClient client,
         string distinctId,
         Dictionary<string, object>? personPropertiesToSet,
@@ -47,7 +47,7 @@ internal static class PostHogApiClientExtensions
     /// <summary>
     /// Identify a group with additional properties
     /// </summary>
-    public static async Task<ApiResult> IdentifyGroupAsync(
+    public static async Task<ApiResult> GroupIdentifyAsync(
         this PostHogApiClient client,
         string type,
         StringOrValue<int> key,

--- a/src/PostHog/Capture/CaptureExtensions.cs
+++ b/src/PostHog/Capture/CaptureExtensions.cs
@@ -15,11 +15,11 @@ public static class CaptureExtensions
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
-    public static bool CaptureEvent(
+    public static bool Capture(
         this IPostHogClient client,
         string distinctId,
         string eventName)
-        => NotNull(client).CaptureEvent(
+        => NotNull(client).Capture(
             distinctId,
             eventName,
             properties: null,
@@ -34,12 +34,12 @@ public static class CaptureExtensions
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
     /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
-    public static bool CaptureEvent(
+    public static bool Capture(
         this IPostHogClient client,
         string distinctId,
         string eventName,
         bool sendFeatureFlags)
-        => NotNull(client).CaptureEvent(
+        => NotNull(client).Capture(
             distinctId,
             eventName,
             properties: null,
@@ -54,12 +54,12 @@ public static class CaptureExtensions
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
-    public static bool CaptureEvent(
+    public static bool Capture(
         this IPostHogClient client,
         string distinctId,
         string eventName,
         Dictionary<string, object>? properties)
-        => NotNull(client).CaptureEvent(
+        => NotNull(client).Capture(
             distinctId,
             eventName,
             properties,
@@ -80,13 +80,13 @@ public static class CaptureExtensions
     /// value in this dictionary is ignored.
     /// </param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
-    public static bool CaptureEvent(
+    public static bool Capture(
         this IPostHogClient client,
         string distinctId,
         string eventName,
         Dictionary<string, object> personPropertiesToSet,
         Dictionary<string, object> personPropertiesToSetOnce)
-        => client.CaptureEvent(distinctId, eventName, properties: null, personPropertiesToSet, personPropertiesToSetOnce);
+        => client.Capture(distinctId, eventName, properties: null, personPropertiesToSet, personPropertiesToSetOnce);
 
     /// <summary>
     /// Captures an event with properties to set on the user.
@@ -103,7 +103,7 @@ public static class CaptureExtensions
     /// value in this dictionary is ignored.
     /// </param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
-    public static bool CaptureEvent(
+    public static bool Capture(
         this IPostHogClient client,
         string distinctId,
         string eventName,
@@ -115,7 +115,7 @@ public static class CaptureExtensions
         properties["$set"] = personPropertiesToSet;
         properties["$set_once"] = personPropertiesToSetOnce;
 
-        return NotNull(client).CaptureEvent(
+        return NotNull(client).Capture(
             distinctId,
             eventName,
             properties,
@@ -131,12 +131,12 @@ public static class CaptureExtensions
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
     /// <param name="groups">A set of groups to send with the event. The groups are identified by their group_type and group_key.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
-    public static bool CaptureEvent(
+    public static bool Capture(
         this IPostHogClient client,
         string distinctId,
         string eventName,
         GroupCollection groups)
-        => NotNull(client).CaptureEvent(
+        => NotNull(client).Capture(
             distinctId,
             eventName,
             properties: null,
@@ -256,7 +256,7 @@ public static class CaptureExtensions
             properties[$"survey_response_{i}"] = surveyResponses[i];
         }
 
-        return NotNull(client).CaptureEvent(distinctId, "survey sent", properties, groups: null, sendFeatureFlags: false);
+        return NotNull(client).Capture(distinctId, "survey sent", properties, groups: null, sendFeatureFlags: false);
     }
 
     /// <summary>
@@ -309,6 +309,6 @@ public static class CaptureExtensions
     {
         properties ??= new Dictionary<string, object>();
         properties[eventPropertyName] = eventPropertyValue;
-        return client.CaptureEvent(distinctId, eventName, properties);
+        return client.Capture(distinctId, eventName, properties);
     }
 }

--- a/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
+++ b/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
@@ -4,7 +4,7 @@ using static PostHog.Library.Ensure;
 
 namespace PostHog; // Intentionally put in the root namespace.
 
-public static class IdentifyGroupAsyncExtensions
+public static class GroupIdentifyAsyncExtensions
 {
     /// <summary>
     /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
@@ -16,7 +16,7 @@ public static class IdentifyGroupAsyncExtensions
     /// <param name="name">The friendly name of the group.</param>
     /// <param name="properties">Additional information about the group.</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
-    public static async Task<ApiResult> IdentifyGroupAsync(
+    public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
         string type,
         StringOrValue<int> key,
@@ -25,7 +25,7 @@ public static class IdentifyGroupAsyncExtensions
     {
         properties ??= new Dictionary<string, object>();
         properties["name"] = name;
-        return await NotNull(client).IdentifyGroupAsync(type, key, properties, CancellationToken.None);
+        return await NotNull(client).GroupIdentifyAsync(type, key, properties, CancellationToken.None);
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public static class IdentifyGroupAsyncExtensions
     /// <param name="properties">Additional information about the group.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
-    public static async Task<ApiResult> IdentifyGroupAsync(
+    public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
         string type,
         StringOrValue<int> key,
@@ -49,7 +49,7 @@ public static class IdentifyGroupAsyncExtensions
     {
         properties ??= new Dictionary<string, object>();
         properties["name"] = name;
-        return await NotNull(client).IdentifyGroupAsync(type, key, properties, cancellationToken);
+        return await NotNull(client).GroupIdentifyAsync(type, key, properties, cancellationToken);
     }
 
     /// <summary>
@@ -61,13 +61,12 @@ public static class IdentifyGroupAsyncExtensions
     /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
     /// <param name="name">The friendly name of the group.</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
-    public static async Task<ApiResult> IdentifyGroupAsync(
+    public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
         string type,
         StringOrValue<int> key,
         string name)
-        => await IdentifyGroupAsync(
-            client,
+        => await client.GroupIdentifyAsync(
             type,
             key,
             name,

--- a/src/PostHog/Extensions/IdentifyPersonAsyncExtensions.cs
+++ b/src/PostHog/Extensions/IdentifyPersonAsyncExtensions.cs
@@ -11,8 +11,8 @@ public static class IdentifyPersonAsyncExtensions
     /// </summary>
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
-    public static Task<ApiResult> IdentifyPersonAsync(this IPostHogClient client, string distinctId)
-        => NotNull(client).IdentifyPersonAsync(distinctId, CancellationToken.None);
+    public static Task<ApiResult> IdentifyAsync(this IPostHogClient client, string distinctId)
+        => NotNull(client).IdentifyAsync(distinctId, CancellationToken.None);
 
     /// <summary>
     /// Identifies a user with the specified distinct ID and user properties.
@@ -21,12 +21,12 @@ public static class IdentifyPersonAsyncExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
-    public static Task<ApiResult> IdentifyPersonAsync(
+    public static Task<ApiResult> IdentifyAsync(
         this IPostHogClient client,
         string distinctId,
         CancellationToken cancellationToken)
         => NotNull(client)
-            .IdentifyPersonAsync(
+            .IdentifyAsync(
             distinctId,
             personPropertiesToSet: null,
             personPropertiesToSetOnce: null,
@@ -40,12 +40,12 @@ public static class IdentifyPersonAsyncExtensions
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="email">An email to associate with the person.</param>
     /// <param name="name">The person's name.</param>
-    public static Task<ApiResult> IdentifyPersonAsync(
+    public static Task<ApiResult> IdentifyAsync(
         this IPostHogClient client,
         string distinctId,
         string? email,
         string? name)
-        => client.IdentifyPersonAsync(
+        => client.IdentifyAsync(
             distinctId,
             email,
             name,
@@ -60,13 +60,13 @@ public static class IdentifyPersonAsyncExtensions
     /// <param name="email">An email to associate with the person.</param>
     /// <param name="name">The person's name.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
-    public static Task<ApiResult> IdentifyPersonAsync(
+    public static Task<ApiResult> IdentifyAsync(
         this IPostHogClient client,
         string distinctId,
         string? email,
         string? name,
         CancellationToken cancellationToken)
-        => client.IdentifyPersonAsync(
+        => client.IdentifyAsync(
             distinctId,
             email,
             name,
@@ -85,13 +85,13 @@ public static class IdentifyPersonAsyncExtensions
     /// Key value pairs to store as properties of the user in addition to the already specified "email" and "name".
     /// Any key value pairs in this dictionary that match existing property keys will overwrite those properties.
     /// </param>
-    public static async Task<ApiResult> IdentifyPersonAsync(
+    public static async Task<ApiResult> IdentifyAsync(
         this IPostHogClient client,
         string distinctId,
         string? email,
         string? name,
         Dictionary<string, object>? personPropertiesToSet)
-        => await client.IdentifyPersonAsync(
+        => await client.IdentifyAsync(
             distinctId,
             email,
             name,
@@ -111,14 +111,14 @@ public static class IdentifyPersonAsyncExtensions
     /// Any key value pairs in this dictionary that match existing property keys will overwrite those properties.
     /// </param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
-    public static async Task<ApiResult> IdentifyPersonAsync(
+    public static async Task<ApiResult> IdentifyAsync(
         this IPostHogClient client,
         string distinctId,
         string? email,
         string? name,
         Dictionary<string, object>? personPropertiesToSet,
         CancellationToken cancellationToken)
-        => await client.IdentifyPersonAsync(
+        => await client.IdentifyAsync(
             distinctId,
             email,
             name,
@@ -141,14 +141,14 @@ public static class IdentifyPersonAsyncExtensions
     /// <param name="personPropertiesToSetOnce">User properties to set only once (ex: Sign up date). If a property already exists, then the
     /// value in this dictionary is ignored.
     /// </param>
-    public static async Task<ApiResult> IdentifyPersonAsync(
+    public static async Task<ApiResult> IdentifyAsync(
         this IPostHogClient client,
         string distinctId,
         string? email,
         string? name,
         Dictionary<string, object>? personPropertiesToSet,
         Dictionary<string, object>? personPropertiesToSetOnce)
-        => await client.IdentifyPersonAsync(
+        => await client.IdentifyAsync(
             distinctId,
             email,
             name,
@@ -172,7 +172,7 @@ public static class IdentifyPersonAsyncExtensions
     /// value in this dictionary is ignored.
     /// </param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
-    public static async Task<ApiResult> IdentifyPersonAsync(
+    public static async Task<ApiResult> IdentifyAsync(
         this IPostHogClient client,
         string distinctId,
         string? email,
@@ -193,7 +193,7 @@ public static class IdentifyPersonAsyncExtensions
             personPropertiesToSet["name"] = name;
         }
 
-        return await NotNull(client).IdentifyPersonAsync(distinctId,
+        return await NotNull(client).IdentifyAsync(distinctId,
                 personPropertiesToSet,
                 personPropertiesToSetOnce,
                 cancellationToken);

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "1.0.0-beta.2";
+    public const string Version = "1.0.0-beta.3";
 }

--- a/src/PostHog/IPostHogClient.cs
+++ b/src/PostHog/IPostHogClient.cs
@@ -46,7 +46,7 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// </param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
-    Task<ApiResult> IdentifyPersonAsync(
+    Task<ApiResult> IdentifyAsync(
         string distinctId,
         Dictionary<string, object>? personPropertiesToSet,
         Dictionary<string, object>? personPropertiesToSetOnce,
@@ -61,7 +61,7 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="properties">Additional information about the group.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
-    Task<ApiResult> IdentifyGroupAsync(
+    Task<ApiResult> GroupIdentifyAsync(
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
@@ -76,7 +76,7 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="groups">Optional: Context of what groups are related to this event, example: { ["company"] = "id:5" }. Can be used to analyze companies instead of users.</param>
     /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
-    bool CaptureEvent(
+    bool Capture(
         string distinctId,
         string eventName,
         Dictionary<string, object>? properties,

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -111,27 +111,27 @@ public sealed class PostHogClient : IPostHogClient
         => await _apiClient.AliasAsync(previousId, newId, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<ApiResult> IdentifyPersonAsync(
+    public async Task<ApiResult> IdentifyAsync(
         string distinctId,
         Dictionary<string, object>? personPropertiesToSet,
         Dictionary<string, object>? personPropertiesToSetOnce,
         CancellationToken cancellationToken)
-        => await _apiClient.IdentifyPersonAsync(
+        => await _apiClient.IdentifyAsync(
             distinctId,
             personPropertiesToSet,
             personPropertiesToSetOnce,
             cancellationToken);
 
     /// <inheritdoc/>
-    public Task<ApiResult> IdentifyGroupAsync(
+    public Task<ApiResult> GroupIdentifyAsync(
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
-    => _apiClient.IdentifyGroupAsync(type, key, properties, cancellationToken);
+    => _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken);
 
     /// <inheritdoc/>
-    public bool CaptureEvent(
+    public bool Capture(
         string distinctId,
         string eventName,
         Dictionary<string, object>? properties,
@@ -319,7 +319,7 @@ public sealed class PostHogClient : IPostHogClient
         cacheEntry.SetPriority(CacheItemPriority.Low);
         cacheEntry.SetSlidingExpiration(_options.Value.FeatureFlagSentCacheSlidingExpiration);
 
-        CaptureEvent(
+        Capture(
             distinctId,
             eventName: "$feature_flag_called",
             properties: new Dictionary<string, object>

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -20,7 +20,7 @@ public class TheCaptureEventMethod
         var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = client.CaptureEvent("some-distinct-id", "some_event");
+        var result = client.Capture("some-distinct-id", "some_event");
 
         Assert.True(result);
         await client.FlushAsync();
@@ -53,7 +53,7 @@ public class TheCaptureEventMethod
         var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = client.CaptureEvent(
+        var result = client.Capture(
             distinctId: "some-distinct-id",
             eventName: "some_event",
             groups: [
@@ -103,7 +103,7 @@ public class TheCaptureEventMethod
         var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = client.CaptureEvent("some-distinct-id", "some_event");
+        var result = client.Capture("some-distinct-id", "some_event");
 
         Assert.True(result);
         await client.FlushAsync();
@@ -142,7 +142,7 @@ public class TheCaptureEventMethod
         );
         var client = container.Activate<PostHogClient>();
 
-        var result = client.CaptureEvent("some-distinct-id", "dotnet test event", sendFeatureFlags: true);
+        var result = client.Capture("some-distinct-id", "dotnet test event", sendFeatureFlags: true);
 
         Assert.True(result);
         await client.FlushAsync();
@@ -255,7 +255,7 @@ public class TheCaptureEventMethod
         var client = container.Activate<PostHogClient>();
 
         // Call it without pre-loading flags.
-        var firstCaptureResult = client.CaptureEvent("distinct_id", "dotnet test event");
+        var firstCaptureResult = client.Capture("distinct_id", "dotnet test event");
 
         Assert.True(firstCaptureResult);
         await client.FlushAsync();
@@ -281,7 +281,7 @@ public class TheCaptureEventMethod
 
         // Load the feature flags
         await client.GetAllFeatureFlagsAsync("distinct_id", options: new AllFeatureFlagsOptions { OnlyEvaluateLocally = true });
-        var secondCaptureResult = client.CaptureEvent("distinct_id", "dotnet test event");
+        var secondCaptureResult = client.Capture("distinct_id", "dotnet test event");
 
         await client.FlushAsync();
         var secondRequestBody = secondRequestHandler.GetReceivedRequestBody(indented: true);
@@ -360,7 +360,7 @@ public class TheIdentifyPersonAsyncMethod
         var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = await client.IdentifyPersonAsync("some-distinct-id");
+        var result = await client.IdentifyAsync("some-distinct-id");
 
         Assert.Equal(1, result.Status);
         var received = requestHandler.GetReceivedRequestBody(indented: true);
@@ -387,7 +387,7 @@ public class TheIdentifyPersonAsyncMethod
         var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = await client.IdentifyPersonAsync(
+        var result = await client.IdentifyAsync(
             distinctId: "some-distinct-id",
             email: "wildling-lover@example.com",
             name: "Jon Snow",
@@ -435,7 +435,7 @@ public class TheIdentifyPersonAsyncMethod
         var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = await client.IdentifyPersonAsync("some-distinct-id");
+        var result = await client.IdentifyAsync("some-distinct-id");
 
         Assert.Equal(1, result.Status);
         var received = requestHandler.GetReceivedRequestBody(indented: true);
@@ -466,7 +466,7 @@ public class TheIdentifyGroupAsyncMethod
         var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = await client.IdentifyGroupAsync(type: "organization", key: "id:5", "PostHog");
+        var result = await client.GroupIdentifyAsync(type: "organization", key: "id:5", "PostHog");
 
         Assert.Equal(1, result.Status);
         var received = requestHandler.GetReceivedRequestBody(indented: true);


### PR DESCRIPTION
While I liked that the names were more explicit, being consistent with the other client libs will cause less overall confusion. Especially given how the docs refer to these methods.