### PR TITLE
chore: add manual release workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,24 @@ jobs:
     steps:
       - name: Check release conditions
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          HAS_BUMP_MAJOR: ${{ contains(github.event.pull_request.labels.*.name, 'bump-major') }}
+          HAS_BUMP_MINOR: ${{ contains(github.event.pull_request.labels.*.name, 'bump-minor') }}
+          HAS_BUMP_PATCH: ${{ contains(github.event.pull_request.labels.*.name, 'bump-patch') }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "bump-type=${{ inputs.bump_type }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "bump-type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
-            echo "Manual release requested with bump type '${{ inputs.bump_type }}'"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-major') }}; then
+            echo "Manual release requested with bump type '$BUMP_TYPE'"
+          elif [ "$HAS_BUMP_MAJOR" = "true" ]; then
             echo "bump-type=major" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-minor') }}; then
+          elif [ "$HAS_BUMP_MINOR" = "true" ]; then
             echo "bump-type=minor" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-patch') }}; then
+          elif [ "$HAS_BUMP_PATCH" = "true" ]; then
             echo "bump-type=patch" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
           else
@@ -207,8 +213,10 @@ jobs:
         id: check-rejection
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+          GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
         run: |
-          RESPONSE=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/approvals)
+          RESPONSE=$(gh api "/repos/$GITHUB_REPOSITORY_NAME/actions/runs/$GITHUB_RUN_ID_VALUE/approvals")
           REJECTED=$(echo "$RESPONSE" | jq '[.[] | select(.state == "rejected")] | length')
           if [ "$REJECTED" -gt 0 ]; then
             echo "was_rejected=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: Version bump to apply
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: read
@@ -16,8 +26,10 @@ jobs:
   check-release-label:
     name: Check for release label
     if: |
-      github.event.pull_request.merged == true
-       && contains(github.event.pull_request.labels.*.name, 'release')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
@@ -26,7 +38,11 @@ jobs:
       - name: Check release conditions
         id: check
         run: |
-          if ${{ contains(github.event.pull_request.labels.*.name, 'bump-major') }}; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "bump-type=${{ inputs.bump_type }}" >> "$GITHUB_OUTPUT"
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "Manual release requested with bump type '${{ inputs.bump_type }}'"
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-major') }}; then
             echo "bump-type=major" >> "$GITHUB_OUTPUT"
             echo "should-release=true" >> "$GITHUB_OUTPUT"
           elif ${{ contains(github.event.pull_request.labels.*.name, 'bump-minor') }}; then

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,12 @@
 # Releasing
 
-Releases are driven by PR labels. When a PR with the right labels is merged to `main`, a GitHub Actions workflow handles version bumping, tagging, creating a GitHub Release (with auto-generated notes), and publishing to NuGet.
+Releases are usually driven by PR labels. When a PR with the right labels is merged to `main`, a GitHub Actions workflow handles version bumping, tagging, creating a GitHub Release (with auto-generated notes), and publishing to NuGet. You can also trigger the `Release` workflow manually from GitHub Actions and choose the bump type.
 
 ## Release Process
 
-1. Add the `release` label and exactly one of `bump-patch`, `bump-minor`, or `bump-major` to your PR
-2. Merge the PR to `main`
-3. Approve the release in the GitHub Environment gate (the workflow pauses for maintainer approval)
-4. The workflow bumps the version in `Directory.Build.props`, commits to `main`, creates a git tag, and creates a GitHub Release
-5. The GitHub Release triggers the [`main.yaml`](.github/workflows/main.yaml) workflow, which builds and publishes the packages to NuGet
+1. Either:
+   - add the `release` label and exactly one of `bump-patch`, `bump-minor`, or `bump-major` to your PR, then merge it to `main`, or
+   - open the `Release` workflow in GitHub Actions, click **Run workflow**, and choose `patch`, `minor`, or `major`
+2. Approve the release in the GitHub Environment gate (the workflow pauses for maintainer approval)
+3. The workflow bumps the version in `Directory.Build.props`, commits to `main`, creates a git tag, and creates a GitHub Release
+4. The GitHub Release triggers the [`main.yaml`](.github/workflows/main.yaml) workflow, which builds and publishes the packages to NuGet


### PR DESCRIPTION
## :bulb: Motivation and Context

The release workflow can currently run only from a merged PR with release labels. Adding `workflow_dispatch` makes it possible to trigger a release manually from GitHub Actions when needed.

This also updates `RELEASING.md` to document the manual path and the required bump type selection.

## :green_heart: How did you test it?

- Reviewed the workflow logic change
- Validated `.github/workflows/release.yml` parses as YAML

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`
