### PR TITLE
feat(flags): support mixed targeting in local evaluation

### DIFF
--- a/src/PostHog/Api/LocalEvaluationApiResult.cs
+++ b/src/PostHog/Api/LocalEvaluationApiResult.cs
@@ -200,6 +200,14 @@ internal record FeatureFlagGroup
     public int? RolloutPercentage { get; init; } = 100;
 
     /// <summary>
+    /// Optional per-condition aggregation override used by mixed-targeting flags.
+    /// When set, this condition targets the specified group type instead of the
+    /// flag-level aggregation. Null means person targeting under a mixed flag.
+    /// </summary>
+    [JsonPropertyName("aggregation_group_type_index")]
+    public int? AggregationGroupTypeIndex { get; init; }
+
+    /// <summary>
     /// Compares this instance to another <see cref="FeatureFlagGroup"/> for equality.
     /// </summary>
     /// <param name="other">The other <see cref="FeatureFlagGroup"/> to compare with.</param>
@@ -219,14 +227,15 @@ internal record FeatureFlagGroup
         return ((Properties is null && other.Properties is null)
                 || (Properties is not null && other.Properties is not null && Properties.SequenceEqual(other.Properties)))
                && Variant == other.Variant
-               && RolloutPercentage == other.RolloutPercentage;
+               && RolloutPercentage == other.RolloutPercentage
+               && AggregationGroupTypeIndex == other.AggregationGroupTypeIndex;
     }
 
     /// <summary>
     /// Serves as the default hash function.
     /// </summary>
     /// <returns>A hash code for the current object.</returns>
-    public override int GetHashCode() => HashCode.Combine(Properties, Variant, RolloutPercentage);
+    public override int GetHashCode() => HashCode.Combine(Properties, Variant, RolloutPercentage, AggregationGroupTypeIndex);
 }
 
 /// <summary>

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -279,8 +279,9 @@ internal sealed class LocalEvaluator
                 var effectiveProperties = properties;
                 var effectiveBucketingId = distinctId;
 
