### PR TITLE
fix: Capture doesn't send flags when sendFeatureFlags=false

### DIFF
--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -174,8 +174,7 @@ public sealed class PostHogClient : IPostHogClient
 
         Task<CapturedEvent> BatchTask(CapturedEventBatchContext context)
         {
-            var shouldEnrich = sendFeatureFlags || (_featureFlagsLoader.IsLoaded && eventName != "$feature_flag_called");
-            if (!shouldEnrich)
+            if (!sendFeatureFlags)
             {
                 return Task.FromResult(capturedEvent);
             }

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -742,6 +742,125 @@ public class TheCaptureMethod
                      }
                      """, received);
     }
+
+    [Fact]
+    public async Task CaptureWithSendFeatureFlagsFalseDoesNotAddFeatureFlagsEvenWhenLocalEvaluationEnabled()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        container.FakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 21, 19, 08, 23, TimeSpan.Zero));
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {
+                "flags": [
+                    {
+                        "id": 1,
+                        "name": "Local Flag",
+                        "key": "local-flag",
+                        "active": true,
+                        "rollout_percentage": 100,
+                        "filters": {
+                            "groups": [
+                                {
+                                    "properties": [],
+                                    "rollout_percentage": 100
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+            """
+        );
+
+        var batchHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        // Preload local flags to ensure they are available
+        await client.GetAllFeatureFlagsAsync("preload-user", options: null, CancellationToken.None);
+
+        client.Capture("test-distinct-id", "test-event", sendFeatureFlags: false);
+        await client.FlushAsync();
+
+        var received = batchHandler.GetReceivedRequestBody(indented: true);
+        Assert.Equal($$"""
+                     {
+                       "api_key": "fake-project-api-key",
+                       "historical_migrations": false,
+                       "batch": [
+                         {
+                           "event": "test-event",
+                           "properties": {
+                             "distinct_id": "test-distinct-id",
+                             "$lib": "posthog-dotnet",
+                             "$lib_version": "{{VersionConstants.Version}}",
+                             "$geoip_disable": true
+                           },
+                           "timestamp": "2024-01-21T19:08:23\u002B00:00"
+                         }
+                       ]
+                     }
+                     """, received);
+    }
+
+    [Fact]
+    public async Task CaptureDefaultsToNotSendingFeatureFlagsEvenWhenLocalEvaluationEnabled()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        container.FakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 21, 19, 08, 23, TimeSpan.Zero));
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {
+                "flags": [
+                    {
+                        "id": 1,
+                        "name": "Local Flag",
+                        "key": "local-flag",
+                        "active": true,
+                        "rollout_percentage": 100,
+                        "filters": {
+                            "groups": [
+                                {
+                                    "properties": [],
+                                    "rollout_percentage": 100
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+            """
+        );
+
+        var batchHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        // Preload local flags to ensure they are available
+        await client.GetAllFeatureFlagsAsync("preload-user", options: null, CancellationToken.None);
+
+        // Capture event WITHOUT specifying sendFeatureFlags (should default to false)
+        client.Capture("test-distinct-id", "test-event");
+        await client.FlushAsync();
+
+        var received = batchHandler.GetReceivedRequestBody(indented: true);
+        Assert.Equal($$"""
+                     {
+                       "api_key": "fake-project-api-key",
+                       "historical_migrations": false,
+                       "batch": [
+                         {
+                           "event": "test-event",
+                           "properties": {
+                             "distinct_id": "test-distinct-id",
+                             "$lib": "posthog-dotnet",
+                             "$lib_version": "{{VersionConstants.Version}}",
+                             "$geoip_disable": true
+                           },
+                           "timestamp": "2024-01-21T19:08:23\u002B00:00"
+                         }
+                       ]
+                     }
+                     """, received);
+    }
 }
 
 public class TheCaptureExceptionMethod


### PR DESCRIPTION
According to the documentation
https://github.com/PostHog/posthog-dotnet/blob/8648856ebd8dc3cb589d361f3fc0d932aceb3291/src/PostHog/Capture/CaptureExtensions.cs#L36

When `sendFeatureFlags` is `true`, it should be expected that flags properties are appended to the event. When `false`, it should be expected that the opposite occurs - flags properties _are not_ appended.

Related to https://github.com/PostHog/posthog/issues/31425