### PR TITLE
docs: align contributing guide with CI checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,13 @@ Thanks for your interest in improving the PostHog .NET SDK.
 
 ## Building
 
-From the repository root, restore dependencies and build the solution:
+From the repository root, use the same restore, formatting, build, and test flow that CI runs:
 
 ```bash
-dotnet restore
-dotnet build
+dotnet restore --locked-mode
+bin/fmt --check
+dotnet build --configuration Release --no-restore --nologo
+dotnet test --configuration Release --no-build --nologo
 ```
 
 ## Running samples
@@ -30,14 +32,6 @@ bin/start
 You can also run the samples from your preferred IDE or editor.
 
 ## Testing
-
-Run the test suite from the repository root:
-
-```bash
-dotnet test
-```
-
-### Test target frameworks
 
 The test projects target both `net8.0` and `netcoreapp3.1`. While .NET Core 3.1 reached end-of-life in December 2022, we continue to test against it because:
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The contributing guide had drifted from the current CI workflow.

This PR updates `CONTRIBUTING.md` so the documented local verification steps match the formatting, build, and test commands we currently run in GitHub Actions.

## :green_heart: How did you test it?

- Not run (docs-only changes)
- Compared the updated commands against `.github/workflows/main.yaml`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`
