### PR TITLE
fix: remove extra closing brace in capture call

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Inject the `IPostHogClient` interface into your controller or page:
 
 ```csharp
 posthogClient.Capture(userId, "user signed up", new() { ["plan"] = "pro" });
-}
 ```
 
 ```csharp


### PR DESCRIPTION
Removed an unnecessary closing brace in the posthogClient.Capture call, ensuring correct syntax.