### PR TITLE
chore: use changelog for GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.releaser.outputs.token }}
           VERSION: ${{ steps.apply-changesets.outputs.new-version }}
-        run: gh release create "$VERSION" --target main --generate-notes
+        run: |
+          CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1; next} flag; END{if (!flag) print defText}' CHANGELOG.md | sed '/[^[:space:]]/,$!d' | tac | sed '/[^[:space:]]/,$!d' | tac)
+          gh release create "$VERSION" --target main --notes "$CHANGELOG_ENTRY"
 
       - name: Send failure event to PostHog
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# posthog-dotnet
+
+Previous release notes are available on the [GitHub releases page](https://github.com/PostHog/posthog-dotnet/releases).


### PR DESCRIPTION
## :bulb: Motivation and Context
GitHub releases should use the SDK changelog entry as the release body instead of auto-generated release notes, so published release notes match the changelog markdown.

This also adds the initial `CHANGELOG.md` file so future changeset releases have a changelog file to publish from, with a note linking older release notes to the GitHub releases page.

## :green_heart: How did you test it?
- Ran `git diff --check`.
- Reviewed the release workflow diff against other SDK release workflows that read `CHANGELOG.md` before creating GitHub releases.
- Validated the changelog extraction command with a synthetic latest `2.6.0` entry and confirmed it excludes previous entries.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
