### PR TITLE
Use `pull_request_target`

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -4,7 +4,7 @@
 name: Call Feature Flags Project Workflow
 
 on:
-    pull_request:
+    pull_request_target:
         types: [opened, ready_for_review, review_requested, synchronize, converted_to_draft, reopened]
 
 jobs:


### PR DESCRIPTION
This will work for PRs from external contributors. If they add our team as reviewers, it'll get added to our project board.