### PR TITLE
Make less decide requests when enriching events

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.4</Version>
+        <Version>1.0.5</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/HogTied.Web/Pages/Index.cshtml.cs
+++ b/samples/HogTied.Web/Pages/Index.cshtml.cs
@@ -131,7 +131,9 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
             {
                 ["plan"] = "free",
                 ["price"] = "$29.99"
-            });
+            },
+            groups: null,
+            sendFeatureFlags: true);
 
         StatusMessage = "Event captured! Events are sent asynchronously, so it may take a few seconds to appear in PostHog.";
 

--- a/src/PostHog/Capture/CapturedEventBatchContext.cs
+++ b/src/PostHog/Capture/CapturedEventBatchContext.cs
@@ -1,0 +1,6 @@
+namespace PostHog;
+
+internal class CapturedEventBatchContext(IFeatureFlagCache featureFlagCache)
+{
+    public IFeatureFlagCache FeatureFlagCache { get; } = featureFlagCache;
+}

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -37,7 +37,7 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
     /// Default properties to send when capturing events. These properties override any properties with the same
     /// key sent with the event.
     /// </summary>
-    public Dictionary<string, object> SuperProperties { get; init; } = new Dictionary<string, object>();
+    public Dictionary<string, object> SuperProperties { get; init; } = new();
 
     /// <summary>
     /// When <see cref="PersonalApiKey"/> is set, this is the interval to poll for feature flags used in

--- a/src/PostHog/Features/FallbackFeatureFlagCache.cs
+++ b/src/PostHog/Features/FallbackFeatureFlagCache.cs
@@ -1,0 +1,38 @@
+using PostHog.Api;
+using PostHog.Library;
+
+namespace PostHog.Features;
+
+/// <summary>
+/// Used to try and retrieve feature flags from a primary cache. If the primary cache fails, it falls back to a
+/// secondary cache.
+/// </summary>
+/// <param name="primary">The primary cache.</param>
+/// <param name="fallback">The secondary cache.</param>
+public class FallbackFeatureFlagCache(IFeatureFlagCache primary, IFeatureFlagCache fallback) : FeatureFlagCacheBase
+{
+    readonly IFeatureFlagCache _primary = Ensure.NotNull(primary);
+    readonly IFeatureFlagCache _fallback = Ensure.NotNull(fallback);
+
+    /// <inherititdoc/>
+    public override async Task<FlagsResult> GetAndCacheFlagsAsync(
+        string distinctId,
+        Func<string, CancellationToken, Task<FlagsResult>> fetcher,
+        CancellationToken cancellationToken)
+    {
+        var flags = await _primary.GetAndCacheFlagsAsync(distinctId, fetcher, cancellationToken);
+        if (flags.Flags.Count > 0)
+        {
+            return flags;
+        }
+        flags = await _fallback.GetAndCacheFlagsAsync(distinctId, fetcher, cancellationToken);
+        if (flags.Flags.Count > 0)
+        {
+            return flags;
+        }
+        return new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>()
+        };
+    }
+}

--- a/src/PostHog/Features/FeatureFlagCacheBase.cs
+++ b/src/PostHog/Features/FeatureFlagCacheBase.cs
@@ -1,0 +1,28 @@
+using PostHog;
+using PostHog.Api;
+using PostHog.Features;
+
+namespace PostHog.Features;
+
+public abstract class FeatureFlagCacheBase : IFeatureFlagCache
+{
+    public async Task<IReadOnlyDictionary<string, FeatureFlag>> GetAndCacheFeatureFlagsAsync(
+        string distinctId,
+        Func<CancellationToken, Task<IReadOnlyDictionary<string, FeatureFlag>>> fetcher,
+        CancellationToken cancellationToken)
+    {
+        var resultsFetcher = async (string id, CancellationToken ct) =>
+        {
+            var flags = await fetcher(ct);
+            return new FlagsResult { Flags = flags };
+        };
+
+        var results = await GetAndCacheFlagsAsync(distinctId, resultsFetcher, cancellationToken);
+        return results.Flags;
+    }
+
+    public abstract Task<FlagsResult> GetAndCacheFlagsAsync(
+        string distinctId,
+        Func<string, CancellationToken, Task<FlagsResult>> fetcher,
+        CancellationToken cancellationToken);
+}

--- a/src/PostHog/Features/IFeatureFlagCache.cs
+++ b/src/PostHog/Features/IFeatureFlagCache.cs
@@ -79,4 +79,3 @@ public sealed class NullFeatureFlagCache : IFeatureFlagCache
         CancellationToken cancellationToken)
         => NotNull(fetcher)(distinctId, cancellationToken);
 }
