### PR TITLE
fix: Ensure serialization doesn't fail when encountering flag dependencies

### DIFF
--- a/src/PostHog/Api/LocalEvaluationApiResult.cs
+++ b/src/PostHog/Api/LocalEvaluationApiResult.cs
@@ -435,5 +435,11 @@ public enum FilterType
     /// If all of the filters match, the group is considered a match.
     /// </summary>
     [JsonStringEnumMemberName("AND")]
-    And
+    And,
+
+    /// <summary>
+    /// Filters on how another flag was evaluated
+    /// </summary>
+    [JsonStringEnumMemberName("flag")]
+    Flag
 }


### PR DESCRIPTION
We're introducing a new type of filter, "flag". When we do, we don't want local evaluation to fail because it can't serialize it.