-                // Mixed-override path: condition-level aggregation differs from flag-level.
-                // This assumes flag-level aggregation is null for mixed flags.
+                // The condition explicitly sets its own aggregation, different from the
+                // flag level. Re-resolve properties and bucketing id from the condition's
+                // group so this condition evaluates against that group.
                 if (conditionAggregation != flagAggregation)
                 {
                     if (conditionAggregation.HasValue)

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -282,20 +282,20 @@ internal sealed class LocalEvaluator
                 // The condition explicitly sets its own aggregation, different from the
                 // flag level. Re-resolve properties and bucketing id from the condition's
                 // group so this condition evaluates against that group.
+                // conditionAggregation is non-null here: if it were null and flagAggregation
+                // were also null they'd be equal, and the only way conditionAggregation can
+                // be null at all (after the ?? above) is that case.
                 if (conditionAggregation != flagAggregation)
                 {
-                    if (conditionAggregation.HasValue)
+                    if (!_groupTypeMapping.TryGetValue(conditionAggregation!.Value, out var groupType)
+                        || groups is null
+                        || !groups.TryGetGroup(groupType, out var group))
                     {
-                        if (!_groupTypeMapping.TryGetValue(conditionAggregation.Value, out var groupType)
-                            || groups is null
-                            || !groups.TryGetGroup(groupType, out var group))
-                        {
-                            // Skip this condition: group type unknown or not passed in.
-                            continue;
-                        }
-                        effectiveProperties = group.Properties;
-                        effectiveBucketingId = group.GroupKey;
+                        // Skip this condition: group type unknown or not passed in.
+                        continue;
                     }
+                    effectiveProperties = group.Properties;
+                    effectiveBucketingId = group.GroupKey;
                 }
 
                 // if any one condition resolves to True, we can short circuit and return

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -262,6 +262,7 @@ internal sealed class LocalEvaluator
     {
         var filters = flag.Filters;
         var flagConditions = filters?.Groups ?? [];
+        var flagAggregation = filters?.AggregationGroupTypeIndex;
         var isInconclusive = false;
         var flagVariants = filters?.Multivariate?.Variants ?? [];
 
@@ -269,9 +270,36 @@ internal sealed class LocalEvaluator
         {
             try
             {
+                // Per-condition aggregation overrides only when the condition explicitly
+                // sets its own AggregationGroupTypeIndex (mixed targeting). When absent,
+                // fall back to the flag-level aggregation so existing pure person and
+                // pure group flags keep their original behavior.
+                var conditionAggregation = condition.AggregationGroupTypeIndex ?? flagAggregation;
+
+                var effectiveProperties = properties;
+                var effectiveBucketingId = distinctId;
+
+                // Mixed-override path: condition-level aggregation differs from flag-level.
+                // This assumes flag-level aggregation is null for mixed flags.
+                if (conditionAggregation != flagAggregation)
+                {
+                    if (conditionAggregation.HasValue)
+                    {
+                        if (!_groupTypeMapping.TryGetValue(conditionAggregation.Value, out var groupType)
+                            || groups is null
+                            || !groups.TryGetGroup(groupType, out var group))
+                        {
+                            // Skip this condition: group type unknown or not passed in.
+                            continue;
+                        }
+                        effectiveProperties = group.Properties;
+                        effectiveBucketingId = group.GroupKey;
+                    }
+                }
+
                 // if any one condition resolves to True, we can short circuit and return
                 // the matching variant
-                if (!IsConditionMatch(flag, distinctId, condition, properties, evaluationCache, groups))
+                if (!IsConditionMatch(flag, effectiveBucketingId, condition, effectiveProperties, evaluationCache, groups))
                 {
                     continue;
                 }
@@ -280,7 +308,7 @@ internal sealed class LocalEvaluator
                 var variant = variantOverride is not null
                               && flagVariants.Select(v => v.Key).Contains(variantOverride)
                     ? variantOverride
-                    : GetMatchingVariant(flag, distinctId);
+                    : GetMatchingVariant(flag, effectiveBucketingId);
 
                 return variant is not null
                     ? new StringOrValue<bool>(variant)

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -843,56 +843,43 @@ public class TheMixedTargetingEvaluation
         };
     }
 
-    [Fact]
-    public void PersonConditionMatchesWhenNoGroupsPassed()
+    public static IEnumerable<object?[]> MixedFlagCases =>
+    [
+        // person condition matches when no groups passed
+        ["user-1", null, new Dictionary<string, object?> { ["email"] = "test@example.com" }, true],
+        // group condition matches when group props match
+        [
+            "user-2",
+            new GroupCollection { new Group("company", "acme", new Dictionary<string, object?> { ["plan"] = "enterprise" }) },
+            new Dictionary<string, object?> { ["email"] = "nope@example.com" },
+            true
+        ],
+        // no match when both person and group fail
+        [
+            "user-3",
+            new GroupCollection { new Group("company", "acme", new Dictionary<string, object?> { ["plan"] = "free" }) },
+            new Dictionary<string, object?> { ["email"] = "nope@example.com" },
+            false
+        ],
+    ];
+
+    [Theory]
+    [MemberData(nameof(MixedFlagCases))]
+    public void EvaluatesMixedFlagAcrossPersonAndGroupConditions(
+        string distinctId,
+        GroupCollection? groups,
+        Dictionary<string, object?>? personProperties,
+        bool expected)
     {
         var localEvaluator = new LocalEvaluator(CreateMixedFlag());
-        var personProperties = new Dictionary<string, object?> { ["email"] = "test@example.com" };
 
         var result = localEvaluator.EvaluateFeatureFlag(
             key: "mixed-flag",
-            distinctId: "user-1",
-            personProperties: personProperties);
-
-        Assert.Equal(true, result);
-    }
-
-    [Fact]
-    public void GroupConditionMatchesWhenGroupPropsMatch()
-    {
-        var localEvaluator = new LocalEvaluator(CreateMixedFlag());
-        var groups = new GroupCollection
-        {
-            new Group("company", "acme", new Dictionary<string, object?> { ["plan"] = "enterprise" })
-        };
-        var personProperties = new Dictionary<string, object?> { ["email"] = "nope@example.com" };
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "mixed-flag",
-            distinctId: "user-2",
+            distinctId: distinctId,
             groups: groups,
             personProperties: personProperties);
 
-        Assert.Equal(true, result);
-    }
-
-    [Fact]
-    public void NoMatchWhenBothPersonAndGroupFail()
-    {
-        var localEvaluator = new LocalEvaluator(CreateMixedFlag());
-        var groups = new GroupCollection
-        {
-            new Group("company", "acme", new Dictionary<string, object?> { ["plan"] = "free" })
-        };
-        var personProperties = new Dictionary<string, object?> { ["email"] = "nope@example.com" };
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "mixed-flag",
-            distinctId: "user-3",
-            groups: groups,
-            personProperties: personProperties);
-
-        Assert.Equal(false, result);
+        Assert.Equal(expected, result);
     }
 
     [Fact]

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -908,11 +908,17 @@ public class TheMixedTargetingEvaluation
         Assert.Equal(false, result);
     }
 
