### PR TITLE
fix: Pass project API key in `remote_config` and `local_evaluation` requests

### DIFF
--- a/samples/HogTied.Web/Pages/Index.cshtml
+++ b/samples/HogTied.Web/Pages/Index.cshtml
@@ -305,7 +305,7 @@
 await posthog.GetRemoteConfigPayloadAsync(
     "unencrypted-remote-config-setting");
 
-> @Model.UnencryptedRemoteConfigSetting
+@(Model.UnencryptedRemoteConfigSetting ?? "null")
 </code></pre>
                     </div>
                     <div class="col-md-6">
@@ -313,7 +313,7 @@ await posthog.GetRemoteConfigPayloadAsync(
 await posthog.GetRemoteConfigPayloadAsync(
     "encrypted-remote-config-setting");
 
-@Model.EncryptedRemoteConfigSetting
+@(Model.EncryptedRemoteConfigSetting ?? "null")
 </code></pre>
                     </div>
                 </div>

--- a/samples/HogTied.Web/appsettings.Development.json
+++ b/samples/HogTied.Web/appsettings.Development.json
@@ -8,7 +8,7 @@
     }
   },
   "PostHogLocal" : {
-    "HostUrl": "http://localhost:8000",
+    "HostUrl": "http://localhost:8010",
     "ProjectApiKey": "SET IN USER SECRETS!",
     "MaxBatchSize": 100,
     "MaxQueueSize": 1000,

--- a/src/PostHog/Api/ComparisonOperator.cs
+++ b/src/PostHog/Api/ComparisonOperator.cs
@@ -96,5 +96,11 @@ public enum ComparisonOperator
     /// Matches if the date represented by the value is after the filter value.
     /// </summary>
     [JsonStringEnumMemberName("is_date_after")]
-    IsDateAfter
+    IsDateAfter,
+
+    /// <summary>
+    /// Matches if the flag condition evaluates to the specified value.
+    /// </summary>
+    [JsonStringEnumMemberName("flag_evaluates_to")]
+    FlagEvaluatesTo
 }

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -147,10 +147,14 @@ internal sealed class PostHogApiClient : IDisposable
     /// <exception cref="ApiException">Thrown when the API returns a <c>quota_limited</c> error.</exception>
     public async Task<LocalEvaluationApiResult?> GetFeatureFlagsForLocalEvaluationAsync(CancellationToken cancellationToken)
     {
+        var uriBuilder = new UriBuilder(new Uri(HostUrl, "/api/feature_flag/local_evaluation"))
+        {
+            Query = $"token={Uri.EscapeDataString(ProjectApiKey)}&send_cohorts"
+        };
         try
         {
             return await GetAuthenticatedResponseAsync<LocalEvaluationApiResult>(
-                "/api/feature_flag/local_evaluation/?send_cohorts",
+                uriBuilder.Uri.PathAndQuery,
                 cancellationToken);
         }
         catch (ApiException e) when (e.ErrorType is "quota_limited")

--- a/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
+++ b/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
@@ -85,7 +85,7 @@ internal static class FakeHttpMessageHandlerExtensions
         string key,
         string responseBody) =>
         handler.AddResponse(
-            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config/"),
+            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-api-key"),
             HttpMethod.Get,
             responseBody: responseBody);
 
@@ -94,7 +94,7 @@ internal static class FakeHttpMessageHandlerExtensions
         string key,
         string responseBody) =>
         handler.AddResponse(
-            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config/"),
+            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-api-key"),
             HttpMethod.Get,
             responseBody: responseBody);
 

