### PR TITLE
feat: Add optional distinctId to GroupIdentifyAsync

### DIFF
--- a/samples/HogTied.Web/Pages/Index.cshtml.cs
+++ b/samples/HogTied.Web/Pages/Index.cshtml.cs
@@ -177,6 +177,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
                 ["size"] = "large",
                 ["location"] = "San Francisco"
             },
+            distinctId: UserId,
             cancellationToken: HttpContext.RequestAborted);
 
         StatusMessage = result.Status == 1

--- a/samples/HogTied.Web/Pages/Index.cshtml.cs
+++ b/samples/HogTied.Web/Pages/Index.cshtml.cs
@@ -169,6 +169,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
 
         // Identify a group
         var result = await posthog.GroupIdentifyAsync(
+            UserId,
             Group.Type,
             Group.Key,
             Group.Name,
@@ -177,7 +178,6 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
                 ["size"] = "large",
                 ["location"] = "San Francisco"
             },
-            distinctId: UserId,
             cancellationToken: HttpContext.RequestAborted);
 
         StatusMessage = result.Status == 1

--- a/src/PostHog/Api/PostHogApiClientExtensions.cs
+++ b/src/PostHog/Api/PostHogApiClientExtensions.cs
@@ -52,10 +52,11 @@ internal static class PostHogApiClientExtensions
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? distinctId = null)
     {
         return await client.SendEventAsync(
-            distinctId: $"${type}_{key}",
+            distinctId: distinctId ?? $"${type}_{key}",
             eventName: "$groupidentify",
             properties: new Dictionary<string, object>
             {

--- a/src/PostHog/Examples.cs
+++ b/src/PostHog/Examples.cs
@@ -40,7 +40,8 @@ public static class Examples
             properties: new()
             {
                 ["employees"] = 11
-            }
+            },
+            distinctId: "user_distinct_id"
         );
 
         if (await posthog.GetFeatureFlagAsync(

--- a/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
+++ b/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
@@ -18,17 +18,19 @@ public static class GroupIdentifyAsyncExtensions
     /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
     /// <param name="name">The friendly name of the group.</param>
     /// <param name="properties">Additional information about the group.</param>
+    /// <param name="distinctId">Optional: The identifier you use for the current user. By default this is set to an identifer in the format "${group_type}_{group_key}"</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
     public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
         string type,
         StringOrValue<int> key,
         string name,
-        Dictionary<string, object>? properties)
+        Dictionary<string, object>? properties,
+        string? distinctId = null)
     {
         properties ??= new Dictionary<string, object>();
         properties["name"] = name;
-        return await NotNull(client).GroupIdentifyAsync(type, key, properties, CancellationToken.None);
+        return await NotNull(client).GroupIdentifyAsync(type, key, properties, CancellationToken.None, distinctId);
     }
 
     /// <summary>
@@ -41,6 +43,7 @@ public static class GroupIdentifyAsyncExtensions
     /// <param name="name">The friendly name of the group.</param>
     /// <param name="properties">Additional information about the group.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
+    /// <param name="distinctId">Optional: The identifier you use for the current user. By default this is set to an identifer in the format "${group_type}_{group_key}"</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
     public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
@@ -48,11 +51,12 @@ public static class GroupIdentifyAsyncExtensions
         StringOrValue<int> key,
         string name,
         Dictionary<string, object>? properties,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? distinctId = null)
     {
         properties ??= new Dictionary<string, object>();
         properties["name"] = name;
-        return await NotNull(client).GroupIdentifyAsync(type, key, properties, cancellationToken);
+        return await NotNull(client).GroupIdentifyAsync(type, key, properties, cancellationToken, distinctId);
     }
 
     /// <summary>
@@ -63,16 +67,19 @@ public static class GroupIdentifyAsyncExtensions
     /// <param name="type">Type of group (ex: 'company'). Limited to 5 per project</param>
     /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
     /// <param name="name">The friendly name of the group.</param>
