### PR TITLE
fix(flags): Pass project API key in remote_config requests

### DIFF
--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -172,10 +172,15 @@ internal sealed class PostHogApiClient : IDisposable
     /// <param name="key">The config key.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
     /// <returns></returns>
-    public async Task<JsonDocument?> GetRemoteConfigPayloadAsync(string key, CancellationToken cancellationToken) =>
-        await GetAuthenticatedResponseAsync<JsonDocument>(
-            $"/api/projects/@current/feature_flags/{key}/remote_config/",
+    public async Task<JsonDocument?> GetRemoteConfigPayloadAsync(string key, CancellationToken cancellationToken)
+    {
+        var uriBuilder = new UriBuilder(new Uri(HostUrl, $"/api/projects/@current/feature_flags/{Uri.EscapeDataString(key)}/remote_config"));
+        uriBuilder.Query = $"token={Uri.EscapeDataString(ProjectApiKey)}";
+
+        return await GetAuthenticatedResponseAsync<JsonDocument>(
+            uriBuilder.Uri.PathAndQuery,
             cancellationToken);
+    }
 
     async Task<T?> GetAuthenticatedResponseAsync<T>(string relativeUrl, CancellationToken cancellationToken)
     {

--- a/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
+++ b/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
@@ -85,7 +85,7 @@ internal static class FakeHttpMessageHandlerExtensions
         string key,
         string responseBody) =>
         handler.AddResponse(
-            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config/"),
+            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-api-key"),
             HttpMethod.Get,
             responseBody: responseBody);
 
@@ -94,7 +94,7 @@ internal static class FakeHttpMessageHandlerExtensions
         string key,
         string responseBody) =>
         handler.AddResponse(
-            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config/"),
+            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-api-key"),
             HttpMethod.Get,
             responseBody: responseBody);
 

--- a/tests/UnitTests/Features/RemoteConfigTests.cs
+++ b/tests/UnitTests/Features/RemoteConfigTests.cs
@@ -91,4 +91,23 @@ public class TheGetRemoteConfigPayloadAsyncMethod
         Assert.NotNull(result);
         Assert.Equal("Valid JSON string", result.RootElement.GetString());
     }
+
+    [Fact]
+    public async Task IncludesProjectApiKeyTokenInRemoteConfigUrl()
+    {
+        var container = new TestContainer("fake-personal-api-key");
+
+        // Use the AddResponse method to verify the URL includes the token parameter
+        container.FakeHttpMessageHandler.AddResponse(
+            new Uri("https://us.i.posthog.com/api/projects/@current/feature_flags/test-flag/remote_config?token=fake-project-api-key"),
+            HttpMethod.Get,
+            responseBody: """{"test": "payload"}"""
+        );
+        var client = container.Activate<PostHogClient>();
+
+        var result = await client.GetRemoteConfigPayloadAsync("test-flag");
+
+        Assert.NotNull(result);
+        Assert.Equal("payload", result.RootElement.GetProperty("test").GetString());
+    }
 }


### PR DESCRIPTION
Fixes the remote_config endpoint to include the project API key as a token parameter for deterministic project routing, matching the implementation in other server-side SDKs.

- Add token parameter to remote_config URL construction
- Add test to verify the token parameter is included in requests
- Update test fixtures to match new URL format

See https://github.com/PostHog/posthog/issues/35303 for the problem.
Port of PostHog Python implementation: https://github.com/PostHog/posthog-python/pull/303
