### PR TITLE
fix: don't sort condition sets with variant overrides to top

### DIFF
--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -264,11 +264,7 @@ internal sealed class LocalEvaluator
         var isInconclusive = false;
         var flagVariants = filters?.Multivariate?.Variants ?? [];
 
-        // Stable sort conditions with variant overrides to the top. This ensures that if overrides are present,
-        // they are evaluated first, and the variant override is applied to the first matching condition.
-        var sortedConditions = flagConditions.OrderBy(c => c.Variant is null);
-
-        foreach (var condition in sortedConditions)
+        foreach (var condition in flagConditions)
         {
             try
             {

--- a/tests/UnitTests.AspNetCore/FeatureManagement/PostHogVariantFeatureManagerTests.cs
+++ b/tests/UnitTests.AspNetCore/FeatureManagement/PostHogVariantFeatureManagerTests.cs
@@ -196,14 +196,14 @@ public class TheGetVariantAsyncMethod
             PersonProperties = new() { ["email"] = "test@posthog.com" }
         };
         Assert.Equal(
-            "second-variant",
+            "third-variant",
             (await featureManager.GetVariantAsync("beta-feature")).Name);
         contextProvider.Context = new PostHogFeatureFlagContext
         {
             DistinctId = "example_id",
         };
         Assert.Equal(
-            "third-variant",
+            "second-variant",
             (await featureManager.GetVariantAsync("beta-feature")).Name);
         contextProvider.Context = new PostHogFeatureFlagContext
         {


### PR DESCRIPTION
Feature flag condition sets with variant overrides were sorted to the top which was confusing and not how customers expected them to work.

https://github.com/PostHog/posthog/issues/37854

Remove sorting condition sets with variant overrides to the top to match server logic.