+    /// <param name="distinctId">Optional: The identifier you use for the current user. By default this is set to an identifer in the format "${group_type}_{group_key}"</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
     public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
         string type,
         StringOrValue<int> key,
-        string name)
+        string name,
+        string? distinctId = null)
         => await client.GroupIdentifyAsync(
             type,
             key,
             name,
             properties: new Dictionary<string, object>(),
-            CancellationToken.None);
+            CancellationToken.None,
+            distinctId);
 }

--- a/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
+++ b/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
@@ -18,19 +18,41 @@ public static class GroupIdentifyAsyncExtensions
     /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
     /// <param name="name">The friendly name of the group.</param>
     /// <param name="properties">Additional information about the group.</param>
-    /// <param name="distinctId">Optional: The identifier you use for the current user. By default this is set to an identifer in the format "${group_type}_{group_key}"</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
     public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
         string type,
         StringOrValue<int> key,
         string name,
-        Dictionary<string, object>? properties,
-        string? distinctId = null)
+        Dictionary<string, object>? properties)
     {
         properties ??= new Dictionary<string, object>();
         properties["name"] = name;
-        return await NotNull(client).GroupIdentifyAsync(type, key, properties, CancellationToken.None, distinctId);
+        return await NotNull(client).GroupIdentifyAsync(type, key, properties, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
+    /// using my product in PostHog.
+    /// </summary>
+    /// <param name="client">The <see cref="IPostHogClient"/>.</param>
+    /// <param name="distinctId">The identifier you use for the current user.</param>
+    /// <param name="type">Type of group (ex: 'company'). Limited to 5 per project</param>
+    /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
+    /// <param name="name">The friendly name of the group.</param>
+    /// <param name="properties">Additional information about the group.</param>
+    /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
+    public static async Task<ApiResult> GroupIdentifyAsync(
+        this IPostHogClient client,
+        string distinctId,
+        string type,
+        StringOrValue<int> key,
+        string name,
+        Dictionary<string, object>? properties)
+    {
+        properties ??= new Dictionary<string, object>();
+        properties["name"] = name;
+        return await NotNull(client).GroupIdentifyAsync(distinctId, type, key, properties, CancellationToken.None);
     }
 
     /// <summary>
@@ -43,7 +65,6 @@ public static class GroupIdentifyAsyncExtensions
     /// <param name="name">The friendly name of the group.</param>
     /// <param name="properties">Additional information about the group.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
-    /// <param name="distinctId">Optional: The identifier you use for the current user. By default this is set to an identifer in the format "${group_type}_{group_key}"</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
     public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
@@ -51,12 +72,37 @@ public static class GroupIdentifyAsyncExtensions
         StringOrValue<int> key,
         string name,
         Dictionary<string, object>? properties,
-        CancellationToken cancellationToken,
-        string? distinctId = null)
+        CancellationToken cancellationToken)
     {
         properties ??= new Dictionary<string, object>();
         properties["name"] = name;
-        return await NotNull(client).GroupIdentifyAsync(type, key, properties, cancellationToken, distinctId);
+        return await NotNull(client).GroupIdentifyAsync(type, key, properties, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
+    /// using my product in PostHog.
+    /// </summary>
+    /// <param name="client">The <see cref="IPostHogClient"/>.</param>
+    /// <param name="distinctId">The identifier you use for the current user.</param>
+    /// <param name="type">Type of group (ex: 'company'). Limited to 5 per project</param>
+    /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
+    /// <param name="name">The friendly name of the group.</param>
+    /// <param name="properties">Additional information about the group.</param>
+    /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
+    /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
+    public static async Task<ApiResult> GroupIdentifyAsync(
+        this IPostHogClient client,
+        string distinctId,
+        string type,
+        StringOrValue<int> key,
+        string name,
+        Dictionary<string, object>? properties,
+        CancellationToken cancellationToken)
+    {
+        properties ??= new Dictionary<string, object>();
+        properties["name"] = name;
+        return await NotNull(client).GroupIdentifyAsync(distinctId, type, key, properties, cancellationToken);
     }
 
     /// <summary>
@@ -67,19 +113,38 @@ public static class GroupIdentifyAsyncExtensions
     /// <param name="type">Type of group (ex: 'company'). Limited to 5 per project</param>
     /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
     /// <param name="name">The friendly name of the group.</param>
-    /// <param name="distinctId">Optional: The identifier you use for the current user. By default this is set to an identifer in the format "${group_type}_{group_key}"</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
     public static async Task<ApiResult> GroupIdentifyAsync(
         this IPostHogClient client,
         string type,
         StringOrValue<int> key,
-        string name,
-        string? distinctId = null)
+        string name)
         => await client.GroupIdentifyAsync(
             type,
             key,
             name,
-            properties: new Dictionary<string, object>(),
-            CancellationToken.None,
-            distinctId);
+            properties: new Dictionary<string, object>());
+
+    /// <summary>
+    /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
+    /// using my product in PostHog.
+    /// </summary>
+    /// <param name="client">The <see cref="IPostHogClient"/>.</param>
+    /// <param name="distinctId">The identifier you use for the current user.</param>
+    /// <param name="type">Type of group (ex: 'company'). Limited to 5 per project</param>
+    /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
+    /// <param name="name">The friendly name of the group.</param>
+    /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
+    public static async Task<ApiResult> GroupIdentifyAsync(
+        this IPostHogClient client,
+        string distinctId,
+        string type,
+        StringOrValue<int> key,
+        string name)
+        => await client.GroupIdentifyAsync(
+            distinctId,
+            type,
+            key,
+            name,
+            properties: new Dictionary<string, object>());
 }

