### PR TITLE
chore: clean up leftover project-api-key references

### DIFF
--- a/samples/PostHog.Example.Console/.env.example
+++ b/samples/PostHog.Example.Console/.env.example
@@ -1,8 +1,8 @@
 # PostHog API Configuration
 # Copy this file to .env and update with your actual values
 
-# Your project API key (found on the /project/settings page in PostHog)
-POSTHOG_PROJECT_API_KEY=phc_your_project_api_key_here
+# Your project token (found on the /project/settings page in PostHog)
+POSTHOG_PROJECT_TOKEN=phc_your_project_token_here
 
 # Your personal API key (for local evaluation and other advanced features)
 # Found on https://us.posthog.com/settings/user-api-keys

--- a/src/PostHog/Examples.cs
+++ b/src/PostHog/Examples.cs
@@ -7,7 +7,7 @@ public static class Examples
 {
     internal static readonly PostHogClient PostHog = new(new PostHogOptions
     {
-        ProjectToken = "<ph_project_api_key>",
+        ProjectToken = "<ph_project_token>",
         HostUrl = new Uri("<ph_client_api_host>"),
         PersonalApiKey = Environment.GetEnvironmentVariable("PostHog__PersonalApiKey"),
     });
@@ -16,7 +16,7 @@ public static class Examples
     {
         await using var posthog = new PostHogClient(new PostHogOptions
         {
-            ProjectToken = "<ph_project_api_key>"
+            ProjectToken = "<ph_project_token>"
         });
         posthog.Capture("distinct_id_of_the_user", "user_signed_up");
         posthog.Capture(

--- a/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
+++ b/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
@@ -68,7 +68,7 @@ internal static class FakeHttpMessageHandlerExtensions
     public static void AddRepeatedFlagsResponse(this FakeHttpMessageHandler handler, int count, string responseBody)
         => handler.AddRepeatedFlagsResponse(count, _ => responseBody);
 
-    internal static readonly Uri LocalEvaluationUrl = new("https://us.i.posthog.com/flags/definitions?token=fake-project-api-key&send_cohorts");
+    internal static readonly Uri LocalEvaluationUrl = new("https://us.i.posthog.com/flags/definitions?token=fake-project-token&send_cohorts");
 
     public static FakeHttpMessageHandler.RequestHandler AddLocalEvaluationResponse(
         this FakeHttpMessageHandler handler,
@@ -148,7 +148,7 @@ internal static class FakeHttpMessageHandlerExtensions
         string key,
         string responseBody) =>
         handler.AddResponse(
-            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-api-key"),
+            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-token"),
             HttpMethod.Get,
             responseBody: responseBody);
 
@@ -157,7 +157,7 @@ internal static class FakeHttpMessageHandlerExtensions
         string key,
         string responseBody) =>
         handler.AddResponse(
-            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-api-key"),
+            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-token"),
             HttpMethod.Get,
             responseBody: responseBody);
 

--- a/tests/TestLibrary/TestContainer.cs
+++ b/tests/TestLibrary/TestContainer.cs
@@ -41,7 +41,7 @@ public sealed class TestContainer : IServiceProvider
     {
         services.Configure<PostHogOptions>(options =>
         {
-            options.ProjectToken = "fake-project-api-key";
+            options.ProjectToken = "fake-project-token";
             options.PersonalApiKey = personalApiKey;
         });
     })
@@ -73,7 +73,7 @@ public sealed class TestContainer : IServiceProvider
     {
         services.Configure<PostHogOptions>(options =>
         {
-            options.ProjectToken = "fake-project-api-key";
+            options.ProjectToken = "fake-project-token";
             options.EnableCompression = false; // Disable compression for tests to avoid gzip handling in fake handler
         });
         services.AddSingleton<ITestOutputHelper>(ConsoleTestOutputHelper);

--- a/tests/UnitTests/Config/RegistrationTests.cs
+++ b/tests/UnitTests/Config/RegistrationTests.cs
@@ -43,7 +43,7 @@ public class TheAddPostHogMethod
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["PostHogTest:PersonalApiKey"] = "fake-secret-personal-api-key",
-                ["PostHogTest:ProjectToken"] = "fake-public-project-api-key",
+                ["PostHogTest:ProjectToken"] = "fake-public-project-token",
                 ["PostHogTest:HostUrl"] = "https://test-host/",
                 ["PostHogTest:FeatureFlagPollInterval"] = "00:00:10",
                 ["PostHogTest:FlushAt"] = "10",
@@ -67,7 +67,7 @@ public class TheAddPostHogMethod
 
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
 
-        Assert.Equal("fake-public-project-api-key", options.ProjectToken);
+        Assert.Equal("fake-public-project-token", options.ProjectToken);
         Assert.Equal("fake-secret-personal-api-key", options.PersonalApiKey);
         Assert.Equal(new Uri("https://test-host/"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
@@ -140,7 +140,7 @@ public class TheAddPostHogMethod
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["PostHogTest:PersonalApiKey"] = "fake-secret-personal-api-key",
-                ["PostHogTest:ProjectToken"] = "fake-public-project-api-key",
+                ["PostHogTest:ProjectToken"] = "fake-public-project-token",
                 ["PostHogTest:HostUrl"] = "https://test-host/",
                 ["PostHogTest:FeatureFlagPollInterval"] = "00:00:10",
                 ["PostHogTest:FlushAt"] = "10",
@@ -172,7 +172,7 @@ public class TheAddPostHogMethod
 
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
 
-        Assert.Equal("fake-public-project-api-key", options.ProjectToken);
+        Assert.Equal("fake-public-project-token", options.ProjectToken);
         Assert.Equal("fake-secret-personal-api-key", options.PersonalApiKey);
         Assert.Equal(new Uri("https://test-host/"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -141,7 +141,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
         JsonAssert.EqualIgnoringUuids(
             $$"""
               {
-                "api_key": "fake-project-api-key",
+                "api_key": "fake-project-token",
                 "historical_migrations": false,
                 "batch": [
                   {
@@ -230,7 +230,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
         JsonAssert.EqualIgnoringUuids(
             $$"""
               {
-                "api_key": "fake-project-api-key",
+                "api_key": "fake-project-token",
                 "historical_migrations": false,
                 "batch": [
                   {
@@ -379,7 +379,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
         JsonAssert.EqualIgnoringUuids(
             $$"""
               {
-                "api_key": "fake-project-api-key",
+                "api_key": "fake-project-token",
                 "historical_migrations": false,
                 "batch": [
                   {
@@ -428,7 +428,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
         JsonAssert.EqualIgnoringUuids(
             $$"""
               {
-                "api_key": "fake-project-api-key",
+                "api_key": "fake-project-token",
                 "historical_migrations": false,
                 "batch": [
                   {
@@ -480,7 +480,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
         JsonAssert.EqualIgnoringUuids(
             $$"""
               {
-                "api_key": "fake-project-api-key",
+                "api_key": "fake-project-token",
                 "historical_migrations": false,
                 "batch": [
                   {
@@ -605,7 +605,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
         JsonAssert.EqualIgnoringUuids(
             $$"""
               {
-                "api_key": "fake-project-api-key",
+                "api_key": "fake-project-token",
                 "historical_migrations": false,
                 "batch": [
                   {
@@ -2336,7 +2336,7 @@ public class TheGetFeatureFlagAsyncMethod
         var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                        {
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "historical_migrations": false,
                          "batch": [
                            {
@@ -2385,7 +2385,7 @@ public class TheGetFeatureFlagAsyncMethod
         var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                        {
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "historical_migrations": false,
                          "batch": [
                            {
@@ -2421,7 +2421,7 @@ public class TheGetFeatureFlagAsyncMethod
         {
             sp.Configure<PostHogOptions>(options =>
             {
-                options.ProjectToken = "fake-project-api-key";
+                options.ProjectToken = "fake-project-token";
                 options.FeatureFlagSentCacheSizeLimit = 2;
                 options.FeatureFlagSentCacheCompactionPercentage = .5; // 50%, or 1 item.
             });
@@ -2450,7 +2450,7 @@ public class TheGetFeatureFlagAsyncMethod
         var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                        {
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "historical_migrations": false,
                          "batch": [
                            {
@@ -3291,7 +3291,7 @@ public class TheGetAllFeatureFlagsAsyncMethod
         {
             services.Configure<PostHogOptions>(options =>
             {
-                options.ProjectToken = "fake-project-api-key";
+                options.ProjectToken = "fake-project-token";
                 options.PersonalApiKey = "fake-personal-api-key";
                 options.FeatureFlagPollInterval = TimeSpan.FromSeconds(30);
             });

--- a/tests/UnitTests/Features/RemoteConfigTests.cs
+++ b/tests/UnitTests/Features/RemoteConfigTests.cs
@@ -99,7 +99,7 @@ public class TheGetRemoteConfigPayloadAsyncMethod
 
         // Use the AddResponse method to verify the URL includes the token parameter
         container.FakeHttpMessageHandler.AddResponse(
-            new Uri("https://us.i.posthog.com/api/projects/@current/feature_flags/test-flag/remote_config?token=fake-project-api-key"),
+            new Uri("https://us.i.posthog.com/api/projects/@current/feature_flags/test-flag/remote_config?token=fake-project-token"),
             HttpMethod.Get,
             responseBody: """{"test": "payload"}"""
         );

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -43,7 +43,7 @@ public class TheIdentifyPersonAsyncMethod
                            "$arch": "{{RuntimeInformation.ProcessArchitecture}}",
                            "$geoip_disable": true
                          },
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "timestamp": "2024-01-21T19:08:23\u002B00:00"
                        }
                        """, received);
@@ -73,7 +73,7 @@ public class TheIdentifyPersonAsyncMethod
                            "$arch": "{{RuntimeInformation.ProcessArchitecture}}",
                            "$geoip_disable": false
                          },
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "timestamp": "2024-01-21T19:08:23\u002B00:00"
                        }
                        """, received);
@@ -117,7 +117,7 @@ public class TheIdentifyPersonAsyncMethod
                            "$arch": "{{RuntimeInformation.ProcessArchitecture}}",
                            "$geoip_disable": true
                          },
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "timestamp": "2024-01-21T19:08:23\u002B00:00"
                        }
                        """, received);
@@ -130,7 +130,7 @@ public class TheIdentifyPersonAsyncMethod
         {
             sp.AddSingleton<IOptions<PostHogOptions>>(new PostHogOptions
             {
-                ProjectToken = "fake-project-api-key",
+                ProjectToken = "fake-project-token",
                 SuperProperties = new Dictionary<string, object> { ["source"] = "repo-name" },
                 EnableCompression = false // Disable for tests to avoid gzip handling in fake handler
             });
@@ -156,7 +156,7 @@ public class TheIdentifyPersonAsyncMethod
                            "$geoip_disable": true,
                            "source": "repo-name"
                          },
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "timestamp": "2024-01-21T19:08:23\u002B00:00"
                        }
                        """, received);
@@ -194,7 +194,7 @@ public class TheIdentifyGroupAsyncMethod
                            "$arch": "{{RuntimeInformation.ProcessArchitecture}}",
                            "$geoip_disable": true
                          },
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "timestamp": "2024-01-21T19:08:23\u002B00:00"
                        }
                        """, received);
@@ -229,7 +229,7 @@ public class TheIdentifyGroupAsyncMethod
                            "$arch": "{{RuntimeInformation.ProcessArchitecture}}",
                            "$geoip_disable": true
                          },
-                         "api_key": "fake-project-api-key",
+                         "api_key": "fake-project-token",
                          "timestamp": "2024-01-21T19:08:23\u002B00:00"
                        }
                        """, received);
@@ -264,7 +264,7 @@ public class TheCaptureMethod
         var received = requestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -421,7 +421,7 @@ public class TheCaptureMethod
 
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -458,7 +458,7 @@ public class TheCaptureMethod
         var received = requestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -496,7 +496,7 @@ public class TheCaptureMethod
         var received = requestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -536,7 +536,7 @@ public class TheCaptureMethod
         var received = requestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -578,7 +578,7 @@ public class TheCaptureMethod
         var received = requestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -621,7 +621,7 @@ public class TheCaptureMethod
         var received = requestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -671,7 +671,7 @@ public class TheCaptureMethod
         var received = requestHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -748,7 +748,7 @@ public class TheCaptureMethod
         var received = batchHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -815,7 +815,7 @@ public class TheCaptureMethod
         var received = batchHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -877,7 +877,7 @@ public class TheCaptureMethod
         var received = batchHandler.GetReceivedRequestBody(indented: true);
         JsonAssert.EqualIgnoringUuids($$"""
                      {
-                       "api_key": "fake-project-api-key",
+                       "api_key": "fake-project-token",
                        "historical_migrations": false,
                        "batch": [
                          {
@@ -1457,7 +1457,7 @@ public class TheLoadFeatureFlagsAsyncMethod
         var container = new TestContainer(services =>
         {
 #pragma warning disable CS0618
-            services.Configure<PostHogOptions>(options => options.ProjectApiKey = "fake-project-api-key");
+            services.Configure<PostHogOptions>(options => options.ProjectApiKey = "fake-project-token");
 #pragma warning restore CS0618
         });
 


### PR DESCRIPTION
## Summary
- Updates stale `fake-project-api-key` / `fake-public-project-api-key` placeholder values in tests to `fake-project-token` / `fake-public-project-token`.
- Renames the sample `.env.example` from `POSTHOG_PROJECT_API_KEY` to `POSTHOG_PROJECT_TOKEN` (the console sample's runtime still falls back to the old var for upgrading users).
- Updates the doc placeholder in `src/PostHog/Examples.cs` from `<ph_project_api_key>` to `<ph_project_token>`.

## Intentionally left untouched (backward compatibility)
- `PostHogOptions.ProjectApiKey` obsolete alias + internal field
- `LogWarningProjectApiKeyDeprecated` warning + "Either ProjectToken or ProjectApiKey must be provided" error
- Legacy tests: `ReadsLegacyProjectApiKeyFromPostHogConfigurationSection`, `CanReadLegacyProjectApiKeyConfiguration`, `ProjectApiKeyAliasMirrorsProjectToken`, `LogsWarningWhenProjectApiKeyIsUsed`
- `POSTHOG_PROJECT_API_KEY` env-var fallback in the console sample
- `secrets.POSTHOG_PROJECT_API_KEY` in `release.yml` (GitHub secret name)

## Test plan
- [x] `dotnet build` succeeds with 0 warnings / 0 errors
- [x] Renamed tests all pass (the 2 pre-existing `CaptureException` failures reproduce on clean `main` and are unrelated)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)