### PR TITLE
chore: upgrade PostHog GitHub Action to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Send failure event to PostHog
         if: failure()
-        uses: PostHog/posthog-github-action@v0.1
+        uses: PostHog/posthog-github-action@v1
         with:
           posthog-token: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
           event: "posthog-dotnet-github-release-workflow-failure"


### PR DESCRIPTION
## :bulb: Motivation and Context

This repo still referenced `PostHog/posthog-github-action@v0.1` in its GitHub workflow(s). This updates that usage to `@v1` so the workflow uses the current supported major version.

## :green_heart: How did you test it?

- Verified the workflow reference was updated from `PostHog/posthog-github-action@v0.1` to `@v1`
- Re-scanned workflow files in the repo to confirm there are no remaining `PostHog/posthog-github-action` references below `@v1`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