-    [Fact]
-    public void RolloutUsesGroupKeyForGroupConditionsUnderMixedFlags()
+    // Group keys whose hash against `Hash("rollout-flag", <key>)` straddles the 50% bucket,
+    // and a distinct_id whose hash is also outside the bucket. If the matcher regressed to
+    // bucketing on distinct_id, both assertions below would yield false and the in-bucket
+    // assertion would fail.
+    [Theory]
+    [InlineData("company-7", true)]   // hash ~0.118 → in bucket at 50%
+    [InlineData("company-2", false)]  // hash ~0.803 → out of bucket at 50%
+    public void RolloutUsesGroupKeyForGroupConditionsUnderMixedFlags(string groupKey, bool expected)
     {
-        // Mixed flag with a single group condition at 100% rollout — passing the group
-        // must resolve locally, proving the matcher hashes on the group key path.
+        const string flagKey = "rollout-flag";
+        const string distinctId = "user-0"; // Hash("rollout-flag", "user-0") ~0.788 (out at 50%)
         var flags = new LocalEvaluationApiResult
         {
             Flags = [
@@ -921,7 +927,7 @@ public class TheMixedTargetingEvaluation
                     Id = 3,
                     TeamId = 1,
                     Name = "Rollout Flag",
-                    Key = "rollout-flag",
+                    Key = flagKey,
                     Active = true,
                     Filters = new FeatureFlagFilters
                     {
@@ -931,7 +937,7 @@ public class TheMixedTargetingEvaluation
                             {
                                 AggregationGroupTypeIndex = 0,
                                 Properties = [],
-                                RolloutPercentage = 100
+                                RolloutPercentage = 50
                             }
                         ]
                     }
@@ -942,15 +948,15 @@ public class TheMixedTargetingEvaluation
         var localEvaluator = new LocalEvaluator(flags);
         var groups = new GroupCollection
         {
-            new Group("company", "acme")
+            new Group("company", groupKey)
         };
 
         var result = localEvaluator.EvaluateFeatureFlag(
-            key: "rollout-flag",
-            distinctId: "any-distinct-id",
+            key: flagKey,
+            distinctId: distinctId,
             groups: groups);
 
-        Assert.Equal(true, result);
+        Assert.Equal(expected, result);
     }
 }
 

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
+using PostHog;
 using PostHog.Api;
 using PostHog.Features;
 using PostHog.Json;
@@ -745,6 +746,211 @@ public class TheEvaluateFeatureFlagMethod
                 distinctId: "some-distinct-id",
                 personProperties: properties);
         });
