### PR TITLE
fix: trim whitespace from API keys and host config

### DIFF
--- a/src/PostHog/Features/LocalFeatureFlagsLoader.cs
+++ b/src/PostHog/Features/LocalFeatureFlagsLoader.cs
@@ -50,7 +50,7 @@ internal sealed class LocalFeatureFlagsLoader(
     /// <exception cref="ApiException">Thrown when the API returns a <c>quota_limited</c> error.</exception>
     public async ValueTask<LocalEvaluator?> GetFeatureFlagsForLocalEvaluationAsync(CancellationToken cancellationToken)
     {
-        if (options.Value.PersonalApiKey is null)
+        if (string.IsNullOrWhiteSpace(options.Value.PersonalApiKey))
         {
             // Local evaluation is not enabled since it requires a personal api key.
             return null;
@@ -70,7 +70,7 @@ internal sealed class LocalFeatureFlagsLoader(
     /// <returns>The local evaluator with the feature flags.</returns>
     public async ValueTask<LocalEvaluator?> RefreshAsync(CancellationToken cancellationToken)
     {
-        if (options.Value.PersonalApiKey is null)
+        if (string.IsNullOrWhiteSpace(options.Value.PersonalApiKey))
         {
             return null;
         }

--- a/src/PostHog/Library/StringExtensions.cs
+++ b/src/PostHog/Library/StringExtensions.cs
@@ -7,6 +7,16 @@ namespace PostHog.Library;
 internal static class StringExtensions
 {
     /// <summary>
+    /// Trims <paramref name="value"/> and returns <c>null</c> when the result is empty.
+    /// </summary>
+    /// <param name="value">The string to normalize.</param>
+    /// <returns>The trimmed string, or <c>null</c> if the input is null, empty, or whitespace-only.</returns>
+    public static string? NullIfEmpty(this string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    /// <summary>
     /// Truncates <paramref name="value"/> so its UTF-8 byte length is at most <paramref name="maxLength"/>.
     /// Appends <paramref name="truncationSymbol"/> if truncation occurs. Respects UTF-8 code point boundaries, but it can split graphemes.
     /// </summary>

--- a/src/PostHog/Library/StringExtensions.cs
+++ b/src/PostHog/Library/StringExtensions.cs
@@ -13,12 +13,8 @@ internal static class StringExtensions
     /// <returns>The trimmed string, or <c>null</c> if the input is null, empty, or whitespace-only.</returns>
     public static string? NullIfEmpty(this string? value)
     {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        return value!.Trim();
+        var trimmed = value?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
     }
 
     /// <summary>

--- a/src/PostHog/Library/StringExtensions.cs
+++ b/src/PostHog/Library/StringExtensions.cs
@@ -13,7 +13,12 @@ internal static class StringExtensions
     /// <returns>The trimmed string, or <c>null</c> if the input is null, empty, or whitespace-only.</returns>
     public static string? NullIfEmpty(this string? value)
     {
-        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value!.Trim();
     }
 
     /// <summary>

--- a/src/PostHog/Library/UriExtensions.cs
+++ b/src/PostHog/Library/UriExtensions.cs
@@ -1,0 +1,23 @@
+namespace PostHog.Library;
+
+internal static class UriExtensions
+{
+    static readonly Uri DefaultHostUrl = new("https://us.i.posthog.com");
+
+    public static Uri NormalizeHostUrl(this Uri? value)
+    {
+        if (value is null)
+        {
+            return DefaultHostUrl;
+        }
+
+        var rawValue = value.OriginalString.Trim();
+        if (!Uri.TryCreate(rawValue, UriKind.Absolute, out var normalized)
+            || (normalized.Scheme != Uri.UriSchemeHttp && normalized.Scheme != Uri.UriSchemeHttps))
+        {
+            return DefaultHostUrl;
+        }
+
+        return normalized;
+    }
+}

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -91,9 +91,7 @@ public sealed class PostHogClient : IPostHogClient
     static void NormalizeOptions(PostHogOptions options, ILogger<PostHogClient> logger)
     {
         options.ProjectApiKey = options.ProjectApiKey?.Trim();
-        options.PersonalApiKey = string.IsNullOrWhiteSpace(options.PersonalApiKey)
-            ? null
-            : options.PersonalApiKey.Trim();
+        options.PersonalApiKey = options.PersonalApiKey.NullIfEmpty();
 
         if (string.IsNullOrEmpty(options.ProjectApiKey))
         {

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -50,6 +50,9 @@ public sealed class PostHogClient : IPostHogClient
         _taskScheduler = taskScheduler ?? new TaskRunTaskScheduler();
         _timeProvider = timeProvider ?? TimeProvider.System;
         loggerFactory ??= NullLoggerFactory.Instance;
+        _logger = loggerFactory.CreateLogger<PostHogClient>();
+
+        NormalizeOptions(_options.Value, _logger);
 
         _apiClient = new PostHogApiClient(
             httpClientFactory.CreateClient(nameof(PostHogClient)),
@@ -82,8 +85,20 @@ public sealed class PostHogClient : IPostHogClient
             CompactionPercentage = options.Value.FeatureFlagSentCacheCompactionPercentage
         });
 
-        _logger = loggerFactory.CreateLogger<PostHogClient>();
         _logger.LogInfoClientCreated(options.Value.MaxBatchSize, options.Value.FlushInterval, options.Value.FlushAt);
+    }
+
+    static void NormalizeOptions(PostHogOptions options, ILogger<PostHogClient> logger)
+    {
+        options.ProjectApiKey = options.ProjectApiKey?.Trim();
+        options.PersonalApiKey = string.IsNullOrWhiteSpace(options.PersonalApiKey)
+            ? null
+            : options.PersonalApiKey.Trim();
+
+        if (string.IsNullOrEmpty(options.ProjectApiKey))
+        {
+            logger.LogErrorProjectApiKeyBlankAfterTrim();
+        }
     }
 
     /// <summary>
@@ -811,24 +826,30 @@ internal static partial class PostHogClientLoggerExtensions
 
     [LoggerMessage(
         EventId = 14,
+        Level = LogLevel.Error,
+        Message = "ProjectApiKey is empty after trimming whitespace; check your project API key")]
+    public static partial void LogErrorProjectApiKeyBlankAfterTrim(this ILogger<PostHogClient> logger);
+
+    [LoggerMessage(
+        EventId = 15,
         Level = LogLevel.Information,
         Message = "[FEATURE FLAGS] Loading feature flags for local evaluation")]
     public static partial void LogInfoLoadFeatureFlags(this ILogger<PostHogClient> logger);
 
     [LoggerMessage(
-        EventId = 15,
+        EventId = 16,
         Level = LogLevel.Warning,
         Message = "[FEATURE FLAGS] You have to specify a personal_api_key to use feature flags.")]
     public static partial void LogWarningPersonalApiKeyRequired(this ILogger<PostHogClient> logger);
 
     [LoggerMessage(
-        EventId = 16,
+        EventId = 17,
         Level = LogLevel.Debug,
         Message = "[FEATURE FLAGS] Feature flags loaded successfully, polling {PollingStatus}")]
     public static partial void LogDebugFeatureFlagsLoaded(this ILogger<PostHogClient> logger, string pollingStatus);
 
     [LoggerMessage(
-        EventId = 17,
+        EventId = 18,
         Level = LogLevel.Error,
         Message = "[FEATURE FLAGS] Failed to load feature flags")]
     public static partial void LogErrorFailedToLoadFeatureFlags(this ILogger<PostHogClient> logger, Exception exception);

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -92,6 +92,7 @@ public sealed class PostHogClient : IPostHogClient
     {
         options.ProjectApiKey = options.ProjectApiKey?.Trim();
         options.PersonalApiKey = options.PersonalApiKey.NullIfEmpty();
+        options.HostUrl = options.HostUrl.NormalizeHostUrl();
 
         if (string.IsNullOrEmpty(options.ProjectApiKey))
         {

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -1467,6 +1467,31 @@ public class TheLoadFeatureFlagsAsyncMethod
     }
 
     [Fact]
+    public void DefaultsHostUrlWhenConfiguredHostIsNullOrInvalid()
+    {
+        var nullHostContainer = new TestContainer(services =>
+        {
+            services.Configure<PostHogOptions>(options => options.HostUrl = null!);
+        });
+
+        _ = nullHostContainer.Activate<PostHogClient>();
+
+        var nullHostOptions = ((IOptions<PostHogOptions>)((IServiceProvider)nullHostContainer).GetService(typeof(IOptions<PostHogOptions>))!).Value;
+        Assert.Equal(new Uri("https://us.i.posthog.com"), nullHostOptions.HostUrl);
+
+        var invalidHostContainer = new TestContainer(services =>
+        {
+            services.Configure<PostHogOptions>(options =>
+                options.HostUrl = new Uri(" \n\t ", UriKind.RelativeOrAbsolute));
+        });
+
+        _ = invalidHostContainer.Activate<PostHogClient>();
+
+        var invalidHostOptions = ((IOptions<PostHogOptions>)((IServiceProvider)invalidHostContainer).GetService(typeof(IOptions<PostHogOptions>))!).Value;
+        Assert.Equal(new Uri("https://us.i.posthog.com"), invalidHostOptions.HostUrl);
+    }
+
+    [Fact]
     public async Task LogsDebugWhenFlagsLoadedSuccessfully()
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -1439,6 +1439,34 @@ public class TheLoadFeatureFlagsAsyncMethod
     }
 
     [Fact]
+    public async Task LogsWarningWhenPersonalApiKeyIsBlankAfterTrimmingWhitespace()
+    {
+        var container = new TestContainer(personalApiKey: " \n\t ");
+        var client = container.Activate<PostHogClient>();
+
+        await client.LoadFeatureFlagsAsync();
+
+        var warningLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Warning);
+        Assert.Contains(warningLogs, log =>
+            log.Message?.Contains("You have to specify a personal_api_key to use feature flags", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public void LogsErrorWhenProjectApiKeyIsBlankAfterTrimmingWhitespace()
+    {
+        var container = new TestContainer(services =>
+        {
+            services.Configure<PostHogOptions>(options => options.ProjectApiKey = " \n\t ");
+        });
+
+        _ = container.Activate<PostHogClient>();
+
+        var errorLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Error);
+        Assert.Contains(errorLogs, log =>
+            log.Message?.Contains("ProjectApiKey is empty after trimming whitespace", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
     public async Task LogsDebugWhenFlagsLoadedSuccessfully()
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");


### PR DESCRIPTION
## :bulb: Motivation and Context
This ports the whitespace-trimming fix from `posthog-go` to `posthog-dotnet`. It trims surrounding spaces and line breaks from the project API key and personal API key before using them so the SDK does not silently send invalid tokens or treat whitespace-only personal API keys as valid local-evaluation credentials.


## :green_heart: How did you test it?
- `dotnet test tests/UnitTests/UnitTests.csproj -f net8.0 --filter "FullyQualifiedName~LogsWarningWhenPersonalApiKeyIsBlankAfterTrimmingWhitespace|FullyQualifiedName~LogsErrorWhenProjectApiKeyIsBlankAfterTrimmingWhitespace|FullyQualifiedName~LogsWarningWhenPersonalApiKeyIsNull"`


## :pencil: Checklist
- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check README.md#publishing-releases -->
