### PR TITLE
docs: move release guide to RELEASING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,7 @@ The test projects target both `net8.0` and `netcoreapp3.1`. While .NET Core 3.1 
 
 This testing approach ensures broad compatibility without requiring users to install legacy runtimes in production.
 
-## Publishing Releases
-
-Releases are driven by PR labels. When a PR with the right labels is merged to `main`, a GitHub Actions workflow handles version bumping, tagging, creating a GitHub Release (with auto-generated notes), and publishing to NuGet.
-
-### Release Process
-
-1. Add the `release` label and exactly one of `bump-patch`, `bump-minor`, or `bump-major` to your PR
-2. Merge the PR to `main`
-3. Approve the release in the GitHub Environment gate (the workflow pauses for maintainer approval)
-4. The workflow bumps the version in `Directory.Build.props`, commits to `main`, creates a git tag, and creates a GitHub Release
-5. The GitHub Release triggers the [`main.yaml`](.github/workflows/main.yaml) workflow, which builds and publishes the packages to NuGet
+For release instructions, see [RELEASING.md](RELEASING.md).
 
 ## Installation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,11 @@
+# Releasing
+
+Releases are driven by PR labels. When a PR with the right labels is merged to `main`, a GitHub Actions workflow handles version bumping, tagging, creating a GitHub Release (with auto-generated notes), and publishing to NuGet.
+
+## Release Process
+
+1. Add the `release` label and exactly one of `bump-patch`, `bump-minor`, or `bump-major` to your PR
+2. Merge the PR to `main`
+3. Approve the release in the GitHub Environment gate (the workflow pauses for maintainer approval)
+4. The workflow bumps the version in `Directory.Build.props`, commits to `main`, creates a git tag, and creates a GitHub Release
+5. The GitHub Release triggers the [`main.yaml`](.github/workflows/main.yaml) workflow, which builds and publishes the packages to NuGet


### PR DESCRIPTION
## Problem

The release instructions only live in `README.md`, which makes them harder to keep as a single source of truth across SDK repos.

## Changes

- added a dedicated `RELEASING.md`
- moved the existing .NET release workflow instructions there
- replaced the inline README release section with a pointer to `RELEASING.md`

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Updated the docs
- [x] No breaking change