+    }
+}
+
+public class TheMixedTargetingEvaluation
+{
+    static LocalEvaluationApiResult CreateMixedFlag()
+    {
+        return new LocalEvaluationApiResult
+        {
+            Flags = [
+                new LocalFeatureFlag
+                {
+                    Id = 1,
+                    TeamId = 1,
+                    Name = "Mixed Flag",
+                    Key = "mixed-flag",
+                    Active = true,
+                    Filters = new FeatureFlagFilters
+                    {
+                        AggregationGroupTypeIndex = null,
+                        Groups = [
+                            new FeatureFlagGroup
+                            {
+                                AggregationGroupTypeIndex = 0,
+                                Properties = [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Group,
+                                        Key = "plan",
+                                        Value = new PropertyFilterValue("enterprise"),
+                                        Operator = ComparisonOperator.Exact,
+                                        GroupTypeIndex = 0
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            },
+                            new FeatureFlagGroup
+                            {
+                                AggregationGroupTypeIndex = null,
+                                Properties = [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "email",
+                                        Value = new PropertyFilterValue("test@example.com"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            }
+                        ]
+                    }
+                }
+            ],
+            GroupTypeMapping = new Dictionary<string, string> { { "0", "company" } }
+        };
+    }
+
+    static LocalEvaluationApiResult CreateOnlyGroupFlag()
+    {
+        return new LocalEvaluationApiResult
+        {
+            Flags = [
+                new LocalFeatureFlag
+                {
+                    Id = 2,
+                    TeamId = 1,
+                    Name = "Only Group Flag",
+                    Key = "only-group-flag",
+                    Active = true,
+                    Filters = new FeatureFlagFilters
+                    {
+                        AggregationGroupTypeIndex = null,
+                        Groups = [
+                            new FeatureFlagGroup
+                            {
+                                AggregationGroupTypeIndex = 0,
+                                Properties = [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Group,
+                                        Key = "plan",
+                                        Value = new PropertyFilterValue("enterprise"),
+                                        Operator = ComparisonOperator.Exact,
+                                        GroupTypeIndex = 0
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            }
+                        ]
+                    }
+                }
+            ],
+            GroupTypeMapping = new Dictionary<string, string> { { "0", "company" } }
+        };
+    }
+
+    [Fact]
+    public void PersonConditionMatchesWhenNoGroupsPassed()
+    {
+        var localEvaluator = new LocalEvaluator(CreateMixedFlag());
+        var personProperties = new Dictionary<string, object?> { ["email"] = "test@example.com" };
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "mixed-flag",
+            distinctId: "user-1",
+            personProperties: personProperties);
+
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void GroupConditionMatchesWhenGroupPropsMatch()
+    {
+        var localEvaluator = new LocalEvaluator(CreateMixedFlag());
+        var groups = new GroupCollection
+        {
+            new Group("company", "acme", new Dictionary<string, object?> { ["plan"] = "enterprise" })
+        };
+        var personProperties = new Dictionary<string, object?> { ["email"] = "nope@example.com" };
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "mixed-flag",
+            distinctId: "user-2",
+            groups: groups,
+            personProperties: personProperties);
+
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void NoMatchWhenBothPersonAndGroupFail()
+    {
+        var localEvaluator = new LocalEvaluator(CreateMixedFlag());
+        var groups = new GroupCollection
+        {
+            new Group("company", "acme", new Dictionary<string, object?> { ["plan"] = "free" })
+        };
+        var personProperties = new Dictionary<string, object?> { ["email"] = "nope@example.com" };
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "mixed-flag",
+            distinctId: "user-3",
+            groups: groups,
+            personProperties: personProperties);
+
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void OnlyGroupConditionWithNoGroupsPassedReturnsFalseWithoutThrowing()
+    {
+        var localEvaluator = new LocalEvaluator(CreateOnlyGroupFlag());
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "only-group-flag",
+            distinctId: "user-1");
+
+        // Group condition skips (no groups passed); no inconclusive raised.
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void RolloutUsesGroupKeyForGroupConditionsUnderMixedFlags()
+    {
+        // Mixed flag with a single group condition at 100% rollout — passing the group
+        // must resolve locally, proving the matcher hashes on the group key path.
+        var flags = new LocalEvaluationApiResult
+        {
+            Flags = [
+                new LocalFeatureFlag
+                {
+                    Id = 3,
+                    TeamId = 1,
+                    Name = "Rollout Flag",
+                    Key = "rollout-flag",
+                    Active = true,
+                    Filters = new FeatureFlagFilters
+                    {
+                        AggregationGroupTypeIndex = null,
+                        Groups = [
+                            new FeatureFlagGroup
+                            {
+                                AggregationGroupTypeIndex = 0,
+                                Properties = [],
+                                RolloutPercentage = 100
+                            }
+                        ]
+                    }
+                }
+            ],
+            GroupTypeMapping = new Dictionary<string, string> { { "0", "company" } }
+        };
+        var localEvaluator = new LocalEvaluator(flags);
+        var groups = new GroupCollection
+        {
+            new Group("company", "acme")
+        };
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "rollout-flag",
+            distinctId: "any-distinct-id",
+            groups: groups);
+
+        Assert.Equal(true, result);
     }
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Feature flags with "mixed targeting" (the `feature-flag-mixed-targeting` beta) allow different condition sets within a single flag to target different aggregation levels — some targeting users/persons, others targeting groups.

The SDK only reads `aggregation_group_type_index` at the flag level. For mixed flags this is `null`, so the SDK treats all conditions as person-targeted. Group conditions fail property matching and the SDK falls back to a server-side HTTP call.

This breaks customers using flags in environments that cannot make HTTP calls (e.g., background workers).

Ports [posthog-python#523](https://github.com/PostHog/posthog-python/pull/523) to posthog-dotnet.

## :green_heart: How did you test it?

Updated `MatchFeatureFlagProperties` in `LocalEvaluator` to resolve aggregation per condition when a condition sets its own `AggregationGroupTypeIndex` that differs from the flag level. Each condition uses the correct properties and bucketing value for its aggregation type. Backwards compatible with existing pure person and pure group flags.

Added a new `AggregationGroupTypeIndex` property on `FeatureFlagGroup` (internal record — not part of the public API surface, so non-breaking).

Added 5 new unit tests in `TheMixedTargetingEvaluation`: person match, group match, no match, only-group-no-groups, and rollout bucketing. All 767 existing UnitTests continue to pass on net8.0; xUnit CI run reports 805 passed, 0 failed, 2 skipped.

### Note on the SDK compliance report

The auto-posted `posthog-dotnet Compliance Report` comment shows `request_payload.request_with_person_properties_device_id` failing with a 404 from `http://sdk-adapter:8080/get_feature_flag`. **This failure pre-exists on `main` and is not related to this PR** — it's reproducible on the three most recent merged PRs (#182, #183, #184). The cause is that the .NET compliance adapter (`sdk_compliance_adapter/`) doesn't implement the `/get_feature_flag` endpoint yet (mirrors the same gap that posthog-go had). Worth tracking as a follow-up to bring the adapter to parity with the harness contract, but out of scope here.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Added exactly one version bump label: `bump-patch`, `bump-minor`, or `bump-major`