### PR TITLE
feat(feature-flags): support quota limiting for feature flags #403

### DIFF
--- a/src/PostHog/Api/ApiErrorResult.cs
+++ b/src/PostHog/Api/ApiErrorResult.cs
@@ -7,4 +7,4 @@ namespace PostHog.Api;
 /// <property name="Code">The error code.</property>
 /// <property name="Detail">Information about the error.</property>
 /// <property name="Attr">Additional context about the error.</property>
-internal record UnauthorizedApiResult(string Type, string Code, string Detail, string? Attr);
+public record ApiErrorResult(string Type, string Code, string Detail, string? Attr);

--- a/src/PostHog/Api/DecideApiResult.cs
+++ b/src/PostHog/Api/DecideApiResult.cs
@@ -14,7 +14,8 @@ internal record DecideApiResult(
     Analytics? Analytics = null,
     bool DefaultIdentifiedOnly = true,
     bool ErrorsWhileComputingFlags = false,
-    IReadOnlyDictionary<string, string>? FeatureFlagPayloads = null);
+    IReadOnlyDictionary<string, string>? FeatureFlagPayloads = null,
+    IReadOnlyList<string>? QuotaLimited = null);
 
 internal record FeatureFlagsConfig([property: JsonPropertyName("enable_collect_everything")] bool EnableCollectEverything);
 internal record Analytics(string Endpoint);

--- a/src/PostHog/Api/DecideApiResult.cs
+++ b/src/PostHog/Api/DecideApiResult.cs
@@ -7,9 +7,6 @@ namespace PostHog.Api;
 /// The API Result for the <c>/decide</c> endpoint. Some properties are ommitted because
 /// they are not necessary for server-side scenarios.
 /// </summary>
-/// <remarks>
-///
-/// </remarks>
 internal record DecideApiResult(
     FeatureFlagsConfig? Config = null,
     bool IsAuthenticated = false,
@@ -17,8 +14,7 @@ internal record DecideApiResult(
     Analytics? Analytics = null,
     bool DefaultIdentifiedOnly = true,
     bool ErrorsWhileComputingFlags = false,
-    IReadOnlyDictionary<string, string>? FeatureFlagPayloads = null,
-    IReadOnlyList<string>? QuotaLimited = null);
+    IReadOnlyDictionary<string, string>? FeatureFlagPayloads = null);
 
 internal record FeatureFlagsConfig([property: JsonPropertyName("enable_collect_everything")] bool EnableCollectEverything);
 internal record Analytics(string Endpoint);

--- a/src/PostHog/Api/DecideApiResult.cs
+++ b/src/PostHog/Api/DecideApiResult.cs
@@ -17,7 +17,8 @@ internal record DecideApiResult(
     Analytics? Analytics = null,
     bool DefaultIdentifiedOnly = true,
     bool ErrorsWhileComputingFlags = false,
-    IReadOnlyDictionary<string, string>? FeatureFlagPayloads = null);
+    IReadOnlyDictionary<string, string>? FeatureFlagPayloads = null,
+    IReadOnlyList<string>? QuotaLimited = null);
 
 internal record FeatureFlagsConfig([property: JsonPropertyName("enable_collect_everything")] bool EnableCollectEverything);
 internal record Analytics(string Endpoint);

--- a/src/PostHog/Library/ApiException.cs
+++ b/src/PostHog/Library/ApiException.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using PostHog.Api;
+
+namespace PostHog.Library;
+
+/// <summary>
+/// Exception thrown when we run into an error while interacting with the PostHog API.
+/// </summary>
+public class ApiException : Exception
+{
+    public ApiException()
+    {
+    }
+
+    public ApiException(string message) : base(message)
+    {
+    }
+
+    public ApiException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public ApiException(ApiErrorResult? error, HttpStatusCode statusCode, Exception? innerException)
+        : base(error?.Detail, innerException)
+    {
+        Code = error?.Code;
+        ErrorType = error?.Type;
+        Attr = error?.Attr;
+        Status = statusCode;
+    }
+
+    public string? Code { get; }
+
+    public string? ErrorType { get; }
+
+    public string? Attr { get; }
+
+    public HttpStatusCode Status { get; }
+}

--- a/src/PostHog/Library/HttpClientExtensions.cs
+++ b/src/PostHog/Library/HttpClientExtensions.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using PostHog.Api;
 using PostHog.Json;
 
@@ -32,17 +33,45 @@ internal static class HttpClientExtensions
             JsonSerializerHelper.Options,
             cancellationToken);
 
-        if (response.StatusCode is HttpStatusCode.Unauthorized)
-        {
-            var error = await response.Content.ReadFromJsonAsync<UnauthorizedApiResult>(
-                cancellationToken: cancellationToken);
-            throw new UnauthorizedAccessException(error?.Detail);
-        }
-        response.EnsureSuccessStatusCode();
+        await response.EnsureSuccessfulApiCall(cancellationToken);
 
         var result = await response.Content.ReadAsStreamAsync(cancellationToken);
         return await JsonSerializerHelper.DeserializeFromCamelCaseJsonAsync<TBody>(
             result,
             cancellationToken: cancellationToken);
