### PR TITLE
Fix unhandled object disposed exception

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/HogTied.Web/Filters/PostHogPageViewFilter.cs
+++ b/samples/HogTied.Web/Filters/PostHogPageViewFilter.cs
@@ -27,7 +27,8 @@ public class PostHogPageViewFilter(IOptions<PostHogOptions> options, IPostHogCli
             {
                 posthog.CapturePageView(
                     distinctId,
-                    pagePath: context.HttpContext.Request.GetDisplayUrl());
+                    pagePath: context.HttpContext.Request.GetDisplayUrl(),
+                    sendFeatureFlags: true);
             }
         }
 

--- a/src/PostHog.AspNetCore/Cache/HttpContextFeatureFlagCache.cs
+++ b/src/PostHog.AspNetCore/Cache/HttpContextFeatureFlagCache.cs
@@ -60,9 +60,7 @@ public class HttpContextFeatureFlagCache(
         }
         catch (ObjectDisposedException ex)
         {
-#pragma warning disable CA1848
-#pragma warning disable CA1727
-            logger.LogWarning(ex, "Failed to retrieve feature flags from HttpContext.Items for distinct ID '{distinctId}'.", distinctId);
+            logger.LogWarningRetrievingFeatureFlagsFromCacheFailed(ex, distinctId);
             return null;
         }
     }
@@ -81,7 +79,7 @@ public class HttpContextFeatureFlagCache(
         }
         catch (ObjectDisposedException ex)
         {
-            logger.LogWarning(ex, "Failed to store feature flags in HttpContext.Items for '{distinctId}'.", distinctId);
+            logger.LogWarningStoringFeatureFlagsInCacheFailed(ex, distinctId);
         }
     }
 
@@ -107,4 +105,22 @@ internal static partial class HttpContextFeatureFlagCacheLoggerExtensions
         Level = LogLevel.Trace,
         Message = "Storing feature flags in HttpContext.Items for '{distinctId}'.")]
     public static partial void LogTraceStoringFeatureFlagsInCache(this ILogger logger, string distinctId);
+
+    [LoggerMessage(
+        EventId = 203,
+        Level = LogLevel.Warning,
+        Message = "Fetching feature flags for '{distinctId}'.")]
+    public static partial void LogWarningRetrievingFeatureFlagsFromCacheFailed(
+        this ILogger logger,
+        Exception exception,
+        string distinctId);
+
+    [LoggerMessage(
+        EventId = 204,
+        Level = LogLevel.Warning,
+        Message = "Storing feature flags in HttpContext.Items failed for '{distinctId}'.")]
+    public static partial void LogWarningStoringFeatureFlagsInCacheFailed(
+        this ILogger logger,
+        Exception exception,
+        string distinctId);
 }

--- a/src/PostHog/Capture/CaptureExtensions.cs
+++ b/src/PostHog/Capture/CaptureExtensions.cs
@@ -208,7 +208,7 @@ public static class CaptureExtensions
         this IPostHogClient client,
         string distinctId,
         string pagePath,
-        bool sendFeatureFlags) => client.CapturePageView(distinctId, pagePath, properties: null, sendFeatureFlags);
+        bool sendFeatureFlags) => NotNull(client).CapturePageView(distinctId, pagePath, properties: null, sendFeatureFlags);
 
 
     /// <summary>

--- a/src/PostHog/Capture/CaptureExtensions.cs
+++ b/src/PostHog/Capture/CaptureExtensions.cs
@@ -156,7 +156,7 @@ public static class CaptureExtensions
         string distinctId,
         string pagePath,
         Dictionary<string, object>? properties)
