### PR TITLE
Fix accessing remote config settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.0-beta.9</Version>
+        <Version>1.0.0-beta.10</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/HogTied.Web/Pages/Index.cshtml
+++ b/samples/HogTied.Web/Pages/Index.cshtml
@@ -212,6 +212,27 @@
                     </div>
                 </div>
             </div>
+
+            <div class="mt-3">
+                <div class="row justify-content-center">
+                    <div class="col-md-6">
+                        <pre><code>
+await posthog.GetRemoteConfigPayloadAsync(
+    "unencrypted-remote-config-setting");
+
+> @Model.UnencryptedRemoteConfigSetting
+</code></pre>
+                    </div>
+                    <div class="col-md-6">
+                        <pre><code>
+await posthog.GetRemoteConfigPayloadAsync(
+    "encrypted-remote-config-setting");
+
+@Model.EncryptedRemoteConfigSetting
+</code></pre>
+                    </div>
+                </div>
+            </div>
         }
     </div>
 </div>

--- a/samples/HogTied.Web/Pages/Index.cshtml.cs
+++ b/samples/HogTied.Web/Pages/Index.cshtml.cs
@@ -43,6 +43,10 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
     [FromQuery]
     public string? FeatureFlagKey { get; set; }
 
+    public string? UnencryptedRemoteConfigSetting { get; set; }
+
+    public string? EncryptedRemoteConfigSetting { get; set; }
+
     public async Task OnGetAsync()
     {
         ApiKeyIsSet = options.Value.ProjectApiKey is not (null or []);
@@ -103,6 +107,10 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
             }
 
             NonExistentFlag = await posthog.IsFeatureEnabledAsync("non-existent-flag", UserId);
+
+            UnencryptedRemoteConfigSetting = (await posthog.GetRemoteConfigPayloadAsync("unencrypted-remote-config-setting", HttpContext.RequestAborted))?.RootElement.GetRawText();
+
+            EncryptedRemoteConfigSetting = (await posthog.GetRemoteConfigPayloadAsync("encrypted-remote-config-setting", HttpContext.RequestAborted))?.RootElement.GetRawText();
         }
     }
 

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "1.0.0-beta.9";
+    public const string Version = "1.0.0-beta.10";
 }

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -330,7 +330,7 @@ public sealed class PostHogClient : IPostHogClient
             // However, we may change that in the future.
             // So this is implemented in a forward-compatible way.
             if (document is { RootElement.ValueKind: JsonValueKind.String } doc
-                && doc.RootElement.GetString() is {} innerJson
+                && doc.RootElement.GetString() is { } innerJson
                 && TryParseJson(innerJson, out var parsedJson))
             {
                 return parsedJson;

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -322,12 +322,40 @@ public sealed class PostHogClient : IPostHogClient
 
         try
         {
-            return await _apiClient.GetRemoteConfigPayloadAsync(key, cancellationToken);
+            var document = await _apiClient.GetRemoteConfigPayloadAsync(key, cancellationToken);
+
+            // The remote config endpoint returns JSON encoded in a string.
+            // For example: "{\"foo\": \"bar\",\"baz\": 42}"
+            // Instead of:  {"foo": "bar","baz": 42}
+            // However, we may change that in the future.
+            // So this is implemented in a forward-compatible way.
+            if (document is { RootElement.ValueKind: JsonValueKind.String } doc
+                && doc.RootElement.GetString() is {} innerJson
+                && TryParseJson(innerJson, out var parsedJson))
+            {
+                return parsedJson;
+            }
+
+            return document;
         }
         catch (Exception e) when (e is not ArgumentException and not NullReferenceException)
         {
             _logger.LogErrorUnableToGetRemoteConfigPayload(e);
             return null;
+        }
+
+        static bool TryParseJson(string json, out JsonDocument? document)
+        {
+            try
+            {
+                document = JsonDocument.Parse(json);
+                return true;
+            }
+            catch (JsonException)
+            {
+                document = null;
+                return false;
+            }
         }
     }
 

--- a/tests/UnitTests/Features/RemoteConfigTests.cs
+++ b/tests/UnitTests/Features/RemoteConfigTests.cs
@@ -31,6 +31,64 @@ public class TheGetRemoteConfigPayloadAsyncMethod
         var result = await client.GetRemoteConfigPayloadAsync("remote-config-key");
 
         Assert.NotNull(result);
+        Assert.Equal("bar", result.RootElement.GetProperty("foo").GetString());
         JsonAssert.Equal("""{"foo": "bar","baz": 42}""", result);
+    }
+
+    [Fact]
+    public async Task HandlesJsonEncodedInString()
+    {
+        var container = new TestContainer("fake-personal-api-key");
+        // Right now, the endpoint doesn't return JSON. It returns a string that contains JSON.
+        container.FakeHttpMessageHandler.AddRemoteConfigResponse(
+            "remote-config-key",
+            """
+            "{\"an encrypted\": \"payload\"}"
+            """
+        );
+        var client = container.Activate<PostHogClient>();
+
+        var result = await client.GetRemoteConfigPayloadAsync("remote-config-key");
+
+        Assert.NotNull(result);
+        Assert.Equal("payload", result.RootElement.GetProperty("an encrypted").GetString());
+    }
+
+    [Fact]
+    public async Task HandlesJsonStringPayload()
+    {
+        var container = new TestContainer("fake-personal-api-key");
+        // Right now, the endpoint doesn't return JSON. It returns a string that contains JSON.
+        container.FakeHttpMessageHandler.AddRemoteConfigResponse(
+            "remote-config-key",
+            """
+            "Valid JSON string"
+            """
+        );
+        var client = container.Activate<PostHogClient>();
+
+        var result = await client.GetRemoteConfigPayloadAsync("remote-config-key");
+
+        Assert.NotNull(result);
+        Assert.Equal("Valid JSON string", result.RootElement.GetString());
+    }
+
+    [Fact]
+    public async Task HandlesJsonEncodedStringPayload()
+    {
+        var container = new TestContainer("fake-personal-api-key");
+        // Right now, the endpoint doesn't return JSON. It returns a string that contains JSON.
+        container.FakeHttpMessageHandler.AddRemoteConfigResponse(
+            "remote-config-key",
+            """
+            "\"Valid JSON string\""
+            """
+        );
+        var client = container.Activate<PostHogClient>();
+
+        var result = await client.GetRemoteConfigPayloadAsync("remote-config-key");
+
+        Assert.NotNull(result);
+        Assert.Equal("Valid JSON string", result.RootElement.GetString());
     }
 }


### PR DESCRIPTION
The remote config endpoint returns JSON encoded in a string.

`"{\"foo\": \"bar\",\"baz\": 42}"`

Instead of:

`{"foo": "bar","baz": 42}`

However, we may change that in the future.
So this is implemented in a forward-compatible way to handle both options.