+    }
+
+    public static async Task EnsureSuccessfulApiCall(
+        this HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        // TODO: Is there any error status codes that we should allow the exception to propagate here?
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+        var (error, exception) = await ReadApiErrorResultAsync();
+
+        throw response.StatusCode switch
+        {
+            HttpStatusCode.Unauthorized => new UnauthorizedAccessException(
+                error?.Detail ?? "Unauthorized. Could not deserialize the response for more info.", exception),
+            _ => new ApiException(error, response.StatusCode, exception)
+        };
+
+        async Task<(ApiErrorResult?, Exception?)> ReadApiErrorResultAsync()
+        {
+            try
+            {
+                // Get defensive here because I'm not sure that `Attr` is always a string, but I believe it be so.
+                var result = await response.Content.ReadFromJsonAsync<ApiErrorResult>(
+                    cancellationToken: cancellationToken);
+                return (result, null);
+            }
+            catch (JsonException e)
+            {
+                return (null, e);
+            }
+        }
     }
 }

--- a/src/PostHog/Library/HttpClientExtensions.cs
+++ b/src/PostHog/Library/HttpClientExtensions.cs
@@ -64,6 +64,7 @@ internal static class HttpClientExtensions
             try
             {
                 // Get defensive here because I'm not sure that `Attr` is always a string, but I believe it be so.
+#pragma warning disable CA2016
                 var result = await response.Content.ReadFromJsonAsync<ApiErrorResult>(
                     cancellationToken: cancellationToken);
                 return (result, null);

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -3166,10 +3166,12 @@ public class TheQuotaLimitBehavior
         var client = container.Activate<PostHogClient>();
 
         var result = await client.GetAllFeatureFlagsAsync("distinct_id");
-        var logEvent = Assert.Single(container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Debug));
-        
+
         Assert.Empty(result);
-        Assert.Equal("Feature flags quota exceeded", logEvent.Message);
+        var logEvents = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Error);
+        Assert.Single(
+            container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Error),
+            e => e.Message == "[FEATURE FLAGS] Quota exceeded for feature flags.");
     }
 
     [Fact]
@@ -3195,10 +3197,11 @@ public class TheQuotaLimitBehavior
         var client = container.Activate<PostHogClient>();
 
         var result = await client.GetAllFeatureFlagsAsync("distinct_id");
-        var logEvent = Assert.Single(container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Debug));
-        
+
         Assert.Empty(result);
-        Assert.Equal("Feature flags quota exceeded", logEvent.Message);
+        Assert.Single(
+            container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Error),
+            e => e.Message == "[FEATURE FLAGS] Quota exceeded for feature flags.");
     }
 
     [Fact]
@@ -3224,9 +3227,10 @@ public class TheQuotaLimitBehavior
         var client = container.Activate<PostHogClient>();
 
         var result = await client.IsFeatureEnabledAsync("flag-key", "distinct_id");
-        var logEvent = Assert.Single(container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Debug));
-        
+
         Assert.False(result);
-        Assert.Equal("Feature flags quota exceeded", logEvent.Message);
+        Assert.Single(
+            container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Error),
+            e => e.Message == "[FEATURE FLAGS] Quota exceeded for feature flags.");
     }
 }

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -3147,21 +3147,25 @@ public class TheQuotaLimitBehavior
     public async Task ReturnsEmptyDictionaryWhenDecideEndpointQuotaExceeded()
     {
         var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddResponse(
-            new Uri("https://us.i.posthog.com/decide?v=3"),
-            HttpMethod.Post,
-            new HttpResponseMessage(HttpStatusCode.PaymentRequired)
-            {
-                Content = new StringContent(
-                    """
-                    {
-                        "type": "quota_limited",
-                        "detail": "You have exceeded your feature flag request quota",
-                        "code": "payment_required"
-                    }
-                    """
-                )
-            }
+        container.FakeHttpMessageHandler.AddDecideResponse(
+        """
+        {
+          "config": {
+            "enable_collect_everything": true
+          },
+          "toolbarParams": {},
+          "isAuthenticated": false,
+          "supportedCompression": [
+            "gzip",
+            "gzip-js"
+          ],
+          "featureFlags": {},
+          "featureFlagPayloads": {},
+          "errorsComputingFlags": false,
+          "quotaLimited": ["feature_flags"],
+          "sessionRecording": false
+        }
+        """
         );
         var client = container.Activate<PostHogClient>();
 


### PR DESCRIPTION
with https://github.com/PostHog/posthog/pull/28564, we now start to respond different with the /decide and /local_evaluation APIs if users have gone over their quota limit. Now we need to change the SDKs to handle these new responses.