-

--- a/src/PostHog/Features/MemoryFeatureFlagCache.cs
+++ b/src/PostHog/Features/MemoryFeatureFlagCache.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Caching.Memory;
+using PostHog.Api;
+using PostHog.Features;
+using PostHog.Library;
+
+namespace PostHog;
+
+/// <summary>
+/// Caches feature flags using a <see cref="MemoryCache"/>.
+/// </summary>
+/// <param name="timeProvider">The time provider to use for the cache.</param>
+/// <param name="sizeLimit">The size limit of the cache. In this case, the number of entries allowed.</param>
+/// <param name="compactPercentage">The amount (as a percentage) the cache should be compacted when it reaches its size limit.</param>
+public sealed class MemoryFeatureFlagCache(TimeProvider timeProvider, int sizeLimit, double compactPercentage) : FeatureFlagCacheBase, IDisposable
+{
+    readonly MemoryCache _cache = new(new MemoryCacheOptions
+    {
+        SizeLimit = sizeLimit,
+        Clock = new TimeProviderSystemClock(timeProvider),
+        CompactionPercentage = compactPercentage
+    });
+
+    /// <inherititdoc/>
+    public override async Task<FlagsResult> GetAndCacheFlagsAsync(
+        string distinctId,
+        Func<string, CancellationToken, Task<FlagsResult>> fetcher,
+        CancellationToken cancellationToken)
+    {
+        var flags = await _cache.GetOrCreateAsync(
+            distinctId,
+            async cacheEntry =>
+            {
+                cacheEntry.SetSize(1);
+                cacheEntry.SetPriority(CacheItemPriority.High);
+                cacheEntry.SetAbsoluteExpiration(TimeSpan.FromSeconds(10));
+                return await fetcher(distinctId, cancellationToken);
+            });
+        return flags ?? new FlagsResult();
+    }
+
+    public void Dispose() => _cache.Dispose();
+}

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -6,5 +6,5 @@
 namespace PostHog.Versioning;
 public static class VersionConstants
 {
-    public const string Version = "1.0.4";
+    public const string Version = "1.0.5";
 }

