### PR TITLE
feat(flags): Allow specifying flags to evaluate

### DIFF
--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -100,12 +100,14 @@ internal sealed class PostHogApiClient : IDisposable
     /// <param name="distinctUserId">The Id of the user.</param>
     /// <param name="personProperties">Optional: What person properties are known. Used to compute flags locally, if personalApiKey is present. Not needed if using remote evaluation, but can be used to override remote values for the purposes of feature flag evaluation.</param>
     /// <param name="groupProperties">Optional: What group properties are known. Used to compute flags locally, if personalApiKey is present.  Not needed if using remote evaluation, but can be used to override remote values for the purposes of feature flag evaluation.</param>
+    /// <param name="flagKeysToEvaluate">The set of flag keys to evaluate. If empty, this returns all flags.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
     /// <returns>A <see cref="DecideApiResult"/>.</returns>
-    public async Task<DecideApiResult?> GetAllFeatureFlagsFromDecideAsync(
+    public async Task<DecideApiResult?> GetFeatureFlagsFromDecideAsync(
         string distinctUserId,
         Dictionary<string, object?>? personProperties,
         GroupCollection? groupProperties,
+        IReadOnlyList<string>? flagKeysToEvaluate,
         CancellationToken cancellationToken)
     {
         var endpointUrl = new Uri(HostUrl, "decide?v=3");
@@ -118,6 +120,11 @@ internal sealed class PostHogApiClient : IDisposable
         if (personProperties is { Count: > 0 })
         {
             payload["person_properties"] = personProperties;
+        }
+
+        if (flagKeysToEvaluate is { Count: > 0 })
+        {
+            payload["flag_keys_to_evaluate"] = flagKeysToEvaluate;
         }
 
         groupProperties?.AddToPayload(payload);

--- a/src/PostHog/Features/FeatureFlagOptions.cs
+++ b/src/PostHog/Features/FeatureFlagOptions.cs
@@ -43,4 +43,9 @@ public class AllFeatureFlagsOptions
     /// Specifying properties for each group is required if <see cref="OnlyEvaluateLocally"/> is <c>true</c>.
     /// </summary>
     public GroupCollection? Groups { get; init; }
+
+    /// <summary>
+    /// The set of flag keys to evaluate in this request. If not specified, all flags are evaluated.
+    /// </summary>
+    public IReadOnlyList<string> FlagKeysToEvaluate { get; init; } = [];
 }

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -267,7 +267,10 @@ public sealed class PostHogClient : IPostHogClient
                 // Fallback to Decide
                 var flagsResult = await DecideAsync(
                     distinctId,
-                    options ?? new FeatureFlagOptions(),
+                    options ?? new FeatureFlagOptions
+                    {
+                        FlagKeysToEvaluate = [featureKey]
+                    },
                     cancellationToken);
                 requestId = flagsResult.RequestId;
                 response = flagsResult.Flags.GetValueOrDefault(featureKey) ?? new FeatureFlag
@@ -458,10 +461,11 @@ public sealed class PostHogClient : IPostHogClient
 
         async Task<FlagsResult> FetchDecideAsync(string distId, CancellationToken ctx)
         {
-            var results = await _apiClient.GetAllFeatureFlagsFromDecideAsync(
+            var results = await _apiClient.GetFeatureFlagsFromDecideAsync(
                 distId,
                 options?.PersonProperties,
                 options?.Groups,
+                options?.FlagKeysToEvaluate,
                 ctx);
             return results.ToFlagsResult();
         }

--- a/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
+++ b/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
@@ -9,7 +9,6 @@ internal static class FakeHttpMessageHandlerExtensions
 {
     static readonly Uri DecideUrl = new("https://us.i.posthog.com/decide?v=3");
 
-
     public static FakeHttpMessageHandler.RequestHandler AddCaptureResponse(this FakeHttpMessageHandler handler) =>
         handler.AddResponse(
             new Uri("https://us.i.posthog.com/capture"),
@@ -27,14 +26,35 @@ internal static class FakeHttpMessageHandlerExtensions
         Exception exception)
         => handler.AddResponseException(DecideUrl, HttpMethod.Post, exception);
 
-    public static FakeHttpMessageHandler.RequestHandler AddDecideResponse(this FakeHttpMessageHandler handler, string responseBody)
-        => handler.AddDecideResponse(Deserialize<DecideApiResult>(responseBody));
+    public static FakeHttpMessageHandler.RequestHandler AddDecideResponse(
+        this FakeHttpMessageHandler handler,
+        Func<Dictionary<string, object>, bool> decideRequestPredicate,
+        string responseBody)
+        => handler.AddDecideResponse(
+            decideRequestPredicate,
+            responseBody: Deserialize<DecideApiResult>(responseBody));
 
-    public static FakeHttpMessageHandler.RequestHandler AddDecideResponse(this FakeHttpMessageHandler handler, DecideApiResult responseBody)
+    public static FakeHttpMessageHandler.RequestHandler AddDecideResponse(
+        this FakeHttpMessageHandler handler,
+        string responseBody)
+        => handler.AddDecideResponse(_ => true, responseBody);
+
+    public static FakeHttpMessageHandler.RequestHandler AddDecideResponse(
+        this FakeHttpMessageHandler handler,
+        DecideApiResult responseBody)
+        => handler.AddDecideResponse(
+            _ => true,
+            responseBody: responseBody);
+
+    public static FakeHttpMessageHandler.RequestHandler AddDecideResponse(
+        this FakeHttpMessageHandler handler,
+        Func<Dictionary<string, object>, bool> decideRequestPredicate,
+        DecideApiResult responseBody)
         => handler.AddResponse(
             DecideUrl,
             HttpMethod.Post,
-            responseBody: responseBody);
+            decideRequestPredicate,
+            responseBody);
 
     public static void AddRepeatedDecideResponse(this FakeHttpMessageHandler handler, int count, Func<int, string> responseBodyFunc)
         => handler.AddRepeatedResponses(


### PR DESCRIPTION
This adds support for https://github.com/PostHog/posthog/pull/29493 which allows specifying a set of flag keys to evaluate.

Fixes #62