--- a/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
+++ b/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
@@ -75,7 +75,7 @@ internal static class FakeHttpMessageHandlerExtensions
         this FakeHttpMessageHandler handler,
         LocalEvaluationApiResult responseBody) =>
         handler.AddResponse(
-            new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation/?send_cohorts"),
+            new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation?token=fake-project-api-key&send_cohorts"),
             HttpMethod.Get,
             responseBody: responseBody);
 

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -3228,7 +3228,7 @@ public class TheGetAllFeatureFlagsAsyncMethod
             FeatureFlagPayloads = new Dictionary<string, string>(),
         });
         container.FakeHttpMessageHandler.AddResponse(
-            new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation/?send_cohorts"),
+            new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation?token=fake-project-api-key&send_cohorts"),
             HttpMethod.Get,
             new HttpResponseMessage(HttpStatusCode.Unauthorized)
             {
@@ -3384,7 +3384,7 @@ public class TheQuotaLimitBehavior
         // When local evaluation is quota limited, we do not want to fallback to /decide.
         var decideHandler = container.FakeHttpMessageHandler.AddDecideResponseException(new InvalidOperationException());
         container.FakeHttpMessageHandler.AddResponse(
-            new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation/?send_cohorts"),
+            new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation?token=fake-project-api-key&send_cohorts"),
             HttpMethod.Get,
             new HttpResponseMessage(HttpStatusCode.PaymentRequired)
             {
@@ -3416,7 +3416,7 @@ public class TheQuotaLimitBehavior
         var container = new TestContainer("fake-personal-api-key");
         var decideHandler = container.FakeHttpMessageHandler.AddDecideResponseException(new InvalidOperationException());
         container.FakeHttpMessageHandler.AddResponse(
-            new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation/?send_cohorts"),
+            new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation?token=fake-project-api-key&send_cohorts"),
             HttpMethod.Get,
             new HttpResponseMessage(HttpStatusCode.PaymentRequired)
             {

--- a/tests/UnitTests/Features/RemoteConfigTests.cs
+++ b/tests/UnitTests/Features/RemoteConfigTests.cs
@@ -91,4 +91,23 @@ public class TheGetRemoteConfigPayloadAsyncMethod
         Assert.NotNull(result);
         Assert.Equal("Valid JSON string", result.RootElement.GetString());
     }
+
+    [Fact]
+    public async Task IncludesProjectApiKeyTokenInRemoteConfigUrl()
+    {
+        var container = new TestContainer("fake-personal-api-key");
+
+        // Use the AddResponse method to verify the URL includes the token parameter
+        container.FakeHttpMessageHandler.AddResponse(
+            new Uri("https://us.i.posthog.com/api/projects/@current/feature_flags/test-flag/remote_config?token=fake-project-api-key"),
+            HttpMethod.Get,
+            responseBody: """{"test": "payload"}"""
+        );
+        var client = container.Activate<PostHogClient>();
+
+        var result = await client.GetRemoteConfigPayloadAsync("test-flag");
+
+        Assert.NotNull(result);
+        Assert.Equal("payload", result.RootElement.GetProperty("test").GetString());
+    }
 }

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -371,7 +371,7 @@ public class TheLoadFeatureFlagsAsyncMethod
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");
         // Add a handler that will throw OperationCanceledException
-        var uri = new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation/?send_cohorts");
+        var uri = new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation?token=fake-project-api-key&send_cohorts");
         container.FakeHttpMessageHandler.AddResponseException(uri, HttpMethod.Get, new OperationCanceledException());
         var client = container.Activate<PostHogClient>();
 
@@ -390,7 +390,7 @@ public class TheLoadFeatureFlagsAsyncMethod
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");
         // Add a handler that will throw OperationCanceledException
-        var uri = new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation/?send_cohorts");
+        var uri = new Uri("https://us.i.posthog.com/api/feature_flag/local_evaluation?token=fake-project-api-key&send_cohorts");
         container.FakeHttpMessageHandler.AddResponseException(uri, HttpMethod.Get, new OperationCanceledException());
         var client = container.Activate<PostHogClient>();
 


### PR DESCRIPTION
Fixes the `remote_config` endpoint to include the project API key as a token parameter for deterministic project routing, matching the implementation in other server-side SDKs.

- Add token parameter to remote_config URL construction
- Add test to verify the token parameter is included in requests
- Update test fixtures to match new URL format

Also added `FlagEvaluatesTo` comparison operator so library doesn't break when encountering a flag dependency.