### PR TITLE
Fix feature flag cache key to include person properties and groups

### DIFF
--- a/samples/HogTied.Web/Pages/Index.cshtml
+++ b/samples/HogTied.Web/Pages/Index.cshtml
@@ -62,6 +62,51 @@
                 </div>
             }
 
+            @if (Model.CacheDemo is not null && Model.UserId is not null) {
+                <div class="alert alert-success mt-3" role="alert">
+                    <h5 class="alert-heading">🚀 Request-Level Cache Demo</h5>
+                    <p>
+                        To demonstrate that feature flags are cached per HTTP request, we checked the
+                        <code>simple-flag</code> twice during this page load:
+                    </p>
+                    <table class="table table-sm table-bordered bg-white mt-2 mb-2">
+                        <thead>
+                            <tr>
+                                <th>Check</th>
+                                <th>Duration</th>
+                                <th>Result</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><strong>First Call</strong> (fetches from API)</td>
+                                <td><code>@Model.CacheDemo.FirstCallMs.ToString("F3") ms</code></td>
+                                <td><code>@Model.CacheDemo.FirstResult</code></td>
+                            </tr>
+                            <tr class="table-success">
+                                <td><strong>Second Call</strong> (cached)</td>
+                                <td><code>@Model.CacheDemo.SecondCallMs.ToString("F3") ms</code></td>
+                                <td><code>@Model.CacheDemo.SecondResult</code></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p class="mb-0">
+                        <strong>Speed Improvement:</strong>
+                        The second call was
+                        @{
+                            var improvement = Model.CacheDemo.FirstCallMs / Model.CacheDemo.SecondCallMs;
+                        }
+                        <span class="badge bg-success">@improvement.ToString("F0")x faster</span>
+                        because it used the cached result from HttpContext.Items!
+                    </p>
+                    <p class="mb-0 mt-2">
+                        <small class="text-muted">
+                            💡 Check your console logs to see the cache hit/miss events (requires Trace logging enabled).
+                        </small>
+                    </p>
+                </div>
+            }
+
             <form method="get">
                 <div class="form-group mb-2">
                     <label asp-for="ProjectSize">Override Project Size (for evaluating feature flags). <code>default: Large</code></label>

