### PR TITLE
chore: remove v prefix from release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
           GH_TOKEN: ${{ steps.releaser.outputs.token }}
           VERSION: ${{ steps.version.outputs.new }}
         run: |
-          gh release create "v$VERSION" --target main --generate-notes
+          gh release create "$VERSION" --target main --generate-notes
 
       - name: Send failure event to PostHog
         if: failure()
@@ -190,7 +190,7 @@ jobs:
               "commitSha": "${{ github.sha }}",
               "jobStatus": "${{ job.status }}",
               "ref": "${{ github.ref }}",
-              "version": "v${{ steps.version.outputs.new }}"
+              "version": "${{ steps.version.outputs.new }}"
             }
 
       - name: Notify Slack - Failed
@@ -200,7 +200,7 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
           thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-          message: "❌ Failed to release `posthog-dotnet@v${{ steps.version.outputs.new }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+          message: "❌ Failed to release `posthog-dotnet@${{ steps.version.outputs.new }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
           emoji_reaction: "x"
 
   notify-rejected:


### PR DESCRIPTION
## :bulb: Motivation and Context
This ports the same release-workflow fix from `posthog-go` to `posthog-dotnet`. The current workflow creates GitHub releases as `v<version>`, but this repo should use plain semantic versions like `1.2.3` for the release tag/version instead.

## :green_heart: How did you test it?
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml-ok"'`
- `git diff --check`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check README.md#publishing-releases -->
