### PR TITLE
Rename ProjectApiKey to ProjectToken with aliases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,10 @@ dotnet test --configuration Release --no-build --nologo
 
 Sample projects live in the `samples` directory.
 
-To run the samples, set your PostHog project API key from the repository root:
+To run the samples, set your PostHog project token from the repository root:
 
 ```bash
-bin/user-secrets set PostHog:ProjectApiKey YOUR_API_KEY
+bin/user-secrets set PostHog:ProjectToken YOUR_PROJECT_TOKEN
 ```
 
 The main ASP.NET Core sample app can then be started with:

--- a/samples/HogTied.Api/appsettings.json
+++ b/samples/HogTied.Api/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "PostHog": {
-    "ProjectApiKey": "phc_67zPXoeBvPFCOv9rZfdzkYzgH71irovde2RGZfuB66M",
+    "ProjectToken": "phc_67zPXoeBvPFCOv9rZfdzkYzgH71irovde2RGZfuB66M",
     "Host": "https://us.i.posthog.com"
   }
 }

--- a/samples/HogTied.Web/Filters/PostHogPageViewFilter.cs
+++ b/samples/HogTied.Web/Filters/PostHogPageViewFilter.cs
@@ -18,7 +18,7 @@ public class PostHogPageViewFilter(IOptions<PostHogOptions> options, IPostHogCli
 
     public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (_options.ProjectApiKey is not null)
+        if (_options.ProjectToken is not null)
         {
             var user = context.HttpContext.User;
             var distinctId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/samples/HogTied.Web/Pages/Index.cshtml
+++ b/samples/HogTied.Web/Pages/Index.cshtml
@@ -29,19 +29,19 @@
         }
     </div>
     <div>
-        @if (!Model.ProjectApiKeyIsSet) {
+        @if (!Model.ProjectTokenIsSet) {
             <div class="alert alert-warning mt-3" role="alert">
-                The project API key is not set.
+                The project token is not set.
                 You can use the following command to set the key in the root of
                 this project:
                 <br />
-                <code>script/user-secrets set PostHog:ProjectApiKey your-api-key</code>
+                <code>script/user-secrets set PostHog:ProjectToken your-project-token</code>
             </div>
         }
         else {
             <div class="alert alert-info mt-3" role="alert">
                 <strong>
-                    The Project API Key <code>@Model.PostHogOptions.ProjectApiKey</code> is set pointing to
+                    The Project Token <code>@Model.PostHogOptions.ProjectToken</code> is set pointing to
                     <code>@Model.PostHogOptions.HostUrl!</code>
                     <br />We're ready to go!
                 </strong>

--- a/samples/HogTied.Web/Pages/Index.cshtml.cs
+++ b/samples/HogTied.Web/Pages/Index.cshtml.cs
@@ -21,7 +21,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
     [BindProperty]
     public string? FakeUserId { get; set; } = "12345";
 
-    public bool ProjectApiKeyIsSet { get; private set; }
+    public bool ProjectTokenIsSet { get; private set; }
 
     public bool PersonalApiKeyIsSet { get; private set; }
 
@@ -64,7 +64,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
 
     public async Task OnGetAsync()
     {
-        ProjectApiKeyIsSet = options.Value.ProjectApiKey is not (null or []);
+        ProjectTokenIsSet = options.Value.ProjectToken is not (null or []);
         PersonalApiKeyIsSet = options.Value.PersonalApiKey is not (null or []);
 
         // Check if the user is authenticated and get their user id.
@@ -75,7 +75,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
         // Parse custom person properties if provided
         ParsePersonProperties();
 
-        if (ProjectApiKeyIsSet && UserId is not null)
+        if (ProjectTokenIsSet && UserId is not null)
         {
             // Identify the current user if they're authenticated.
             if (User.Identity?.IsAuthenticated == true)
@@ -157,7 +157,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
     public async Task<IActionResult> OnPostAsync()
     {
         await OnGetAsync();
-        if (!ProjectApiKeyIsSet || UserId is null)
+        if (!ProjectTokenIsSet || UserId is null)
         {
             return RedirectToPage();
         }
@@ -182,7 +182,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
     public async Task<IActionResult> OnPostCaptureExceptionAsync()
     {
         await OnGetAsync();
-        if (!ProjectApiKeyIsSet || UserId is null)
+        if (!ProjectTokenIsSet || UserId is null)
         {
             return RedirectToPage();
         }
@@ -203,7 +203,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
     public async Task<IActionResult> OnPostIdentifyGroupAsync()
     {
         await OnGetAsync();
-        if (!ProjectApiKeyIsSet || UserId is null)
+        if (!ProjectTokenIsSet || UserId is null)
         {
             return RedirectToPage();
         }

--- a/samples/HogTied.Web/appsettings.Development.json
+++ b/samples/HogTied.Web/appsettings.Development.json
@@ -10,13 +10,13 @@
   },
   "PostHogLocal" : {
     "HostUrl": "http://localhost:8010",
-    "ProjectApiKey": "SET IN USER SECRETS!",
+    "ProjectToken": "SET IN USER SECRETS!",
     "MaxBatchSize": 100,
     "MaxQueueSize": 1000,
     "FlushAt": 5,
     "FlushInterval": "0:0:10"
   },
   "PostHog" : {
-    "ProjectApiKey": "SET IN USER SECRETS!"
+    "ProjectToken": "SET IN USER SECRETS!"
   }
 }

--- a/samples/PostHog.Example.Console/Program.cs
+++ b/samples/PostHog.Example.Console/Program.cs
@@ -25,23 +25,24 @@ var envPaths = new[]
 DotEnv.Load(options: new DotEnvOptions(envFilePaths: envPaths, ignoreExceptions: true));
 
 // Get configuration from environment variables
-var projectApiKey = Environment.GetEnvironmentVariable("POSTHOG_PROJECT_API_KEY");
+var projectToken = Environment.GetEnvironmentVariable("POSTHOG_PROJECT_TOKEN")
+                   ?? Environment.GetEnvironmentVariable("POSTHOG_PROJECT_API_KEY");
 var personalApiKey = Environment.GetEnvironmentVariable("POSTHOG_PERSONAL_API_KEY");
 var endpoint = Environment.GetEnvironmentVariable("POSTHOG_HOST") ?? "https://us.i.posthog.com";
 
 // Check credentials
-if (string.IsNullOrEmpty(projectApiKey))
+if (string.IsNullOrEmpty(projectToken))
 {
-    Console.WriteLine("❌ Missing POSTHOG_PROJECT_API_KEY!");
+    Console.WriteLine("❌ Missing POSTHOG_PROJECT_TOKEN or POSTHOG_PROJECT_API_KEY!");
     Console.WriteLine("   Please set the environment variable or copy .env.example to .env");
     Console.WriteLine();
-    Console.Write("Enter your PostHog project API key (starts with phc_): ");
-    projectApiKey = Console.ReadLine()?.Trim();
+    Console.Write("Enter your PostHog project token (starts with phc_): ");
+    projectToken = Console.ReadLine()?.Trim();
 }
 
-if (string.IsNullOrEmpty(projectApiKey))
+if (string.IsNullOrEmpty(projectToken))
 {
-    Console.WriteLine("❌ Project API key is required. Exiting.");
+    Console.WriteLine("❌ Project token is required. Exiting.");
     return 1;
 }
 
@@ -55,7 +56,7 @@ if (endpointUri.Scheme != "https" && !endpointUri.IsLoopback)
 }
 
 Console.WriteLine("✅ PostHog credentials loaded successfully!");
-Console.WriteLine($"   Project API Key: ✅ Configured");
+Console.WriteLine($"   Project Token: ✅ Configured");
 Console.WriteLine($"   Personal API Key: {(string.IsNullOrEmpty(personalApiKey) ? "❌ Not set (local evaluation disabled)" : "✅ Configured")}");
 Console.WriteLine($"   Endpoint: {endpoint}");
 Console.WriteLine();
@@ -63,7 +64,7 @@ Console.WriteLine();
 // Create PostHog options
 var options = new PostHogOptions
 {
-    ProjectApiKey = projectApiKey,
+    ProjectToken = projectToken,
     PersonalApiKey = personalApiKey,
     HostUrl = new Uri(endpoint),
     FlushAt = 1, // Flush immediately for demo purposes

--- a/samples/PostHog.Example.Console/Program.cs
+++ b/samples/PostHog.Example.Console/Program.cs
@@ -33,7 +33,7 @@ var endpoint = Environment.GetEnvironmentVariable("POSTHOG_HOST") ?? "https://us
 // Check credentials
 if (string.IsNullOrEmpty(projectToken))
 {
-    Console.WriteLine("❌ Missing POSTHOG_PROJECT_TOKEN or POSTHOG_PROJECT_API_KEY!");
+    Console.WriteLine("❌ Missing either POSTHOG_PROJECT_TOKEN or POSTHOG_PROJECT_API_KEY!");
     Console.WriteLine("   Please set the environment variable or copy .env.example to .env");
     Console.WriteLine();
     Console.Write("Enter your PostHog project token (starts with phc_): ");

--- a/sdk_compliance_adapter/Program.cs
+++ b/sdk_compliance_adapter/Program.cs
@@ -154,6 +154,7 @@ record HealthResponse(
 );
 
 record InitRequest(
+    // The SDK compliance protocol still uses the wire name `api_key` for the PostHog project token.
     [property: JsonPropertyName("api_key")] string ApiKey,
     [property: JsonPropertyName("host")] string Host,
     [property: JsonPropertyName("flush_at")] int? FlushAt = null,

--- a/sdk_compliance_adapter/Program.cs
+++ b/sdk_compliance_adapter/Program.cs
@@ -36,7 +36,7 @@ app.MapPost("/init", async (InitRequest request) =>
 
     var options = new PostHogOptions
     {
-        ProjectApiKey = request.ApiKey,
+        ProjectToken = request.ApiKey,
         HostUrl = new Uri(request.Host),
         FlushAt = state.FlushAt,
         FlushInterval = TimeSpan.FromMilliseconds(state.FlushIntervalMs),

--- a/src/PostHog.AI/README.md
+++ b/src/PostHog.AI/README.md
@@ -28,7 +28,7 @@ var builder = Host.CreateApplicationBuilder(args);
 // 1. Configure PostHog
 builder.Services.AddPostHog(options =>
 {
-    options.ProjectApiKey = "YOUR_PROJECT_API_KEY";
+    options.ProjectToken = "YOUR_PROJECT_TOKEN";
     options.HostUrl = new Uri("https://us.i.posthog.com"); // or eu.i.posthog.com
 });
 

--- a/src/PostHog.AspNetCore/README.md
+++ b/src/PostHog.AspNetCore/README.md
@@ -25,10 +25,10 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddPostHog();
 ```
 
-Set your project API key using user secrets:
+Set your project token using user secrets:
 
 ```bash
-$ dotnet user-secrets set PostHog:ProjectApiKey YOUR_API_KEY
+$ dotnet user-secrets set PostHog:ProjectToken YOUR_PROJECT_TOKEN
 ```
 
 In most cases, that's all you need to configure!

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -69,6 +69,7 @@ internal sealed class PostHogApiClient : IDisposable
 
         var payload = new Dictionary<string, object>
         {
+            // PostHog's ingestion API still expects the project token under the wire name `api_key`.
             ["api_key"] = ProjectToken,
             ["historical_migrations"] = false,
             ["batch"] = events.ToReadOnlyList()
@@ -157,6 +158,7 @@ internal sealed class PostHogApiClient : IDisposable
     {
         var uriBuilder = new UriBuilder(new Uri(HostUrl, "/flags/definitions"))
         {
+            // PostHog's feature flag API still expects the project token in the `token` query parameter.
             Query = $"token={Uri.EscapeDataString(ProjectToken)}&send_cohorts"
         };
         try
@@ -188,6 +190,7 @@ internal sealed class PostHogApiClient : IDisposable
     {
         var uriBuilder = new UriBuilder(new Uri(HostUrl, $"/api/projects/@current/feature_flags/{Uri.EscapeDataString(key)}/remote_config"))
         {
+            // PostHog's remote config API still expects the project token in the `token` query parameter.
             Query = $"token={Uri.EscapeDataString(ProjectToken)}"
         };
 
@@ -263,6 +266,7 @@ internal sealed class PostHogApiClient : IDisposable
 
     void PrepareAndMutatePayload(Dictionary<string, object> payload)
     {
+        // PostHog's decide API still expects the project token under the wire name `api_key`.
         payload["api_key"] = ProjectToken;
 
         var properties = payload.GetOrAdd<string, Dictionary<string, object>>("properties");

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -54,7 +54,7 @@ internal sealed class PostHogApiClient : IDisposable
     Uri HostUrl => _options.Value.HostUrl;
 
     string ProjectToken => _options.Value.ProjectToken
-                            ?? throw new InvalidOperationException("The Project Token is not configured.");
+                            ?? throw new InvalidOperationException("Either ProjectToken or ProjectApiKey must be provided.");
 
     /// <summary>
     /// Capture an event with optional properties

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -53,8 +53,8 @@ internal sealed class PostHogApiClient : IDisposable
 
     Uri HostUrl => _options.Value.HostUrl;
 
-    string ProjectApiKey => _options.Value.ProjectApiKey
-                            ?? throw new InvalidOperationException("The Project API Key is not configured.");
+    string ProjectToken => _options.Value.ProjectToken
+                            ?? throw new InvalidOperationException("The Project Token is not configured.");
 
     /// <summary>
     /// Capture an event with optional properties
@@ -69,7 +69,7 @@ internal sealed class PostHogApiClient : IDisposable
 
         var payload = new Dictionary<string, object>
         {
-            ["api_key"] = ProjectApiKey,
+            ["api_key"] = ProjectToken,
             ["historical_migrations"] = false,
             ["batch"] = events.ToReadOnlyList()
         };
@@ -157,7 +157,7 @@ internal sealed class PostHogApiClient : IDisposable
     {
         var uriBuilder = new UriBuilder(new Uri(HostUrl, "/flags/definitions"))
         {
-            Query = $"token={Uri.EscapeDataString(ProjectApiKey)}&send_cohorts"
+            Query = $"token={Uri.EscapeDataString(ProjectToken)}&send_cohorts"
         };
         try
         {
@@ -188,7 +188,7 @@ internal sealed class PostHogApiClient : IDisposable
     {
         var uriBuilder = new UriBuilder(new Uri(HostUrl, $"/api/projects/@current/feature_flags/{Uri.EscapeDataString(key)}/remote_config"))
         {
-            Query = $"token={Uri.EscapeDataString(ProjectApiKey)}"
+            Query = $"token={Uri.EscapeDataString(ProjectToken)}"
         };
 
         return await GetAuthenticatedResponseAsync<JsonDocument>(
@@ -263,7 +263,7 @@ internal sealed class PostHogApiClient : IDisposable
 
     void PrepareAndMutatePayload(Dictionary<string, object> payload)
     {
-        payload["api_key"] = ProjectApiKey;
+        payload["api_key"] = ProjectToken;
 
         var properties = payload.GetOrAdd<string, Dictionary<string, object>>("properties");
 

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -24,10 +24,12 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
         set => _projectToken = value;
     }
 
+    internal bool HasLegacyProjectApiKey => _projectApiKey is not null;
+
     /// <summary>
     /// Obsolete alias for <see cref="ProjectToken"/>.
     /// </summary>
-    [Obsolete("Use ProjectToken instead.")]
+    [Obsolete("Use ProjectToken instead. This will be removed in the next major version.")]
     public string? ProjectApiKey
     {
         get => _projectToken ?? _projectApiKey;

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -7,13 +7,32 @@ namespace PostHog;
 /// </summary>
 public sealed class PostHogOptions : IOptions<PostHogOptions>
 {
+    string? _projectToken;
+    string? _projectApiKey;
+
     /// <summary>
-    /// The project API key that identifies which project this client works with.
+    /// The PostHog project token that identifies which project this client works with.
     /// </summary>
     /// <remarks>
-    /// You can find this https://us.posthog.com/project/{YOUR_PROJECT_ID}/settings/project
+    /// You can find this at https://us.posthog.com/settings/project-details#variables
+    ///
+    /// This field was formerly named <see cref="ProjectApiKey"/>.
     /// </remarks>
-    public string? ProjectApiKey { get; set; }
+    public string? ProjectToken
+    {
+        get => _projectToken ?? _projectApiKey;
+        set => _projectToken = value;
+    }
+
+    /// <summary>
+    /// Obsolete alias for <see cref="ProjectToken"/>.
+    /// </summary>
+    [Obsolete("Use ProjectToken instead.")]
+    public string? ProjectApiKey
+    {
+        get => _projectToken ?? _projectApiKey;
+        set => _projectApiKey = value;
+    }
 
     /// <summary>
     /// Optional personal API key for local feature flag evaluation.

--- a/src/PostHog/Examples.cs
+++ b/src/PostHog/Examples.cs
@@ -7,7 +7,7 @@ public static class Examples
 {
     internal static readonly PostHogClient PostHog = new(new PostHogOptions
     {
-        ProjectApiKey = "<ph_project_api_key>",
+        ProjectToken = "<ph_project_api_key>",
         HostUrl = new Uri("<ph_client_api_host>"),
         PersonalApiKey = Environment.GetEnvironmentVariable("PostHog__PersonalApiKey"),
     });
@@ -16,7 +16,7 @@ public static class Examples
     {
         await using var posthog = new PostHogClient(new PostHogOptions
         {
-            ProjectApiKey = "<ph_project_api_key>"
+            ProjectToken = "<ph_project_api_key>"
         });
         posthog.Capture("distinct_id_of_the_user", "user_signed_up");
         posthog.Capture(

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -90,13 +90,13 @@ public sealed class PostHogClient : IPostHogClient
 
     static void NormalizeOptions(PostHogOptions options, ILogger<PostHogClient> logger)
     {
-        options.ProjectApiKey = options.ProjectApiKey?.Trim();
+        options.ProjectToken = options.ProjectToken?.Trim();
         options.PersonalApiKey = options.PersonalApiKey.NullIfEmpty();
         options.HostUrl = options.HostUrl.NormalizeHostUrl();
 
-        if (string.IsNullOrEmpty(options.ProjectApiKey))
+        if (string.IsNullOrEmpty(options.ProjectToken))
         {
-            logger.LogErrorProjectApiKeyBlankAfterTrim();
+            logger.LogErrorProjectTokenBlankAfterTrim();
         }
     }
 
@@ -224,7 +224,7 @@ public sealed class PostHogClient : IPostHogClient
         {
             var host = _options.Value.HostUrl.ToString().TrimEnd('/').Replace(".i.", ".", StringComparison.Ordinal);
             properties ??= [];
-            properties["$exception_personURL"] = $"{host}/project/{_options.Value.ProjectApiKey}/person/{distinctId}";
+            properties["$exception_personURL"] = $"{host}/project/{_options.Value.ProjectToken}/person/{distinctId}";
             properties = ExceptionPropertiesBuilder.Build(properties, exception);
 
             return Capture(distinctId, "$exception", properties, groups, sendFeatureFlags, timestamp);
@@ -826,8 +826,8 @@ internal static partial class PostHogClientLoggerExtensions
     [LoggerMessage(
         EventId = 14,
         Level = LogLevel.Error,
-        Message = "ProjectApiKey is empty after trimming whitespace; check your project API key")]
-    public static partial void LogErrorProjectApiKeyBlankAfterTrim(this ILogger<PostHogClient> logger);
+        Message = "ProjectToken is empty after trimming whitespace; check your project token")]
+    public static partial void LogErrorProjectTokenBlankAfterTrim(this ILogger<PostHogClient> logger);
 
     [LoggerMessage(
         EventId = 15,

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -90,13 +90,18 @@ public sealed class PostHogClient : IPostHogClient
 
     static void NormalizeOptions(PostHogOptions options, ILogger<PostHogClient> logger)
     {
+        if (options.HasLegacyProjectApiKey)
+        {
+            logger.LogWarningProjectApiKeyDeprecated();
+        }
+
         options.ProjectToken = options.ProjectToken?.Trim();
         options.PersonalApiKey = options.PersonalApiKey.NullIfEmpty();
         options.HostUrl = options.HostUrl.NormalizeHostUrl();
 
         if (string.IsNullOrEmpty(options.ProjectToken))
         {
-            logger.LogErrorProjectTokenBlankAfterTrim();
+            logger.LogErrorProjectTokenRequired();
         }
     }
 
@@ -825,24 +830,30 @@ internal static partial class PostHogClientLoggerExtensions
 
     [LoggerMessage(
         EventId = 14,
-        Level = LogLevel.Error,
-        Message = "ProjectToken is empty after trimming whitespace; check your project token")]
-    public static partial void LogErrorProjectTokenBlankAfterTrim(this ILogger<PostHogClient> logger);
+        Level = LogLevel.Warning,
+        Message = "ProjectApiKey is deprecated and will be removed in the next major version. Use ProjectToken instead.")]
+    public static partial void LogWarningProjectApiKeyDeprecated(this ILogger<PostHogClient> logger);
 
     [LoggerMessage(
         EventId = 15,
+        Level = LogLevel.Error,
+        Message = "Either ProjectToken or ProjectApiKey must be provided.")]
+    public static partial void LogErrorProjectTokenRequired(this ILogger<PostHogClient> logger);
+
+    [LoggerMessage(
+        EventId = 16,
         Level = LogLevel.Information,
         Message = "[FEATURE FLAGS] Loading feature flags for local evaluation")]
     public static partial void LogInfoLoadFeatureFlags(this ILogger<PostHogClient> logger);
 
     [LoggerMessage(
-        EventId = 16,
+        EventId = 17,
         Level = LogLevel.Warning,
         Message = "[FEATURE FLAGS] You have to specify a personal_api_key to use feature flags.")]
     public static partial void LogWarningPersonalApiKeyRequired(this ILogger<PostHogClient> logger);
 
     [LoggerMessage(
-        EventId = 17,
+        EventId = 18,
         Level = LogLevel.Debug,
         Message = "[FEATURE FLAGS] Feature flags loaded successfully, polling {PollingStatus}")]
     public static partial void LogDebugFeatureFlagsLoaded(this ILogger<PostHogClient> logger, string pollingStatus);
@@ -854,13 +865,13 @@ internal static partial class PostHogClientLoggerExtensions
     public static partial void LogErrorFailedToLoadFeatureFlags(this ILogger<PostHogClient> logger, Exception exception);
 
     [LoggerMessage(
-        EventId = 18,
+        EventId = 19,
         Level = LogLevel.Error,
         Message = "CaptureException called with null exception")]
     public static partial void LogErrorCaptureExceptionNull(this ILogger<PostHogClient> logger);
 
     [LoggerMessage(
-        EventId = 19,
+        EventId = 20,
         Level = LogLevel.Error,
         Message = "CaptureException failed with an exception")]
     public static partial void LogErrorCaptureExceptionFailed(this ILogger<PostHogClient> logger, Exception exception);

--- a/src/PostHog/README.md
+++ b/src/PostHog/README.md
@@ -22,6 +22,6 @@ To use this package, you need to create an instance of `PostHogClient` and call 
 ```csharp
 using PostHog;
 
-var client = new PostHogClient(new PostHogOptions { ProjectApiKey = "YOUR_PROJECT_API_KEY" });
+var client = new PostHogClient(new PostHogOptions { ProjectToken = "YOUR_PROJECT_TOKEN" });
 client.Capture("user-123", "Test Event");
 ```

--- a/tests/TestLibrary/TestContainer.cs
+++ b/tests/TestLibrary/TestContainer.cs
@@ -41,7 +41,7 @@ public sealed class TestContainer : IServiceProvider
     {
         services.Configure<PostHogOptions>(options =>
         {
-            options.ProjectApiKey = "fake-project-api-key";
+            options.ProjectToken = "fake-project-api-key";
             options.PersonalApiKey = personalApiKey;
         });
     })
@@ -73,7 +73,7 @@ public sealed class TestContainer : IServiceProvider
     {
         services.Configure<PostHogOptions>(options =>
         {
-            options.ProjectApiKey = "fake-project-api-key";
+            options.ProjectToken = "fake-project-api-key";
             options.EnableCompression = false; // Disable compression for tests to avoid gzip handling in fake handler
         });
         services.AddSingleton<ITestOutputHelper>(ConsoleTestOutputHelper);

--- a/tests/UnitTests.AspNetCore/RegistrationTests.cs
+++ b/tests/UnitTests.AspNetCore/RegistrationTests.cs
@@ -25,7 +25,7 @@ public class TheAddPostHogMethod
         configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["PostHog:PersonalApiKey"] = "fake-secret",
-            ["PostHog:ProjectApiKey"] = "fake-not-so-secret",
+            ["PostHog:ProjectToken"] = "fake-not-so-secret",
             ["PostHog:HostUrl"] = "https://test-host.com",
             ["PostHog:FeatureFlagPollInterval"] = "00:00:10",
         });
@@ -36,11 +36,34 @@ public class TheAddPostHogMethod
         Assert.NotNull(provider.GetRequiredService<IPostHogClient>());
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
         Assert.Equal("fake-secret", options.PersonalApiKey);
-        Assert.Equal("fake-not-so-secret", options.ProjectApiKey);
+        Assert.Equal("fake-not-so-secret", options.ProjectToken);
         Assert.Equal(new Uri("https://test-host.com"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
     }
 
+
+    [Fact]
+    public void ReadsLegacyProjectApiKeyFromPostHogConfigurationSection()
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Host.UseDefaultServiceProvider((_, options) =>
+        {
+            options.ValidateScopes = true;
+            options.ValidateOnBuild = true;
+        });
+        var services = builder.Services;
+        var configuration = builder.Configuration;
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["PostHog:ProjectApiKey"] = "fake-not-so-secret",
+        });
+
+        builder.AddPostHog();
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
+        Assert.Equal("fake-not-so-secret", options.ProjectToken);
+    }
 
     [Fact]
     async Task CanConfigureServices()
@@ -56,7 +79,7 @@ public class TheAddPostHogMethod
         configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["PostHogLocal:PersonalApiKey"] = "fake-secret",
-            ["PostHogLocal:ProjectApiKey"] = "fake-not-so-secret",
+            ["PostHogLocal:ProjectToken"] = "fake-not-so-secret",
             ["PostHogLocal:HostUrl"] = "https://local-test-host.com",
             ["PostHogLocal:FeatureFlagPollInterval"] = "00:00:20",
         });
@@ -76,7 +99,7 @@ public class TheAddPostHogMethod
         Assert.NotNull(provider.GetRequiredService<IPostHogClient>());
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
         Assert.Equal("fake-secret", options.PersonalApiKey);
-        Assert.Equal("fake-not-so-secret", options.ProjectApiKey);
+        Assert.Equal("fake-not-so-secret", options.ProjectToken);
         Assert.Equal(new Uri("https://local-test-host.com"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(20), options.FeatureFlagPollInterval);
         // Confirm the HttpClient has the message handler.

--- a/tests/UnitTests/Config/RegistrationTests.cs
+++ b/tests/UnitTests/Config/RegistrationTests.cs
@@ -43,7 +43,7 @@ public class TheAddPostHogMethod
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["PostHogTest:PersonalApiKey"] = "fake-secret-personal-api-key",
-                ["PostHogTest:ProjectApiKey"] = "fake-public-project-api-key",
+                ["PostHogTest:ProjectToken"] = "fake-public-project-api-key",
                 ["PostHogTest:HostUrl"] = "https://test-host/",
                 ["PostHogTest:FeatureFlagPollInterval"] = "00:00:10",
                 ["PostHogTest:FlushAt"] = "10",
@@ -67,7 +67,7 @@ public class TheAddPostHogMethod
 
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
 
-        Assert.Equal("fake-public-project-api-key", options.ProjectApiKey);
+        Assert.Equal("fake-public-project-api-key", options.ProjectToken);
         Assert.Equal("fake-secret-personal-api-key", options.PersonalApiKey);
         Assert.Equal(new Uri("https://test-host/"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
@@ -86,6 +86,53 @@ public class TheAddPostHogMethod
     }
 
     [Fact]
+    public void CanReadLegacyProjectApiKeyConfiguration()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PostHogTest:ProjectApiKey"] = "fake-public-project-api-key",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddPostHog(options =>
+        {
+            options.UseConfigurationSection(configuration.GetSection("PostHogTest"));
+        });
+
+        var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
+
+        Assert.Equal("fake-public-project-api-key", options.ProjectToken);
+    }
+
+    [Fact]
+    public void ProjectApiKeyAliasMirrorsProjectToken()
+    {
+        var options = new PostHogOptions
+        {
+            ProjectToken = "fake-public-project-token"
+        };
+
+#pragma warning disable CS0618
+        Assert.Equal("fake-public-project-token", options.ProjectApiKey);
+
+        options = new PostHogOptions
+        {
+            ProjectApiKey = "fake-public-project-api-key"
+        };
+#pragma warning restore CS0618
+
+        Assert.Equal("fake-public-project-api-key", options.ProjectToken);
+    }
+
+    [Fact]
     public void AllowsOverridingConfiguration()
     {
         var services = new ServiceCollection();
@@ -93,7 +140,7 @@ public class TheAddPostHogMethod
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["PostHogTest:PersonalApiKey"] = "fake-secret-personal-api-key",
-                ["PostHogTest:ProjectApiKey"] = "fake-public-project-api-key",
+                ["PostHogTest:ProjectToken"] = "fake-public-project-api-key",
                 ["PostHogTest:HostUrl"] = "https://test-host/",
                 ["PostHogTest:FeatureFlagPollInterval"] = "00:00:10",
                 ["PostHogTest:FlushAt"] = "10",
@@ -125,7 +172,7 @@ public class TheAddPostHogMethod
 
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
 
-        Assert.Equal("fake-public-project-api-key", options.ProjectApiKey);
+        Assert.Equal("fake-public-project-api-key", options.ProjectToken);
         Assert.Equal("fake-secret-personal-api-key", options.PersonalApiKey);
         Assert.Equal(new Uri("https://test-host/"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -2421,7 +2421,7 @@ public class TheGetFeatureFlagAsyncMethod
         {
             sp.Configure<PostHogOptions>(options =>
             {
-                options.ProjectApiKey = "fake-project-api-key";
+                options.ProjectToken = "fake-project-api-key";
                 options.FeatureFlagSentCacheSizeLimit = 2;
                 options.FeatureFlagSentCacheCompactionPercentage = .5; // 50%, or 1 item.
             });
@@ -2527,7 +2527,7 @@ public class TheGetFeatureFlagAsyncMethod
     {
         var container = new TestContainer(sp => sp.AddSingleton<IOptions<PostHogOptions>>(new PostHogOptions
         {
-            ProjectApiKey = "test-api-key",
+            ProjectToken = "test-api-key",
             FeatureFlagSentCacheSizeLimit = 20,
             FeatureFlagSentCacheSlidingExpiration = TimeSpan.FromSeconds(3),
             EnableCompression = false // Disable for tests to avoid gzip handling in fake handler
@@ -3291,7 +3291,7 @@ public class TheGetAllFeatureFlagsAsyncMethod
         {
             services.Configure<PostHogOptions>(options =>
             {
-                options.ProjectApiKey = "fake-project-api-key";
+                options.ProjectToken = "fake-project-api-key";
                 options.PersonalApiKey = "fake-personal-api-key";
                 options.FeatureFlagPollInterval = TimeSpan.FromSeconds(30);
             });
@@ -3380,7 +3380,7 @@ public class TheGetAllFeatureFlagsAsyncMethod
     }
 
     [Fact]
-    public async Task ReturnsEmptyDictionaryWhenProjectApiKeyIncorrect()
+    public async Task ReturnsEmptyDictionaryWhenProjectTokenIncorrect()
     {
         var container = new TestContainer();
         container.FakeHttpMessageHandler.AddResponse(

--- a/tests/UnitTests/Features/RemoteConfigTests.cs
+++ b/tests/UnitTests/Features/RemoteConfigTests.cs
@@ -93,7 +93,7 @@ public class TheGetRemoteConfigPayloadAsyncMethod
     }
 
     [Fact]
-    public async Task IncludesProjectTokenTokenInRemoteConfigUrl()
+    public async Task IncludesProjectTokenInRemoteConfigUrl()
     {
         var container = new TestContainer("fake-personal-api-key");
 

--- a/tests/UnitTests/Features/RemoteConfigTests.cs
+++ b/tests/UnitTests/Features/RemoteConfigTests.cs
@@ -93,7 +93,7 @@ public class TheGetRemoteConfigPayloadAsyncMethod
     }
 
     [Fact]
-    public async Task IncludesProjectApiKeyTokenInRemoteConfigUrl()
+    public async Task IncludesProjectTokenTokenInRemoteConfigUrl()
     {
         var container = new TestContainer("fake-personal-api-key");
 

--- a/tests/UnitTests/Library/HttpClientExtensionsTests.cs
+++ b/tests/UnitTests/Library/HttpClientExtensionsTests.cs
@@ -23,7 +23,7 @@ public class ThePostJsonWithRetryAsyncMethod
         TimeSpan? maxRetryDelay = null,
         bool enableCompression = false) => new()
         {
-            ProjectApiKey = "test-api-key",
+            ProjectToken = "test-api-key",
             MaxRetries = maxRetries,
             InitialRetryDelay = initialRetryDelay ?? TimeSpan.FromMilliseconds(1),
             MaxRetryDelay = maxRetryDelay ?? TimeSpan.FromSeconds(30),
@@ -577,7 +577,7 @@ public class ThePostCompressedJsonAsyncMethod
         using var httpClient = new HttpClient(handler);
         var options = new PostHogOptions
         {
-            ProjectApiKey = "test-api-key",
+            ProjectToken = "test-api-key",
             EnableCompression = true
         };
         var timeProvider = new FakeTimeProvider();
@@ -623,7 +623,7 @@ public class ThePostCompressedJsonAsyncMethod
         using var httpClient = new HttpClient(handler);
         var options = new PostHogOptions
         {
-            ProjectApiKey = "test-api-key",
+            ProjectToken = "test-api-key",
             EnableCompression = false
         };
         var timeProvider = new FakeTimeProvider();

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -1452,7 +1452,24 @@ public class TheLoadFeatureFlagsAsyncMethod
     }
 
     [Fact]
-    public void LogsErrorWhenProjectTokenIsBlankAfterTrimmingWhitespace()
+    public void LogsWarningWhenProjectApiKeyIsUsed()
+    {
+        var container = new TestContainer(services =>
+        {
+#pragma warning disable CS0618
+            services.Configure<PostHogOptions>(options => options.ProjectApiKey = "fake-project-api-key");
+#pragma warning restore CS0618
+        });
+
+        _ = container.Activate<PostHogClient>();
+
+        var warningLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Warning);
+        Assert.Contains(warningLogs, log =>
+            log.Message?.Contains("ProjectApiKey is deprecated", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public void LogsErrorWhenProjectTokenIsMissing()
     {
         var container = new TestContainer(services =>
         {
@@ -1463,7 +1480,7 @@ public class TheLoadFeatureFlagsAsyncMethod
 
         var errorLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Error);
         Assert.Contains(errorLogs, log =>
-            log.Message?.Contains("ProjectToken is empty after trimming whitespace", StringComparison.Ordinal) == true);
+            log.Message?.Contains("Either ProjectToken or ProjectApiKey must be provided", StringComparison.Ordinal) == true);
     }
 
     [Fact]

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -130,7 +130,7 @@ public class TheIdentifyPersonAsyncMethod
         {
             sp.AddSingleton<IOptions<PostHogOptions>>(new PostHogOptions
             {
-                ProjectApiKey = "fake-project-api-key",
+                ProjectToken = "fake-project-api-key",
                 SuperProperties = new Dictionary<string, object> { ["source"] = "repo-name" },
                 EnableCompression = false // Disable for tests to avoid gzip handling in fake handler
             });
@@ -1452,18 +1452,18 @@ public class TheLoadFeatureFlagsAsyncMethod
     }
 
     [Fact]
-    public void LogsErrorWhenProjectApiKeyIsBlankAfterTrimmingWhitespace()
+    public void LogsErrorWhenProjectTokenIsBlankAfterTrimmingWhitespace()
     {
         var container = new TestContainer(services =>
         {
-            services.Configure<PostHogOptions>(options => options.ProjectApiKey = " \n\t ");
+            services.Configure<PostHogOptions>(options => options.ProjectToken = " \n\t ");
         });
 
         _ = container.Activate<PostHogClient>();
 
         var errorLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Error);
         Assert.Contains(errorLogs, log =>
-            log.Message?.Contains("ProjectApiKey is empty after trimming whitespace", StringComparison.Ordinal) == true);
+            log.Message?.Contains("ProjectToken is empty after trimming whitespace", StringComparison.Ordinal) == true);
     }
 
     [Fact]


### PR DESCRIPTION
## :bulb: Motivation and Context

The .NET SDK still exposed and documented `ProjectApiKey`, while other SDKs are moving toward `project token` terminology. This updates the public .NET surface to prefer `ProjectToken`, while keeping `ProjectApiKey` and legacy configuration keys working as backwards-compatible aliases.

It also adds clarifying comments around wire-level names like `api_key` and `token` so readers can see that those protocol fields still carry the project token.

This follow-up improves runtime logging for the deprecated alias by warning when `ProjectApiKey` is used, and makes missing-value messages clearer by using an explicit either/or message.

follow up from flutter https://github.com/PostHog/posthog-flutter/pull/374

## :green_heart: How did you test it?

```bash
dotnet test tests/UnitTests/UnitTests.csproj --framework net8.0 --filter "FullyQualifiedName~PostHogClientTests.LogsWarningWhenProjectApiKeyIsUsed|FullyQualifiedName~PostHogClientTests.LogsErrorWhenProjectTokenIsMissing|FullyQualifiedName~RegistrationTests|FullyQualifiedName~RemoteConfigTests.IncludesProjectTokenInRemoteConfigUrl" --nologo
dotnet test tests/UnitTests.AspNetCore/UnitTests.AspNetCore.csproj --framework net8.0 --filter "FullyQualifiedName~RegistrationTests" --nologo
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added the `release` label to the PR
- [x] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`

<!-- For more details check README.md#publishing-releases -->