-        => client.CaptureSpecialEvent(
+        => NotNull(client).CaptureSpecialEvent(
             distinctId,
             eventName: "$pageview",
             eventPropertyName: "$current_url",
@@ -169,10 +169,47 @@ public static class CaptureExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="pagePath">The URL or path of the page to capture.</param>
+    /// <param name="properties">Additional context to save with the event.</param>
+    /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>
+    /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
+    public static bool CapturePageView(
+        this IPostHogClient client,
+        string distinctId,
+        string pagePath,
+        Dictionary<string, object>? properties,
+        bool sendFeatureFlags)
+        => NotNull(client).CaptureSpecialEvent(
+            distinctId,
+            eventName: "$pageview",
+            eventPropertyName: "$current_url",
+            eventPropertyValue: pagePath,
+            properties,
+            sendFeatureFlags);
+
+    /// <summary>
+    /// Captures a Page View ($pageview) event.
+    /// </summary>
+    /// <param name="client">The <see cref="IPostHogClient"/>.</param>
+    /// <param name="distinctId">The identifier you use for the user.</param>
+    /// <param name="pagePath">The URL or path of the page to capture.</param>
     public static bool CapturePageView(
         this IPostHogClient client,
         string distinctId,
         string pagePath) => client.CapturePageView(distinctId, pagePath, properties: null);
+
+    /// <summary>
+    /// Captures a Page View ($pageview) event.
+    /// </summary>
+    /// <param name="client">The <see cref="IPostHogClient"/>.</param>
+    /// <param name="distinctId">The identifier you use for the user.</param>
+    /// <param name="pagePath">The URL or path of the page to capture.</param>
+    /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>
+    public static bool CapturePageView(
+        this IPostHogClient client,
+        string distinctId,
+        string pagePath,
+        bool sendFeatureFlags) => client.CapturePageView(distinctId, pagePath, properties: null, sendFeatureFlags);
+
 
     /// <summary>
     /// Captures a Screen View ($screen) event.
@@ -187,12 +224,35 @@ public static class CaptureExtensions
         string distinctId,
         string screenName,
         Dictionary<string, object>? properties)
-        => client.CaptureSpecialEvent(
+        => NotNull(client).CaptureSpecialEvent(
             distinctId,
             eventName: "$screen",
             eventPropertyName: "$screen_name",
             eventPropertyValue: screenName,
             properties);
+
+    /// <summary>
+    /// Captures a Screen View ($screen) event.
+    /// </summary>
+    /// <param name="client">The <see cref="IPostHogClient"/>.</param>
+    /// <param name="distinctId">The identifier you use for the user.</param>
+    /// <param name="screenName">The URL or path of the page to capture.</param>
+    /// <param name="properties">Additional context to save with the event.</param>
+    /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>
+    /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
+    public static bool CaptureScreenView(
+        this IPostHogClient client,
+        string distinctId,
+        string screenName,
+        Dictionary<string, object>? properties,
+        bool sendFeatureFlags)
+        => NotNull(client).CaptureSpecialEvent(
+            distinctId,
+            eventName: "$screen",
+            eventPropertyName: "$screen_name",
+            eventPropertyValue: screenName,
+            properties,
+            sendFeatureFlags);
 
     /// <summary>
     /// Captures a Screen View ($screen) event.
@@ -272,7 +332,7 @@ public static class CaptureExtensions
         string distinctId,
         string surveyId,
         Dictionary<string, object>? properties)
-        => client.CaptureSpecialEvent(
+        => NotNull(client).CaptureSpecialEvent(
             distinctId,
             eventName: "survey shown",
             eventPropertyName: "$survey_id",
@@ -292,7 +352,7 @@ public static class CaptureExtensions
         string distinctId,
         string surveyId,
         Dictionary<string, object>? properties)
-        => client.CaptureSpecialEvent(
+        => NotNull(client).CaptureSpecialEvent(
             distinctId,
             eventName: "survey dismissed",
             eventPropertyName: "$survey_id",
@@ -305,10 +365,11 @@ public static class CaptureExtensions
         string eventName,
         string eventPropertyName,
         string eventPropertyValue,
-        Dictionary<string, object>? properties)
+        Dictionary<string, object>? properties,
+        bool sendFeatureFlags = false)
     {
         properties ??= new Dictionary<string, object>();
         properties[eventPropertyName] = eventPropertyValue;
-        return client.Capture(distinctId, eventName, properties);
+        return NotNull(client).Capture(distinctId, eventName, properties, null, sendFeatureFlags);
     }
 }

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "1.0.1";
+    public const string Version = "1.0.2";
 }


### PR DESCRIPTION
HttpContext.Items can be disposed by the time we're trying to set the cache. This is because we might be making in a background thread. In that case, we don't want to fail the operation.

Also added some overloads to `CapturePageView` and `CaptureScreen` that send feature flag data.