--- a/src/PostHog/Library/AsyncBatchHandler.cs
+++ b/src/PostHog/Library/AsyncBatchHandler.cs
@@ -18,7 +18,7 @@ namespace PostHog.Library;
 internal class BatchItem<TItem, TBatchContext>(Func<TBatchContext, Task<TItem>> itemFetcher)
 {
     /// <summary>
-    /// Resolves the item to send in te batch.
+    /// Resolves the item to send in the batch.
     /// </summary>
     /// <param name="context">Context to provide to the resolver.</param>
     /// <returns>The item to send in the batch.</returns>

--- a/src/PostHog/Library/AsyncBatchHandler.cs
+++ b/src/PostHog/Library/AsyncBatchHandler.cs
@@ -8,15 +8,37 @@ using static PostHog.Library.Ensure;
 namespace PostHog.Library;
 
 /// <summary>
+/// Represents a batch item that can be fetched asynchronously.
+/// </summary>
+/// <param name="itemFetcher">Used to fetch the item to send in the batch.</param>
+/// <typeparam name="TItem">The type of the item.</typeparam>
+/// <typeparam name="TBatchContext">
+/// The type of the context object to pass to batch items. A new instance is passed for each batch.
+/// </typeparam>
+internal class BatchItem<TItem, TBatchContext>(Func<TBatchContext, Task<TItem>> itemFetcher)
+{
+    /// <summary>
+    /// Resolves the item to send in te batch.
+    /// </summary>
+    /// <param name="context">Context to provide to the resolver.</param>
+    /// <returns>The item to send in the batch.</returns>
+    public Task<TItem> ResolveItem(TBatchContext context) => itemFetcher(context);
+}
+
+/// <summary>
 /// Allows enqueueing items and flushing them in batches. Flushes happen on a periodic basis or when the queue reaches
 /// a certain size (<see cref="PostHogOptions.FlushAt"/>).
 /// </summary>
 /// <typeparam name="TItem">The type of item to batch.</typeparam>
-internal sealed class AsyncBatchHandler<TItem> : IDisposable, IAsyncDisposable
+/// <typeparam name="TBatchContext">
+/// The type of the context object to pass to batch items. A new instance is passed for each batch.
+/// </typeparam>
+internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAsyncDisposable
 {
-    readonly Channel<Task<TItem>> _channel;
+    readonly Channel<BatchItem<TItem, TBatchContext>> _channel;
     readonly IOptions<PostHogOptions> _options;
     readonly Func<IEnumerable<TItem>, Task> _batchHandlerFunc;
+    readonly Func<TBatchContext> _batchContextFunc;
     readonly ILogger<AsyncBatchHandler> _logger;
     readonly PeriodicTimer _timer;
     readonly CancellationTokenSource _cancellationTokenSource = new();
@@ -26,6 +48,7 @@ internal sealed class AsyncBatchHandler<TItem> : IDisposable, IAsyncDisposable
 
     public AsyncBatchHandler(
         Func<IEnumerable<TItem>, Task> batchHandlerFunc,
+        Func<TBatchContext> batchContextFunc,
         IOptions<PostHogOptions> options,
         ITaskScheduler taskScheduler,
         TimeProvider timeProvider,
@@ -33,8 +56,9 @@ internal sealed class AsyncBatchHandler<TItem> : IDisposable, IAsyncDisposable
     {
         _options = NotNull(options);
         _batchHandlerFunc = batchHandlerFunc;
+        _batchContextFunc = batchContextFunc;
         _logger = logger;
-        _channel = Channel.CreateBounded<Task<TItem>>(new BoundedChannelOptions(_options.Value.MaxQueueSize)
+        _channel = Channel.CreateBounded<BatchItem<TItem, TBatchContext>>(new BoundedChannelOptions(_options.Value.MaxQueueSize)
         {
             FullMode = BoundedChannelFullMode.DropOldest
         });
@@ -45,9 +69,16 @@ internal sealed class AsyncBatchHandler<TItem> : IDisposable, IAsyncDisposable
 
     public AsyncBatchHandler(
         Func<IEnumerable<TItem>, Task> batchHandlerFunc,
+        Func<TBatchContext> batchContextFunc,
         TimeProvider timeProvider,
         IOptions<PostHogOptions> options)
-        : this(batchHandlerFunc, options, new TaskRunTaskScheduler(), timeProvider, NullLogger<AsyncBatchHandler>.Instance)
+        : this(
+            batchHandlerFunc,
+            batchContextFunc,
+            options,
+            new TaskRunTaskScheduler(),
+            timeProvider,
+            NullLogger<AsyncBatchHandler>.Instance)
     {
     }
 
@@ -58,7 +89,14 @@ internal sealed class AsyncBatchHandler<TItem> : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="item">The item to enqueue</param>
     /// <returns><c>true</c> if the item was enqueued, otherwise <c>false</c>ß</returns>
-    public bool Enqueue(Task<TItem> item)
+    public bool Enqueue(Task<TItem> item) => Enqueue(new BatchItem<TItem, TBatchContext>(_ => item));
+
+    /// <summary>
+    /// Enqueues a batch item and returns true if the item was successfully enqueued.
+    /// </summary>
+    /// <param name="item">The item to enqueue</param>
+    /// <returns><c>true</c> if the item was enqueued, otherwise <c>false</c>ß</returns>
+    public bool Enqueue(BatchItem<TItem, TBatchContext> item)
     {
         if (Count >= _options.Value.MaxQueueSize)
         {
@@ -163,9 +201,11 @@ internal sealed class AsyncBatchHandler<TItem> : IDisposable, IAsyncDisposable
 
         try
         {
+            var batchContext = _batchContextFunc();
             while (_channel.Reader.TryReadBatch(_options.Value.MaxBatchSize, out var batch))
             {
-                var resolved = await Task.WhenAll(batch);
+                var tasks = batch.Select(item => item.ResolveItem(batchContext));
+                var resolved = await Task.WhenAll(tasks);
                 await SendBatch(resolved);
             }
         }

--- a/tests/UnitTests/Features/FallbackFeatureFlagCacheTests.cs
+++ b/tests/UnitTests/Features/FallbackFeatureFlagCacheTests.cs
@@ -1,0 +1,52 @@
+using PostHog;
+using PostHog.Features;
+
+namespace FallbackFeatureFlagCacheTests;
+
+public class TheGetAndCacheFeatureFlagsAsyncMethod
+{
+    [Fact]
+    public async Task ReturnsItemInPrimaryCache()
+    {
+        var timeProvider = TimeProvider.System;
+        var primaryCache = new MemoryFeatureFlagCache(timeProvider, 10, 0.2);
+        var secondaryCache = new MemoryFeatureFlagCache(timeProvider, 10, 0.2);
+
+        var cache = new FallbackFeatureFlagCache(primaryCache, secondaryCache);
+        var distinctId = "test-distinct-id";
+        var expectedFlags = new Dictionary<string, FeatureFlag>
+        {
+            { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+        };
+        await primaryCache.GetAndCacheFeatureFlagsAsync(distinctId, _ => Task.FromResult<IReadOnlyDictionary<string, FeatureFlag>>(expectedFlags), CancellationToken.None);
+
+        var result = await cache.GetAndCacheFeatureFlagsAsync(
+            distinctId,
+            _ => Task.FromResult<IReadOnlyDictionary<string, FeatureFlag>>(new Dictionary<string, FeatureFlag>()), CancellationToken.None);
+
+        Assert.Equal(expectedFlags, result);
+    }
+
+    [Fact]
+    public async Task ReturnsItemInSecondaryCache()
+    {
+        var timeProvider = TimeProvider.System;
+        var primaryCache = new MemoryFeatureFlagCache(timeProvider, 10, 0.2);
+        var secondaryCache = new MemoryFeatureFlagCache(timeProvider, 10, 0.2);
+
+        var cache = new FallbackFeatureFlagCache(primaryCache, secondaryCache);
+        var distinctId = "test-distinct-id";
+        var expectedFlags = new Dictionary<string, FeatureFlag>
+        {
+            { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+        };
+        await secondaryCache.GetAndCacheFeatureFlagsAsync(distinctId, _ => Task.FromResult<IReadOnlyDictionary<string, FeatureFlag>>(expectedFlags), CancellationToken.None);
+
+        var result = await cache.GetAndCacheFeatureFlagsAsync(
+            distinctId,
+            _ => Task.FromResult<IReadOnlyDictionary<string, FeatureFlag>>(new Dictionary<string, FeatureFlag>()), CancellationToken.None);
+
+        Assert.Equal(expectedFlags, result);
+    }
+
+}

--- a/tests/UnitTests/Features/MemoryFeatureFlagCacheTests.cs
+++ b/tests/UnitTests/Features/MemoryFeatureFlagCacheTests.cs
@@ -1,0 +1,44 @@
+using PostHog;
+using PostHog.Features;
+
+namespace InMemoryFeatureFlagCacheTests;
+
+public class TheGetAndCacheFeatureFlagsAsyncMethod
+{
+    [Fact]
+    public async Task ReturnsCachedFlagsWhenFlagsAreCached()
+    {
+        var timeProvider = TimeProvider.System;
+        var cache = new MemoryFeatureFlagCache(timeProvider, 100, 0.1);
+        var distinctId = "test-distinct-id";
+        var expectedFlags = new Dictionary<string, FeatureFlag>
+        {
+            { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+        };
+        await cache.GetAndCacheFeatureFlagsAsync(distinctId, _ => Task.FromResult((IReadOnlyDictionary<string, FeatureFlag>)expectedFlags), CancellationToken.None);
+
+        var result = await cache.GetAndCacheFeatureFlagsAsync(
+            distinctId,
+            _ => Task.FromResult<IReadOnlyDictionary<string, FeatureFlag>>(new Dictionary<string, FeatureFlag>()), CancellationToken.None);
+
+        Assert.Equal(expectedFlags, result);
+    }
+
+    [Fact]
+    public async Task FetchesAndCachesFlagsWhenFlagsAreNotCached()
+    {
+        var timeProvider = TimeProvider.System;
+        var cache = new MemoryFeatureFlagCache(timeProvider, 100, 0.1);
+        var distinctId = "test-distinct-id";
+        var expectedFlags = new Dictionary<string, FeatureFlag>
+        {
+            { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+        };
+
+        var result = await cache.GetAndCacheFeatureFlagsAsync(
+            distinctId,
+            _ => Task.FromResult<IReadOnlyDictionary<string, FeatureFlag>>(expectedFlags), CancellationToken.None);
+
+        Assert.Equal(expectedFlags, result);
+    }
+}


### PR DESCRIPTION
When `sendFeatureFlags` is `true`, the client makes a `Decide` requests to get the latest feature flags in order to enrich the captured event with the current feature flag values.

However, when processing a batch, it doesn't make sense to make a decide request multiple times for the same `distinctId`. This PR adds an in-memory cache that lasts for the duration of the batch.

So far, I don't think a lot of the other client libraries actually use the `/batch` endpoint to batch requests. And if they do, I don't think they're caching `/decide` requests. This is a change I'd like to consider doing for all of the clients.