--- a/src/PostHog/IPostHogClient.cs
+++ b/src/PostHog/IPostHogClient.cs
@@ -61,14 +61,29 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
     /// <param name="properties">Additional information about the group.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
-    /// <param name="distinctId">Optional: The identifier you use for the current user. By default this is set to an identifer in the format "${group_type}_{group_key}"</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
     Task<ApiResult> GroupIdentifyAsync(
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
-        CancellationToken cancellationToken,
-        string? distinctId = null);
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
+    /// using my product in PostHog.
+    /// </summary>
+    /// <param name="distinctId">The identifier you use for the current user.</param>
+    /// <param name="type">Type of group (ex: 'company'). Limited to 5 per project</param>
+    /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
+    /// <param name="properties">Additional information about the group.</param>
+    /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
+    /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
+    Task<ApiResult> GroupIdentifyAsync(
+        string distinctId,
+        string type,
+        StringOrValue<int> key,
+        Dictionary<string, object>? properties,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Captures an event.

--- a/src/PostHog/IPostHogClient.cs
+++ b/src/PostHog/IPostHogClient.cs
@@ -61,12 +61,14 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="key">Unique identifier for that type of group (ex: 'id:5')</param>
     /// <param name="properties">Additional information about the group.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
+    /// <param name="distinctId">Optional: The identifier you use for the current user. By default this is set to an identifer in the format "${group_type}_{group_key}"</param>
     /// <returns>An <see cref="ApiResult"/> with the result of the operation.</returns>
     Task<ApiResult> GroupIdentifyAsync(
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken,
+        string? distinctId = null);
 
     /// <summary>
     /// Captures an event.

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -120,8 +120,16 @@ public sealed class PostHogClient : IPostHogClient
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
-        CancellationToken cancellationToken,
-        string? distinctId = null)
+        CancellationToken cancellationToken)
+    => _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<ApiResult> GroupIdentifyAsync(
+        string distinctId,
+        string type,
+        StringOrValue<int> key,
+        Dictionary<string, object>? properties,
+        CancellationToken cancellationToken)
     => _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken, distinctId);
 
     /// <inheritdoc/>

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -120,8 +120,9 @@ public sealed class PostHogClient : IPostHogClient
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
-        CancellationToken cancellationToken)
-    => _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken);
+        CancellationToken cancellationToken = default,
+        string? distinctId = null)
+    => _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken, distinctId);
 
     /// <inheritdoc/>
     public bool Capture(

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -120,7 +120,7 @@ public sealed class PostHogClient : IPostHogClient
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
-        CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken,
         string? distinctId = null)
     => _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken, distinctId);
 

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -169,7 +169,7 @@ public class TheIdentifyGroupAsyncMethod
         var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = await client.GroupIdentifyAsync(type: "organization", key: "id:5", "PostHog", distinctId: "custom_distinct_id");