--- a/samples/HogTied.Web/appsettings.Development.json
+++ b/samples/HogTied.Web/appsettings.Development.json
@@ -4,7 +4,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
-      "PostHog": "Information"
+      "PostHog": "Information",
+      "PostHog.Cache.HttpContextFeatureFlagCache": "Trace"
     }
   },
   "PostHogLocal" : {

--- a/src/PostHog/Features/FallbackFeatureFlagCache.cs
+++ b/src/PostHog/Features/FallbackFeatureFlagCache.cs
@@ -17,15 +17,17 @@ public class FallbackFeatureFlagCache(IFeatureFlagCache primary, IFeatureFlagCac
     /// <inherititdoc/>
     public override async Task<FlagsResult> GetAndCacheFlagsAsync(
         string distinctId,
+        IReadOnlyDictionary<string, object?>? personProperties,
+        GroupCollection? groups,
         Func<string, CancellationToken, Task<FlagsResult>> fetcher,
         CancellationToken cancellationToken)
     {
-        var flags = await _primary.GetAndCacheFlagsAsync(distinctId, fetcher, cancellationToken);
+        var flags = await _primary.GetAndCacheFlagsAsync(distinctId, personProperties, groups, fetcher, cancellationToken);
         if (flags.Flags.Count > 0)
         {
             return flags;
         }
-        flags = await _fallback.GetAndCacheFlagsAsync(distinctId, fetcher, cancellationToken);
+        flags = await _fallback.GetAndCacheFlagsAsync(distinctId, personProperties, groups, fetcher, cancellationToken);
         if (flags.Flags.Count > 0)
         {
             return flags;

--- a/src/PostHog/Features/FeatureFlagCacheBase.cs
+++ b/src/PostHog/Features/FeatureFlagCacheBase.cs
@@ -17,12 +17,23 @@ public abstract class FeatureFlagCacheBase : IFeatureFlagCache
             return new FlagsResult { Flags = flags };
         };
 
-        var results = await GetAndCacheFlagsAsync(distinctId, resultsFetcher, cancellationToken);
+        var results = await GetAndCacheFlagsAsync(distinctId, null, null, resultsFetcher, cancellationToken);
         return results.Flags;
+    }
+
+    public async Task<FlagsResult> GetAndCacheFlagsAsync(
+        string distinctId,
+        Func<string, CancellationToken, Task<FlagsResult>> fetcher,
+        CancellationToken cancellationToken)
+    {
+        // Call the new method with null properties for backward compatibility
+        return await GetAndCacheFlagsAsync(distinctId, null, null, fetcher, cancellationToken);
     }
 
     public abstract Task<FlagsResult> GetAndCacheFlagsAsync(
         string distinctId,
+        IReadOnlyDictionary<string, object?>? personProperties,
+        GroupCollection? groups,
         Func<string, CancellationToken, Task<FlagsResult>> fetcher,
         CancellationToken cancellationToken);
 }

--- a/src/PostHog/Features/FeatureFlagCacheKey.cs
+++ b/src/PostHog/Features/FeatureFlagCacheKey.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using System.Text.Json;
+using PostHog.Json;
+using PostHog.Library;
+
+namespace PostHog.Features;
+
+/// <summary>
+/// Generates stable cache keys for feature flag results based on distinct ID, person properties, and groups.
+/// </summary>
+internal static class FeatureFlagCacheKey
+{
+    /// <summary>
+    /// Generates a stable cache key from the provided parameters.
+    /// The same inputs will always produce the same key, and different inputs will produce different keys.
+    /// </summary>
+    /// <param name="distinctId">The distinct ID of the user.</param>
+    /// <param name="personProperties">Optional person properties that affect feature flag evaluation.</param>
+    /// <param name="groups">Optional groups with their properties that affect feature flag evaluation.</param>
+    /// <returns>A stable string cache key.</returns>
+    public static string Generate(
+        string distinctId,
+        IReadOnlyDictionary<string, object?>? personProperties,
+        GroupCollection? groups)
+    {
+        Ensure.NotNull(distinctId);
+
+        var builder = new StringBuilder();
+        builder.Append(distinctId);
+
+        if (personProperties is { Count: > 0 })
+        {
+            builder.Append('|');
+            builder.Append("p:");
+            builder.Append(SerializeDictionary(personProperties));
+        }
+
+        if (groups is { Count: > 0 })
+        {
+            builder.Append('|');
+            builder.Append("g:");
+
+            // Sort groups by type for stability
+            var sortedGroups = groups.OrderBy(g => g.GroupType).ToArray();
+
+            for (var i = 0; i < sortedGroups.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(',');
+                }
+
+                var group = sortedGroups[i];
+                builder.Append(group.GroupType);
+                builder.Append('=');
+                builder.Append(group.GroupKey);
+
+                if (group.Properties is { Count: > 0 })
+                {
+                    builder.Append('[');
+                    builder.Append(SerializeDictionary(group.Properties));
+                    builder.Append(']');
+                }
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    static string SerializeDictionary(IReadOnlyDictionary<string, object?> dictionary)
+    {
+        // Sort keys for stable serialization
+        var sortedPairs = dictionary
+            .OrderBy(kvp => kvp.Key)
+            .ToArray();
+
+        // Use JSON serialization for complex values
+        return JsonSerializer.Serialize(sortedPairs, JsonSerializerHelper.Options);
+    }
+}

--- a/src/PostHog/Features/MemoryFeatureFlagCache.cs
+++ b/src/PostHog/Features/MemoryFeatureFlagCache.cs
@@ -23,11 +23,14 @@ public sealed class MemoryFeatureFlagCache(TimeProvider timeProvider, int sizeLi
     /// <inherititdoc/>
     public override async Task<FlagsResult> GetAndCacheFlagsAsync(
         string distinctId,
+        IReadOnlyDictionary<string, object?>? personProperties,
+        GroupCollection? groups,
         Func<string, CancellationToken, Task<FlagsResult>> fetcher,
         CancellationToken cancellationToken)
     {
+        var cacheKey = FeatureFlagCacheKey.Generate(distinctId, personProperties, groups);
         var flags = await _cache.GetOrCreateAsync(
-            distinctId,
+            cacheKey,
             async cacheEntry =>
             {
                 cacheEntry.SetSize(1);

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -223,6 +223,8 @@ public sealed class PostHogClient : IPostHogClient
     {
         var result = await featureFlagCache.GetAndCacheFlagsAsync(
             distinctId,
+            personProperties: null,
+            groups: groups,
             (userId, ctx) => DecideAsync(
                 userId,
                 options: new AllFeatureFlagsOptions
@@ -529,6 +531,8 @@ public sealed class PostHogClient : IPostHogClient
     {
         var result = await cache.GetAndCacheFlagsAsync(
             distinctId,
+            personProperties: options?.PersonProperties,
+            groups: options?.Groups,
             fetcher: FetchDecideAsync,
             cancellationToken: cancellationToken);
 

--- a/tests/UnitTests/Features/FeatureFlagCacheKeyTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagCacheKeyTests.cs
@@ -1,0 +1,472 @@
+using PostHog;
+using PostHog.Features;
+
+namespace FeatureFlagCacheKeyTests;
+
+public class TheGenerateMethod
+{
+    [Fact]
+    public void GeneratesStableKeyForDistinctIdOnly()
+    {
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, null);
+
+        Assert.Equal(key1, key2);
+        Assert.Equal("user123", key1);
+    }
+
+    [Fact]
+    public void GeneratesDifferentKeysForDifferentDistinctIds()
+    {
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, null);
+        var key2 = FeatureFlagCacheKey.Generate("user456", null, null);
+
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesStableKeyWithPersonProperties()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com",
+            ["age"] = 25
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", properties, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", properties, null);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesStableKeyRegardlessOfPropertyOrder()
+    {
+        var properties1 = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com",
+            ["age"] = 25,
+            ["country"] = "US"
+        };
+
+        var properties2 = new Dictionary<string, object?>
+        {
+            ["country"] = "US",
+            ["email"] = "test@example.com",
+            ["age"] = 25
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", properties1, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", properties2, null);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesDifferentKeysForDifferentPersonProperties()
+    {
+        var properties1 = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com",
+            ["age"] = 25
+        };
+
+        var properties2 = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com",
+            ["age"] = 30
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", properties1, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", properties2, null);
+
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesDifferentKeysWhenPersonPropertiesPresent()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com"
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", properties, null);
+
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesStableKeyWithGroups()
+    {
+        var groups = new GroupCollection
+        {
+            { "company", "acme" },
+            { "project", "123" }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesStableKeyWithGroupsRegardlessOfOrder()
+    {
+        var groups1 = new GroupCollection
+        {
+            { "company", "acme" },
+            { "project", "123" }
+        };
+
+        var groups2 = new GroupCollection
+        {
+            { "project", "123" },
+            { "company", "acme" }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups1);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups2);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesDifferentKeysForDifferentGroups()
+    {
+        var groups1 = new GroupCollection
+        {
+            { "company", "acme" }
+        };
+
+        var groups2 = new GroupCollection
+        {
+            { "company", "initech" }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups1);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups2);
+
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesStableKeyWithGroupProperties()
+    {
+        var groups = new GroupCollection
+        {
+            new Group("company", "acme")
+            {
+                ["tier"] = "enterprise",
+                ["region"] = "us-west"
+            }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesStableKeyWithGroupPropertiesRegardlessOfOrder()
+    {
+        var groups1 = new GroupCollection
+        {
+            new Group("company", "acme")
+            {
+                ["tier"] = "enterprise",
+                ["region"] = "us-west"
+            }
+        };
+
+        var groups2 = new GroupCollection
+        {
+            new Group("company", "acme")
+            {
+                ["region"] = "us-west",
+                ["tier"] = "enterprise"
+            }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups1);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups2);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesDifferentKeysForDifferentGroupProperties()
+    {
+        var groups1 = new GroupCollection
+        {
+            new Group("company", "acme")
+            {
+                ["tier"] = "enterprise"
+            }
+        };
+
+        var groups2 = new GroupCollection
+        {
+            new Group("company", "acme")
+            {
+                ["tier"] = "starter"
+            }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups1);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups2);
+
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesDifferentKeysWithAndWithoutGroupProperties()
+    {
+        var groups1 = new GroupCollection
+        {
+            { "company", "acme" }
+        };
+
+        var groups2 = new GroupCollection
+        {
+            new Group("company", "acme")
+            {
+                ["tier"] = "enterprise"
+            }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups1);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups2);
+
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesStableKeyWithAllParameters()
+    {
+        var personProperties = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com",
+            ["age"] = 25
+        };
+
+        var groups = new GroupCollection
+        {
+            new Group("company", "acme")
+            {
+                ["tier"] = "enterprise"
+            },
+            { "project", "123" }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", personProperties, groups);
+        var key2 = FeatureFlagCacheKey.Generate("user123", personProperties, groups);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void HandlesNullValuesInProperties()
+    {
+        var properties1 = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com",
+            ["middle_name"] = null
+        };
+
+        var properties2 = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com",
+            ["middle_name"] = null
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", properties1, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", properties2, null);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void HandlesComplexNestedProperties()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["metadata"] = new Dictionary<string, object>
+            {
+                ["source"] = "mobile",
+                ["version"] = 2
+            }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", properties, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", properties, null);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void TreatsEmptyPropertiesDictionarySameAsNull()
+    {
+        var emptyProps = new Dictionary<string, object?>();
+        var key1 = FeatureFlagCacheKey.Generate("user123", emptyProps, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, null);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void TreatsEmptyGroupCollectionSameAsNull()
+    {
+        var emptyGroups = new GroupCollection();
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, emptyGroups);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, null);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesStableKeyWithMultipleGroupsEachWithProperties()
+    {
+        var groups = new GroupCollection
+        {
+            new Group("company", "acme")
+            {
+                ["tier"] = "enterprise",
+                ["industry"] = "tech"
+            },
+            new Group("team", "engineering")
+            {
+                ["size"] = 50,
+                ["location"] = "remote"
+            }
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void HandlesDiversePropertyTypes()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["string"] = "value",
+            ["int"] = 42,
+            ["double"] = 98.5,
+            ["bool"] = true,
+            ["array"] = new[] { "vip", "beta" },
+            ["null"] = null
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", properties, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", properties, null);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void HandlesSpecialCharactersInDistinctId()
+    {
+        var key1 = FeatureFlagCacheKey.Generate("user@123!#$%^&*()", null, null);
+        var key2 = FeatureFlagCacheKey.Generate("user@123!#$%^&*()", null, null);
+
+        Assert.Equal(key1, key2);
+        Assert.Contains("user@123!#$%^&*()", key1, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HandlesEmptyStringDistinctId()
+    {
+        var key1 = FeatureFlagCacheKey.Generate("", null, null);
+        var key2 = FeatureFlagCacheKey.Generate("", null, null);
+
+        Assert.Equal(key1, key2);
+        Assert.Equal("", key1);
+    }
+
+    [Fact]
+    public void HandlesWhitespaceDistinctId()
+    {
+        var key1 = FeatureFlagCacheKey.Generate("   ", null, null);
+        var key2 = FeatureFlagCacheKey.Generate("   ", null, null);
+
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void GeneratesDifferentKeysForDifferentGroupTypesWithSameKey()
+    {
+        var groups1 = new GroupCollection { { "company", "123" } };
+        var groups2 = new GroupCollection { { "project", "123" } };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups1);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups2);
+
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void PropertyNamesAreCaseSensitive()
+    {
+        var props1 = new Dictionary<string, object?> { ["Email"] = "test@example.com" };
+        var props2 = new Dictionary<string, object?> { ["email"] = "test@example.com" };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", props1, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", props2, null);
+
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void HandlesLargeNumberOfProperties()
+    {
+        var properties = new Dictionary<string, object?>();
+        for (int i = 0; i < 100; i++)
+        {
+            properties[$"prop{i}"] = $"value{i}";
+        }
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", properties, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", properties, null);
+
+        Assert.Equal(key1, key2);
+        Assert.NotEmpty(key1);
+    }
+
+    [Fact]
+    public void HandlesLargeNumberOfGroups()
+    {
+        var groups = new GroupCollection();
+        for (int i = 0; i < 20; i++)
+        {
+            groups.Add($"group{i}", $"key{i}");
+        }
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", null, groups);
+        var key2 = FeatureFlagCacheKey.Generate("user123", null, groups);
+
+        Assert.Equal(key1, key2);
+        Assert.NotEmpty(key1);
+    }
+
+    [Fact]
+    public void GeneratesDifferentKeysForDifferentPropertyCounts()
+    {
+        var props1 = new Dictionary<string, object?> { ["email"] = "test@example.com" };
+        var props2 = new Dictionary<string, object?>
+        {
+            ["email"] = "test@example.com",
+            ["name"] = "Test User"
+        };
+
+        var key1 = FeatureFlagCacheKey.Generate("user123", props1, null);
+        var key2 = FeatureFlagCacheKey.Generate("user123", props2, null);
+
+        Assert.NotEqual(key1, key2);
+    }
+}

--- a/tests/UnitTests/Features/MemoryFeatureFlagCacheTests.cs
+++ b/tests/UnitTests/Features/MemoryFeatureFlagCacheTests.cs
@@ -1,4 +1,5 @@
 using PostHog;
+using PostHog.Api;
 using PostHog.Features;
 
 namespace InMemoryFeatureFlagCacheTests;
@@ -40,5 +41,203 @@ public class TheGetAndCacheFeatureFlagsAsyncMethod
             _ => Task.FromResult<IReadOnlyDictionary<string, FeatureFlag>>(expectedFlags), CancellationToken.None);
 
         Assert.Equal(expectedFlags, result);
+    }
+}
+
+public class TheGetAndCacheFlagsAsyncMethodWithPropertiesAndGroups
+{
+    [Fact]
+    public async Task ReturnsCachedFlagsWhenAllParametersMatch()
+    {
+        var timeProvider = TimeProvider.System;
+        var cache = new MemoryFeatureFlagCache(timeProvider, 100, 0.1);
+        var distinctId = "test-user";
+        var personProperties = new Dictionary<string, object?> { ["email"] = "test@example.com" };
+        var groups = new GroupCollection { { "company", "acme" } };
+
+        var expectedFlags = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+            }
+        };
+
+        var fetchCount = 0;
+        var fetcher = (string id, CancellationToken ct) =>
+        {
+            fetchCount++;
+            return Task.FromResult(expectedFlags);
+        };
+
+        // First call should fetch
+        await cache.GetAndCacheFlagsAsync(distinctId, personProperties, groups, fetcher, CancellationToken.None);
+        Assert.Equal(1, fetchCount);
+
+        // Second call with same parameters should use cache
+        var result = await cache.GetAndCacheFlagsAsync(distinctId, personProperties, groups, fetcher, CancellationToken.None);
+        Assert.Equal(1, fetchCount); // Should not fetch again
+        Assert.Equal(expectedFlags.Flags, result.Flags);
+    }
+
+    [Fact]
+    public async Task FetchesNewFlagsWhenPersonPropertiesDiffer()
+    {
+        var timeProvider = TimeProvider.System;
+        var cache = new MemoryFeatureFlagCache(timeProvider, 100, 0.1);
+        var distinctId = "test-user";
+        var personProperties1 = new Dictionary<string, object?> { ["email"] = "test1@example.com" };
+        var personProperties2 = new Dictionary<string, object?> { ["email"] = "test2@example.com" };
+
+        var flags1 = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+            }
+        };
+
+        var flags2 = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = false } }
+            }
+        };
+
+        var fetchCount = 0;
+        var fetcher = (string id, CancellationToken ct) =>
+        {
+            fetchCount++;
+            return Task.FromResult(fetchCount == 1 ? flags1 : flags2);
+        };
+
+        var result1 = await cache.GetAndCacheFlagsAsync(distinctId, personProperties1, null, fetcher, CancellationToken.None);
+        var result2 = await cache.GetAndCacheFlagsAsync(distinctId, personProperties2, null, fetcher, CancellationToken.None);
+
+        Assert.Equal(2, fetchCount); // Should fetch twice because properties differ
+        Assert.NotEqual(result1.Flags, result2.Flags);
+    }
+
+    [Fact]
+    public async Task FetchesNewFlagsWhenGroupsDiffer()
+    {
+        var timeProvider = TimeProvider.System;
+        var cache = new MemoryFeatureFlagCache(timeProvider, 100, 0.1);
+        var distinctId = "test-user";
+        var groups1 = new GroupCollection { { "company", "acme" } };
+        var groups2 = new GroupCollection { { "company", "initech" } };
+
+        var flags1 = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+            }
+        };
+
+        var flags2 = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = false } }
+            }
+        };
+
+        var fetchCount = 0;
+        var fetcher = (string id, CancellationToken ct) =>
+        {
+            fetchCount++;
+            return Task.FromResult(fetchCount == 1 ? flags1 : flags2);
+        };
+
+        var result1 = await cache.GetAndCacheFlagsAsync(distinctId, null, groups1, fetcher, CancellationToken.None);
+        var result2 = await cache.GetAndCacheFlagsAsync(distinctId, null, groups2, fetcher, CancellationToken.None);
+
+        Assert.Equal(2, fetchCount); // Should fetch twice because groups differ
+        Assert.NotEqual(result1.Flags, result2.Flags);
+    }
+
+    [Fact]
+    public async Task FetchesNewFlagsWhenGroupPropertiesDiffer()
+    {
+        var timeProvider = TimeProvider.System;
+        var cache = new MemoryFeatureFlagCache(timeProvider, 100, 0.1);
+        var distinctId = "test-user";
+        var groups1 = new GroupCollection
+        {
+            new Group("company", "acme") { ["tier"] = "enterprise" }
+        };
+        var groups2 = new GroupCollection
+        {
+            new Group("company", "acme") { ["tier"] = "starter" }
+        };
+
+        var flags1 = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+            }
+        };
+
+        var flags2 = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = false } }
+            }
+        };
+
+        var fetchCount = 0;
+        var fetcher = (string id, CancellationToken ct) =>
+        {
+            fetchCount++;
+            return Task.FromResult(fetchCount == 1 ? flags1 : flags2);
+        };
+
+        var result1 = await cache.GetAndCacheFlagsAsync(distinctId, null, groups1, fetcher, CancellationToken.None);
+        var result2 = await cache.GetAndCacheFlagsAsync(distinctId, null, groups2, fetcher, CancellationToken.None);
+
+        Assert.Equal(2, fetchCount); // Should fetch twice because group properties differ
+        Assert.NotEqual(result1.Flags, result2.Flags);
+    }
+
+    [Fact]
+    public async Task FetchesNewFlagsWhenNullVsNonNullProperties()
+    {
+        var timeProvider = TimeProvider.System;
+        var cache = new MemoryFeatureFlagCache(timeProvider, 100, 0.1);
+        var distinctId = "test-user";
+        var personProperties = new Dictionary<string, object?> { ["email"] = "test@example.com" };
+
+        var flags1 = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = true } }
+            }
+        };
+
+        var flags2 = new FlagsResult
+        {
+            Flags = new Dictionary<string, FeatureFlag>
+            {
+                { "flag1", new FeatureFlag { Key = "flag1", IsEnabled = false } }
+            }
+        };
+
+        var fetchCount = 0;
+        var fetcher = (string id, CancellationToken ct) =>
+        {
+            fetchCount++;
+            return Task.FromResult(fetchCount == 1 ? flags1 : flags2);
+        };
+
+        var result1 = await cache.GetAndCacheFlagsAsync(distinctId, null, null, fetcher, CancellationToken.None);
+        var result2 = await cache.GetAndCacheFlagsAsync(distinctId, personProperties, null, fetcher, CancellationToken.None);
+
+        Assert.Equal(2, fetchCount); // Should fetch twice because one has properties and one doesn't
+        Assert.NotEqual(result1.Flags, result2.Flags);
     }
 }


### PR DESCRIPTION
The cache key previously only used distinctId, which caused incorrect cached results when the same user had different person properties or belonged to different groups. The `/flags` endpoint can return different feature flags based on these parameters.

Changes:
- Add `FeatureFlagCacheKey` class to generate stable cache keys from distinctId, person properties, and groups
- Add new `IFeatureFlagCache.GetAndCacheFlagsAsync` overload with personProperties and groups parameters
- Mark old `GetAndCacheFlagsAsync` method as obsolete
- Update all built-in cache implementations to use new cache key
- Update `PostHogClient` to pass properties and groups to cache
- Add comprehensive unit and integration tests

The changes are backward compatible. Custom `IFeatureFlagCache` implementations will continue to work with a safe default behavior (no caching) until updated to override the new method.

Fixes #75