### PR TITLE
chore: Quote shell vars

### DIFF
--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -10,6 +10,6 @@ fatal() {
 set_source_and_root_dir() {
     { set +x; } 2>/dev/null
     source_dir="$( cd -P "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
-    root_dir=$(cd $source_dir && cd ../ && pwd)
-    cd $root_dir
+    root_dir=$(cd "$source_dir" && cd ../ && pwd)
+    cd "$root_dir"
 }


### PR DESCRIPTION
Quote `$source_dir` and `$root_dir` to prevent word splitting and globbing issues with paths containing spaces.