### PR TITLE
Remove internal method from IPostHogClient interface

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/HogTied.Web/Pages/Index.cshtml
+++ b/samples/HogTied.Web/Pages/Index.cshtml
@@ -41,7 +41,7 @@
         else {
             <div class="alert alert-info mt-3" role="alert">
                 <strong>
-                    The Project API Key (@Model.PostHogOptions.ProjectApiKey) is set pointing to
+                    The Project API Key <code>@Model.PostHogOptions.ProjectApiKey</code> is set pointing to
                     <code>@Model.PostHogOptions.HostUrl!</code>
                     <br />We're ready to go!
                 </strong>

--- a/src/PostHog.AspNetCore/FeatureManagement/FeatureManagementExtensions.cs
+++ b/src/PostHog.AspNetCore/FeatureManagement/FeatureManagementExtensions.cs
@@ -1,0 +1,23 @@
+using PostHog.Features;
+
+namespace PostHog.FeatureManagement;
+
+internal static class FeatureManagementExtensions
+{
+    public static async Task<LocalEvaluator?> GetLocalEvaluatorAsync(this IPostHogClient posthog, CancellationToken cancellationToken)
+    {
+        // Get the local evaluator from the PostHog client so that we can return a list of the feature flags.
+        // This makes me feel dirty, but I don't yet want to add a method to `IPostHogClient` for this just
+        // yet because I'll have to support it and I want time to think about it. For example, should it be
+        // IAsyncEnumerable or IReadOnlyList? Should it be a method on `IPostHogClient` or a separate interface?
+        Func<CancellationToken, Task<LocalEvaluator?>> getAsync = posthog is PostHogClient posthogClient
+            ? posthogClient.GetLocalEvaluatorAsync
+            : cancelToken =>
+            {
+                var method = typeof(PostHogClient).GetMethod("GetLocalEvaluatorAsync", [typeof(CancellationToken)]);
+                return method?.Invoke(posthog, [cancelToken]) as Task<LocalEvaluator?>
+                       ?? Task.FromResult<LocalEvaluator?>(null);
+            };
+        return await getAsync(cancellationToken);
+    }
+}

--- a/src/PostHog.AspNetCore/FeatureManagement/FeatureManagementExtensions.cs
+++ b/src/PostHog.AspNetCore/FeatureManagement/FeatureManagementExtensions.cs
@@ -11,7 +11,9 @@ internal static class FeatureManagementExtensions
         // yet because I'll have to support it and I want time to think about it. For example, should it be
         // IAsyncEnumerable or IReadOnlyList? Should it be a method on `IPostHogClient` or a separate interface?
         Func<CancellationToken, Task<LocalEvaluator?>> getAsync = posthog is PostHogClient posthogClient
+#pragma warning disable CS0618 // Type or member is obsolete: It's for our internal use only, so we're good.
             ? posthogClient.GetLocalEvaluatorAsync
+#pragma warning restore CS0618 // Type or member is obsolete
             : cancelToken =>
             {
                 var method = typeof(PostHogClient).GetMethod("GetLocalEvaluatorAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic, [typeof(CancellationToken)]);

--- a/src/PostHog.AspNetCore/FeatureManagement/FeatureManagementExtensions.cs
+++ b/src/PostHog.AspNetCore/FeatureManagement/FeatureManagementExtensions.cs
@@ -14,7 +14,7 @@ internal static class FeatureManagementExtensions
             ? posthogClient.GetLocalEvaluatorAsync
             : cancelToken =>
             {
-                var method = typeof(PostHogClient).GetMethod("GetLocalEvaluatorAsync", [typeof(CancellationToken)]);
+                var method = typeof(PostHogClient).GetMethod("GetLocalEvaluatorAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic, [typeof(CancellationToken)]);
                 return method?.Invoke(posthog, [cancelToken]) as Task<LocalEvaluator?>
                        ?? Task.FromResult<LocalEvaluator?>(null);
             };

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "1.0.2";
+    public const string Version = "1.0.3";
 }

--- a/src/PostHog/IPostHogClient.cs
+++ b/src/PostHog/IPostHogClient.cs
@@ -146,11 +146,4 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// The version of this library.
     /// </summary>
     string Version { get; }
-
-    /// <summary>
-    /// Retrieves the local evaluator for evaluating feature flags locally.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    internal Task<LocalEvaluator?> GetLocalEvaluatorAsync(CancellationToken cancellationToken);
 }

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -467,7 +467,9 @@ public sealed class PostHogClient : IPostHogClient
     /// <inheritdoc/>
     public string Version => VersionConstants.Version;
 
-    async Task<LocalEvaluator?> IPostHogClient.GetLocalEvaluatorAsync(CancellationToken cancellationToken)
+    // HACK: Temporary hack until we come up with a better approach. This is to support Feature Management
+    //       in the PostHog.AspNetCore package, which is why I don't want to make it public here.
+    internal async Task<LocalEvaluator?> GetLocalEvaluatorAsync(CancellationToken cancellationToken)
     {
         try
         {

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -469,6 +469,7 @@ public sealed class PostHogClient : IPostHogClient
 
     // HACK: Temporary hack until we come up with a better approach. This is to support Feature Management
     //       in the PostHog.AspNetCore package, which is why I don't want to make it public here.
+    [Obsolete("This method is for internal use only and may go away soon.")]
     internal async Task<LocalEvaluator?> GetLocalEvaluatorAsync(CancellationToken cancellationToken)
     {
         try


### PR DESCRIPTION
This method was there to support .NET Feature Management. For now, I'll just cast to `PostHogClient` and use reflection if the `IPostHogClient` isn't a `PostHogClient`. It's ugly, but it'll do for now.

I do see the benefit of a method to enumerate flag definitions on `IPostHogClient`, I just need to think it over a bit. Any method we add, we have to support. Do we do an `IAsyncEnumerabel` or a `Task<IReadOnlyList>` or something else?

Fixes #60