### PR TITLE
Catch and log all exceptions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "1.0.3";
+    public const string Version = "1.0.4";
 }


### PR DESCRIPTION
And just debug assert that they're not "coding error" exceptions.

We don't want to miss out on exception logging in our async batching that could cause the process to crash without good info.

And bump version to 1.0.4.