### PR TITLE
feat: use .NET 8 packages

### DIFF
--- a/src/PostHog/Api/ComparisonOperator.cs
+++ b/src/PostHog/Api/ComparisonOperator.cs
@@ -11,90 +11,90 @@ public enum ComparisonOperator
     /// <summary>
     /// Matches if the value is in the list of filter values. Only used for cohort filters.
     /// </summary>
-    [JsonStringEnumMemberName("in")]
+    [JsonPropertyName("in")]
     In,
 
     /// <summary>
     /// Matches if the value is an exact match to the filter value.
     /// </summary>
-    [JsonStringEnumMemberName("exact")]
+    [JsonPropertyName("exact")]
     Exact,
 
     /// <summary>
     /// Matches if the value is not an exact match to the filter value.
     /// </summary>
-    [JsonStringEnumMemberName("is_not")]
+    [JsonPropertyName("is_not")]
     IsNot,
 
     /// <summary>
     /// Matches if the value is set.
     /// </summary>
-    [JsonStringEnumMemberName("is_set")]
+    [JsonPropertyName("is_set")]
     IsSet,
 
     /// <summary>
     /// Matches if the value is not set.
     /// </summary>
-    [JsonStringEnumMemberName("is_not_set")]
+    [JsonPropertyName("is_not_set")]
     IsNotSet,
 
     /// <summary>
     /// Matches if the value is greater than the filter value.
     /// </summary>
-    [JsonStringEnumMemberName("gt")]
+    [JsonPropertyName("gt")]
     GreaterThan,
 
     /// <summary>
     /// Matches if the value is less than the filter value.
     /// </summary>
-    [JsonStringEnumMemberName("lt")]
+    [JsonPropertyName("lt")]
     LessThan,
 
     /// <summary>
     /// Matches if the value is greater than or equal to the filter value.
     /// </summary>
-    [JsonStringEnumMemberName("gte")]
+    [JsonPropertyName("gte")]
     GreaterThanOrEquals,
 
     /// <summary>
     /// Matches if the value is less than or equal to the filter value.
     /// </summary>
-    [JsonStringEnumMemberName("lte")]
+    [JsonPropertyName("lte")]
     LessThanOrEquals,
 
     /// <summary>
     /// Matches if the value contains the filter value, ignoring case differences.
     /// </summary>
-    [JsonStringEnumMemberName("icontains")]
+    [JsonPropertyName("icontains")]
     ContainsIgnoreCase,
 
     /// <summary>
     /// Matches if the value does not contain the filter value, ignoring case differences.
     /// </summary>
-    [JsonStringEnumMemberName("not_icontains")]
+    [JsonPropertyName("not_icontains")]
     DoesNotContainIgnoreCase,
 
     /// <summary>
     /// Matches if the value matches the regular expression filter pattern.
     /// </summary>
-    [JsonStringEnumMemberName("regex")]
+    [JsonPropertyName("regex")]
     Regex,
 
     /// <summary>
     /// Matches if regular expression filter value does not match the value.
     /// </summary>
-    [JsonStringEnumMemberName("not_regex")]
+    [JsonPropertyName("not_regex")]
     NotRegex,
 
     /// <summary>
     /// Matches if the date represented by the value is before the filter value.
     /// </summary>
-    [JsonStringEnumMemberName("is_date_before")]
+    [JsonPropertyName("is_date_before")]
     IsDateBefore,
 
     /// <summary>
     /// Matches if the date represented by the value is after the filter value.
     /// </summary>
-    [JsonStringEnumMemberName("is_date_after")]
+    [JsonPropertyName("is_date_after")]
     IsDateAfter
 }

--- a/src/PostHog/Api/LocalEvaluationApiResult.cs
+++ b/src/PostHog/Api/LocalEvaluationApiResult.cs
@@ -410,30 +410,30 @@ public enum FilterType
     /// <summary>
     /// Filters on person properties.
     /// </summary>
-    [JsonStringEnumMemberName("person")]
+    [JsonPropertyName("person")]
     Person,
 
     /// <summary>
     /// Filters on group properties.
     /// </summary>
-    [JsonStringEnumMemberName("group")]
+    [JsonPropertyName("group")]
     Group,
 
     /// <summary>
     /// Filters on cohort membership
     /// </summary>
-    [JsonStringEnumMemberName("cohort")]
+    [JsonPropertyName("cohort")]
     Cohort,
 
     /// <summary>
     /// If any of the filters match, the group is considered a match.
     /// </summary>
-    [JsonStringEnumMemberName("OR")]
+    [JsonPropertyName("OR")]
     Or,
 
     /// <summary>
     /// If all of the filters match, the group is considered a match.
     /// </summary>
-    [JsonStringEnumMemberName("AND")]
+    [JsonPropertyName("AND")]
     And
 }

--- a/src/PostHog/PostHog.csproj
+++ b/src/PostHog/PostHog.csproj
@@ -8,17 +8,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.1" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="System.Threading.Channels" Version="9.0.1" />
-        <PackageReference Include="System.Net.Http.Json" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
+        <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
+        <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
This PR updates the package dependencies to match .NET 8 versions instead of .NET 9 versions.

## Motivation
I've tried using this library in my .NET 8 project, but updating all those libs to the .NET 9 version broke my app. The library was previously using .NET 9 package versions, which made it difficult to use in .NET 8 projects. By aligning the package versions with .NET 8, this change makes the library easier to integrate and use in .NET 8 projects while maintaining compatibility.

## Changes
- Updated package dependencies from .NET 9 versions to .NET 8 versions

## Benefits
- Improved compatibility with .NET 8 projects
- Easier integration for developers using .NET 8
- Maintains functionality while using appropriate package versions

## Testing
- [ ] Existing tests pass
- [ ] No breaking changes introduced
- [ ] Verified compatibility with .NET 8 projects