### PR TITLE
Prepare the 1.0.0 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.0-beta.12</Version>
+        <Version>1.0.0</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/HogTied.Web/Filters/PostHogPageViewFilter.cs
+++ b/samples/HogTied.Web/Filters/PostHogPageViewFilter.cs
@@ -6,7 +6,13 @@ using Microsoft.AspNetCore.Http.Extensions;
 
 namespace HogTied.Web;
 
-public class PostHogPageViewFilter(IOptions<PostHogOptions> options, IPostHogClient postHogClient) : IAsyncPageFilter
+/// <summary>
+/// Page view filter that captures page views for PostHog. This demonstrates how you might use PostHog to
+/// capture page views in every ASP.NET Core Razor page.
+/// </summary>
+/// <param name="options">PostHog options.</param>
+/// <param name="posthog">The PostHog client.</param>
+public class PostHogPageViewFilter(IOptions<PostHogOptions> options, IPostHogClient posthog) : IAsyncPageFilter
 {
     readonly PostHogOptions _options = options.Value;
 
@@ -19,7 +25,7 @@ public class PostHogPageViewFilter(IOptions<PostHogOptions> options, IPostHogCli
 
             if (distinctId is not null)
             {
-                postHogClient.CapturePageView(
+                posthog.CapturePageView(
                     distinctId,
                     pagePath: context.HttpContext.Request.GetDisplayUrl());
             }

--- a/src/PostHog.AspNetCore/Config/IPostHogAspNetCoreConfigurationBuilder.cs
+++ b/src/PostHog.AspNetCore/Config/IPostHogAspNetCoreConfigurationBuilder.cs
@@ -2,6 +2,9 @@ using Microsoft.Extensions.Configuration;
 
 namespace PostHog.Config;
 
+/// <summary>
+/// Interface for the configuration builder used to configure PostHog services for ASP.NET Core.
+/// </summary>
 public interface IPostHogAspNetCoreConfigurationBuilder : IPostHogConfigurationBuilder
 {
     public IConfiguration Configuration { get; }

--- a/src/PostHog.AspNetCore/FeatureManagement/IPostHogFeatureManagementBuilder.cs
+++ b/src/PostHog.AspNetCore/FeatureManagement/IPostHogFeatureManagementBuilder.cs
@@ -3,6 +3,9 @@ using Microsoft.FeatureManagement;
 
 namespace PostHog.FeatureManagement;
 
+/// <summary>
+/// Interface for configuring PostHog feature management services.
+/// </summary>
 public interface IPostHogFeatureManagementBuilder
 {
     /// <summary>The application services.</summary>

--- a/src/PostHog/Api/ApiResult.cs
+++ b/src/PostHog/Api/ApiResult.cs
@@ -5,14 +5,9 @@ namespace PostHog.Api;
 /// <summary>
 /// Result of a PostHog API call.
 /// </summary>
-public class ApiResult(StringOrValue<int> status)
-{
-    /// <summary>
-    /// The status.
-    /// </summary>
-    /// <remarks>
-    /// For Capture, this returns {"status": 1} if the event was captured successfully.
-    /// For Batch, this returns {"status": "Ok"} if all events were captured successfully.
-    /// </remarks>
-    public StringOrValue<int> Status => status;
-}
+/// <remarks>
+/// For Capture, this returns {"status": 1} if the event was captured successfully.
+/// For Batch, this returns {"status": "Ok"} if all events were captured successfully.
+/// </remarks>
+/// <param name="Status">The nstatus of the call.</param>
+public record ApiResult(StringOrValue<int> Status);

--- a/src/PostHog/Api/ApiResult.cs
+++ b/src/PostHog/Api/ApiResult.cs
@@ -9,5 +9,5 @@ namespace PostHog.Api;
 /// For Capture, this returns {"status": 1} if the event was captured successfully.
 /// For Batch, this returns {"status": "Ok"} if all events were captured successfully.
 /// </remarks>
-/// <param name="Status">The nstatus of the call.</param>
+/// <param name="Status">The status of the call.</param>
 public record ApiResult(StringOrValue<int> Status);

--- a/src/PostHog/Api/ComparisonOperator.cs
+++ b/src/PostHog/Api/ComparisonOperator.cs
@@ -75,7 +75,7 @@ public enum ComparisonOperator
     DoesNotContainIgnoreCase,
 
     /// <summary>
-    /// Matches if regular expression filter value matches the value.
+    /// Matches if the value matches the regular expression filter pattern.
     /// </summary>
     [JsonStringEnumMemberName("regex")]
     Regex,

--- a/src/PostHog/Api/ComparisonOperator.cs
+++ b/src/PostHog/Api/ComparisonOperator.cs
@@ -8,48 +8,93 @@ namespace PostHog.Api;
 [JsonConverter(typeof(JsonStringEnumConverter<ComparisonOperator>))]
 public enum ComparisonOperator
 {
+    /// <summary>
+    /// Matches if the value is in the list of filter values.
+    /// </summary>
     [JsonStringEnumMemberName("in")]
     In, // Only used for cohort filters
 
+    /// <summary>
+    /// Matches if the value is an exact match to the filter value.
+    /// </summary>
     [JsonStringEnumMemberName("exact")]
     Exact,
 
+    /// <summary>
+    /// Matches if the value is not an exact match to the filter value.
+    /// </summary>
     [JsonStringEnumMemberName("is_not")]
     IsNot,
 
+    /// <summary>
+    /// Matches if the value is set.
+    /// </summary>
     [JsonStringEnumMemberName("is_set")]
     IsSet,
 
+    /// <summary>
+    /// Matches if the value is not set.
+    /// </summary>
     [JsonStringEnumMemberName("is_not_set")]
     IsNotSet,
 
+    /// <summary>
+    /// Matches if the value is greater than the filter value.
+    /// </summary>
     [JsonStringEnumMemberName("gt")]
     GreaterThan,
 
+    /// <summary>
+    /// Matches if the value is less than the filter value.
+    /// </summary>
     [JsonStringEnumMemberName("lt")]
     LessThan,
 
+    /// <summary>
+    /// Matches if the value is greater than or equal to the filter value.
+    /// </summary>
     [JsonStringEnumMemberName("gte")]
     GreaterThanOrEquals,
 
+    /// <summary>
+    /// Matches if the value is less than or equal to the filter value.
+    /// </summary>
     [JsonStringEnumMemberName("lte")]
     LessThanOrEquals,
 
+    /// <summary>
+    /// Matches if the value contains the filter value, ignoring case differences.
+    /// </summary>
     [JsonStringEnumMemberName("icontains")]
     ContainsIgnoreCase,
 
+    /// <summary>
+    /// Matches if the value does not contain the filter value, ignoring case differences.
+    /// </summary>
     [JsonStringEnumMemberName("not_icontains")]
     DoesNotContainsIgnoreCase,
 
+    /// <summary>
+    /// Matches if regular expression filter value matches the value.
+    /// </summary>
     [JsonStringEnumMemberName("regex")]
     Regex,
 
+    /// <summary>
+    /// Matches if regular expression filter value does not match the value.
+    /// </summary>
     [JsonStringEnumMemberName("not_regex")]
     NotRegex,
 
+    /// <summary>
+    /// Matches if the date represented by the value is before the filter value.
+    /// </summary>
     [JsonStringEnumMemberName("is_date_before")]
     IsDateBefore,
 
+    /// <summary>
+    /// Matches if the date represented by the value is after the filter value.
+    /// </summary>
     [JsonStringEnumMemberName("is_date_after")]
     IsDateAfter
 }

--- a/src/PostHog/Api/ComparisonOperator.cs
+++ b/src/PostHog/Api/ComparisonOperator.cs
@@ -9,10 +9,10 @@ namespace PostHog.Api;
 public enum ComparisonOperator
 {
     /// <summary>
-    /// Matches if the value is in the list of filter values.
+    /// Matches if the value is in the list of filter values. Only used for cohort filters.
     /// </summary>
     [JsonStringEnumMemberName("in")]
-    In, // Only used for cohort filters
+    In,
 
     /// <summary>
     /// Matches if the value is an exact match to the filter value.

--- a/src/PostHog/Api/ComparisonOperator.cs
+++ b/src/PostHog/Api/ComparisonOperator.cs
@@ -72,7 +72,7 @@ public enum ComparisonOperator
     /// Matches if the value does not contain the filter value, ignoring case differences.
     /// </summary>
     [JsonStringEnumMemberName("not_icontains")]
-    DoesNotContainsIgnoreCase,
+    DoesNotContainIgnoreCase,
 
     /// <summary>
     /// Matches if regular expression filter value matches the value.

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -13,7 +13,7 @@ using PostHog.Versioning;
 namespace PostHog.Api;
 
 /// <summary>
-/// PostHog API client for capturing events and managing user tracking
+/// PostHog API client used to make API calls to PostHog for capturing events, feature flags, etc.
 /// </summary>
 internal sealed class PostHogApiClient : IDisposable
 {

--- a/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
+++ b/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
@@ -4,6 +4,9 @@ using static PostHog.Library.Ensure;
 
 namespace PostHog; // Intentionally put in the root namespace.
 
+/// <summary>
+/// Extension methods for identifying a group.
+/// </summary>
 public static class GroupIdentifyAsyncExtensions
 {
     /// <summary>

--- a/src/PostHog/Extensions/IdentifyPersonAsyncExtensions.cs
+++ b/src/PostHog/Extensions/IdentifyPersonAsyncExtensions.cs
@@ -3,6 +3,9 @@ using static PostHog.Library.Ensure;
 
 namespace PostHog; // Intentionally put in the root namespace.
 
+/// <summary>
+/// Extension methods for identifying a user.
+/// </summary>
 public static class IdentifyPersonAsyncExtensions
 {
     /// <summary>

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -508,7 +508,7 @@ internal sealed class LocalEvaluator
             ComparisonOperator.LessThan => value > overrideValue,
             ComparisonOperator.LessThanOrEquals => value >= overrideValue,
             ComparisonOperator.ContainsIgnoreCase => value.IsContainedBy(overrideValue, StringComparison.OrdinalIgnoreCase),
-            ComparisonOperator.DoesNotContainsIgnoreCase => !value.IsContainedBy(overrideValue, StringComparison.OrdinalIgnoreCase),
+            ComparisonOperator.DoesNotContainIgnoreCase => !value.IsContainedBy(overrideValue, StringComparison.OrdinalIgnoreCase),
             ComparisonOperator.Regex => value.IsRegexMatch(overrideValue),
             ComparisonOperator.NotRegex => !value.IsRegexMatch(overrideValue),
             ComparisonOperator.IsSet => true, // We already checked to see that the key exists.

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "1.0.0-beta.12";
+    public const string Version = "1.0.0";
 }

--- a/src/PostHog/Json/InconclusiveMatchException.cs
+++ b/src/PostHog/Json/InconclusiveMatchException.cs
@@ -1,5 +1,9 @@
 namespace PostHog.Json;
 
+/// <summary>
+/// Exception thrown when a match is inconclusive. This is thrown internally and should not be thrown by any
+/// public methods of the client.
+/// </summary>
 public class InconclusiveMatchException : Exception
 {
     public InconclusiveMatchException(string message) : base(message)

--- a/src/PostHog/Json/PropertyFilterValueJsonConverter.cs
+++ b/src/PostHog/Json/PropertyFilterValueJsonConverter.cs
@@ -6,7 +6,7 @@ namespace PostHog.Json;
 
 using static Ensure;
 
-public class PropertyFilterValueJsonConverter : JsonConverter<PropertyFilterValue>
+internal sealed class PropertyFilterValueJsonConverter : JsonConverter<PropertyFilterValue>
 {
     public override PropertyFilterValue? Read(
         ref Utf8JsonReader reader,

--- a/src/PostHog/Library/AsyncBatchHandler.cs
+++ b/src/PostHog/Library/AsyncBatchHandler.cs
@@ -8,7 +8,7 @@ namespace PostHog.Library;
 
 /// <summary>
 /// Allows enqueueing items and flushing them in batches. Flushes happen on a periodic basis or when the queue reaches
-/// a certain size (<see cref="PostHogOptions.FlushAt"/>.
+/// a certain size (<see cref="PostHogOptions.FlushAt"/>).
 /// </summary>
 /// <typeparam name="TItem">The type of item to batch.</typeparam>
 internal sealed class AsyncBatchHandler<TItem> : IDisposable, IAsyncDisposable

--- a/src/PostHog/Library/AsyncBatchHandler.cs
+++ b/src/PostHog/Library/AsyncBatchHandler.cs
@@ -6,6 +6,11 @@ using static PostHog.Library.Ensure;
 
 namespace PostHog.Library;
 
+/// <summary>
+/// Allows enqueueing items and flushing them in batches. Flushes happen on a periodic basis or when the queue reaches
+/// a certain size (<see cref="PostHogOptions.FlushAt"/>.
+/// </summary>
+/// <typeparam name="TItem">The type of item to batch.</typeparam>
 internal sealed class AsyncBatchHandler<TItem> : IDisposable, IAsyncDisposable
 {
     readonly Channel<Task<TItem>> _channel;

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -71,7 +71,7 @@ public sealed class PostHogClient : IPostHogClient
         _featureFlagSentCache = new MemoryCache(new MemoryCacheOptions
         {
             SizeLimit = options.Value.FeatureFlagSentCacheSizeLimit,
-            Clock = new TimeProviderSystemClock(NotNull(timeProvider)),
+            Clock = new TimeProviderSystemClock(_timeProvider),
             CompactionPercentage = options.Value.FeatureFlagSentCacheCompactionPercentage
         });
 

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -259,10 +259,10 @@ public class TheEvaluateFeatureFlagMethod
 
     [Theory]
     [InlineData("Works at PostHog", ComparisonOperator.ContainsIgnoreCase, "\"posthog\"", true)]
-    [InlineData("Works at PostHog", ComparisonOperator.DoesNotContainsIgnoreCase, "\"posthog\"", false)]
-    [InlineData("Works at PostHog", ComparisonOperator.DoesNotContainsIgnoreCase, "\"PostHog\"", false)]
+    [InlineData("Works at PostHog", ComparisonOperator.DoesNotContainIgnoreCase, "\"posthog\"", false)]
+    [InlineData("Works at PostHog", ComparisonOperator.DoesNotContainIgnoreCase, "\"PostHog\"", false)]
     [InlineData("Loves puppies", ComparisonOperator.ContainsIgnoreCase, "\"cats\"", false)]
-    [InlineData("Loves puppies", ComparisonOperator.DoesNotContainsIgnoreCase, "\"cats\"", true)]
+    [InlineData("Loves puppies", ComparisonOperator.DoesNotContainIgnoreCase, "\"cats\"", true)]
     public void HandlesContainsComparisons(object overrideValue, ComparisonOperator comparison, string filterValueJson, bool expected)
     {
         var flags = CreateFlags(


### PR DESCRIPTION
This bumps the version to 1.0.0 (removing the beta label).

It also adds some code documentation and changes the ctor for `PostHogClient` to accept nulls for each of the dependencies and provides a simple alternative when null.