+        var result = await client.GroupIdentifyAsync("custom_distinct_id", type: "organization", key: "id:5", "PostHog");
 
         Assert.Equal(1, result.Status);
         var received = requestHandler.GetReceivedRequestBody(indented: true);

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -160,6 +160,41 @@ public class TheIdentifyGroupAsyncMethod
                        }
                        """, received);
     }
+
+    [Fact] // Ported from PostHog/posthog-python test_basic_group_identify
+    public async Task SendsCorrectPayloadWithUserProvidedDistinctId()
+    {
+        var container = new TestContainer();
+        container.FakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 21, 19, 08, 23, TimeSpan.Zero));
+        var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
+        var client = container.Activate<PostHogClient>();
+
+        var result = await client.GroupIdentifyAsync(type: "organization", key: "id:5", "PostHog", distinctId: "custom_distinct_id");
+
+        Assert.Equal(1, result.Status);
+        var received = requestHandler.GetReceivedRequestBody(indented: true);
+        Assert.Equal($$"""
+                       {
+                         "event": "$groupidentify",
+                         "distinct_id": "custom_distinct_id",
+                         "properties": {
+                           "$group_type": "organization",
+                           "$group_key": "id:5",
+                           "$group_set": {
+                             "name": "PostHog"
+                           },
+                           "$lib": "posthog-dotnet",
+                           "$lib_version": "{{VersionConstants.Version}}",
+                           "$os": "{{RuntimeInformation.OSDescription}}",
+                           "$framework": "{{RuntimeInformation.FrameworkDescription}}",
+                           "$arch": "{{RuntimeInformation.ProcessArchitecture}}",
+                           "$geoip_disable": true
+                         },
+                         "api_key": "fake-project-api-key",
+                         "timestamp": "2024-01-21T19:08:23\u002B00:00"
+                       }
+                       """, received);
+    }
 }
 
 public class TheCaptureMethod


### PR DESCRIPTION
Currently we set the `distinctId` on `GroupIdentifyAsync` calls using our own generated identifier based on the format `${group_type}_{group_key}`. While this works, it's out of keeping with other SDKs where generally we also allow users to set their own `distinctId` (e.g [Python](https://github.com/PostHog/posthog-python/blob/337f7da7c585a8fa04da8945c1fe6beccb05c6a5/posthog/client.py#L343-L346)). While it's not a major issue as groups are technically used for aggregating events (not persons) and therefore the `$groupidentify` event can just be used to announce the group to PostHog and add/update properties, i.e. not necessarily needing to be linked to a specific person via `distinctId`. That said - it's still a bit of a jarring experience and it would bring the .NET package in line with other SDKs if we allowed it to be set.

I've made `distinctId` optional to avoid making a breaking change.

User request context: https://posthoghelp.zendesk.com/agent/tickets/37401. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41560)

Tested the changes locally in the sample app and they seem to work as expected ([event](https://us.posthog.com/project/35787/events/019970f1-7fef-7b20-a6cb-c76c5627b9b3/2025-09-22T12%3A21%3A39.024000%2B02%3A00)).