### PR TITLE
chore: support per-package releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,11 @@ jobs:
           ref: ${{ needs.version-bump.outputs.commit-sha }}
           fetch-depth: 0
 
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Fetch tags
         run: git fetch --tags --force
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ on:
 permissions:
   contents: read
 
-# Concurrency control: only one release process can run at a time
-# This prevents race conditions if multiple releasable changesets merge simultaneously
+# Concurrency control: only one release process can run at a time.
+# This prevents race conditions if multiple releasable changesets merge simultaneously.
 concurrency:
   group: release
   cancel-in-progress: false
@@ -53,8 +53,8 @@ jobs:
       slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
       posthog_project_api_key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
 
-  release:
-    name: Bump version and release
+  version-bump:
+    name: Bump versions and commit to main
     needs: [check-changesets, notify-approval-needed]
     runs-on: ubuntu-latest
     if: always() && needs.check-changesets.outputs.has-changesets == 'true'
@@ -63,11 +63,13 @@ jobs:
       contents: write
       actions: write
       id-token: write
+    outputs:
+      committed: ${{ steps.commit-version-bump.outputs.committed }}
+      commit-sha: ${{ steps.commit-version-bump.outputs.commit-sha }}
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_NOLOGO: true
       DOTNET_VERSION: "9.0.102"
-      PackageDirectory: ${{ github.workspace }}/build/packages/Release
     steps:
       - name: Notify Slack - Approved
         if: needs.notify-approval-needed.outputs.slack_ts != ''
@@ -78,6 +80,7 @@ jobs:
           thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
           message: "✅ Release approved! Version bump in progress..."
           emoji_reaction: "white_check_mark"
+
       - name: Get GitHub App token
         id: releaser
         uses: actions/create-github-app-token@v3
@@ -114,17 +117,28 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Apply changesets and update version
-        id: apply-changesets
-        run: |
-          pnpm changeset version
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          CURRENT_VERSION=$(grep -o '<Version>[^<]*' Directory.Build.props | head -n 1 | sed 's/<Version>//')
-          sed -i "s|<Version>${CURRENT_VERSION}</Version>|<Version>${NEW_VERSION}</Version>|" Directory.Build.props
-          echo "new-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "New version: $NEW_VERSION"
+      - name: Apply changesets
+        run: pnpm changeset version
 
-      - name: Restore NuGet Packages
+      - name: Sync package versions to project files
+        run: |
+          set -euo pipefail
+
+          set_version() {
+            local project_file="$1"
+            local version="$2"
+            perl -0pi -e 's/<Version>[^<]+<\/Version>/<Version>'"$version"'<\/Version>/' "$project_file"
+          }
+
+          POSTHOG_VERSION=$(node -p "require('./src/PostHog/package.json').version")
+          ASPNETCORE_VERSION=$(node -p "require('./src/PostHog.AspNetCore/package.json').version")
+          AI_VERSION=$(node -p "require('./src/PostHog.AI/package.json').version")
+
+          set_version "src/PostHog/PostHog.csproj" "$POSTHOG_VERSION"
+          set_version "src/PostHog.AspNetCore/PostHog.AspNetCore.csproj" "$ASPNETCORE_VERSION"
+          set_version "src/PostHog.AI/PostHog.AI.csproj" "$AI_VERSION"
+
+      - name: Restore NuGet packages
         run: dotnet restore --locked-mode
 
       - name: Build
@@ -135,39 +149,18 @@ jobs:
 
       - name: Commit version bump
         id: commit-version-bump
-        env:
-          NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}
         run: |
           git add -A
           if git diff --staged --quiet; then
             echo "No changes to commit"
             echo "committed=false" >> "$GITHUB_OUTPUT"
+            echo "commit-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: release $NEW_VERSION [version bump] [skip ci]"
+            git commit -m "chore: update package versions [version bump] [skip ci]"
             git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
+            echo "commit-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: NuGet login
-        if: steps.commit-version-bump.outputs.committed == 'true'
-        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
-        id: login
-        with:
-          user: PostHog-Engineering
-
-      - name: Publish NuGet package
-        if: steps.commit-version-bump.outputs.committed == 'true'
-        shell: bash
-        env:
-          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
-        run: find "${{ env.PackageDirectory }}" -type f -name "*.nupkg" -exec dotnet nuget push {} --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate \;
-
-      - name: Create GitHub Release
-        if: steps.commit-version-bump.outputs.committed == 'true'
-        env:
-          GH_TOKEN: ${{ steps.releaser.outputs.token }}
-          VERSION: ${{ steps.apply-changesets.outputs.new-version }}
-        run: gh release create "$VERSION" --target main --generate-notes
 
       - name: Send failure event to PostHog
         if: failure()
@@ -180,7 +173,7 @@ jobs:
               "commitSha": "${{ github.sha }}",
               "jobStatus": "${{ job.status }}",
               "ref": "${{ github.ref }}",
-              "version": "${{ steps.apply-changesets.outputs.new-version }}"
+              "phase": "version-bump"
             }
 
       - name: Notify Slack - Failed
@@ -190,14 +183,176 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
           thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-          message: "❌ Failed to release `posthog-dotnet@${{ steps.apply-changesets.outputs.new-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+          message: "❌ Failed to bump versions for `posthog-dotnet`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+          emoji_reaction: "x"
+
+  publish:
+    name: Publish packages
+    needs: [version-bump, notify-approval-needed]
+    runs-on: ubuntu-latest
+    if: always() && needs.version-bump.outputs.committed == 'true'
+    permissions:
+      contents: write
+      actions: write
+      id-token: write
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_NOLOGO: true
+      DOTNET_VERSION: "9.0.102"
+      PackageDirectory: ${{ github.workspace }}/build/packages/Release
+    strategy:
+      # If any package fails to publish, stop immediately. PostHog must publish before dependents.
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        package:
+          - name: PostHog
+            path: src/PostHog
+            project: src/PostHog/PostHog.csproj
+            changelog: src/PostHog/CHANGELOG.md
+          - name: PostHog.AspNetCore
+            path: src/PostHog.AspNetCore
+            project: src/PostHog.AspNetCore/PostHog.AspNetCore.csproj
+            changelog: src/PostHog.AspNetCore/CHANGELOG.md
+          - name: PostHog.AI
+            path: src/PostHog.AI
+            project: src/PostHog.AI/PostHog.AI.csproj
+            changelog: src/PostHog.AI/CHANGELOG.md
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version-bump.outputs.commit-sha }}
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Detect version change for ${{ matrix.package.name }}
+        id: detect-version
+        run: |
+          set -euo pipefail
+
+          PACKAGE_JSON="${{ matrix.package.path }}/package.json"
+          CURRENT_VERSION=$(node -p "require('./${PACKAGE_JSON}').version")
+          RELEASE_TAG="${{ matrix.package.name }}-v${CURRENT_VERSION}"
+
+          if git diff --quiet HEAD^ HEAD -- "$PACKAGE_JSON"; then
+            echo "${{ matrix.package.name }} version did not change in the version-bump commit"
+            echo "has-new-version=false" >> "$GITHUB_OUTPUT"
+          elif git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Tag $RELEASE_TAG already exists - no new version to release"
+            echo "has-new-version=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New ${{ matrix.package.name }} version detected: $CURRENT_VERSION"
+            echo "has-new-version=true" >> "$GITHUB_OUTPUT"
+            echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+            echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Restore NuGet packages
+        if: steps.detect-version.outputs.has-new-version == 'true'
+        run: dotnet restore --locked-mode
+
+      - name: Build and pack ${{ matrix.package.name }}
+        if: steps.detect-version.outputs.has-new-version == 'true'
+        run: dotnet build "${{ matrix.package.project }}" --configuration Release --no-restore
+
+      - name: NuGet login
+        if: steps.detect-version.outputs.has-new-version == 'true'
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
+        id: login
+        with:
+          user: PostHog-Engineering
+
+      - name: Publish ${{ matrix.package.name }} to NuGet
+        if: steps.detect-version.outputs.has-new-version == 'true'
+        env:
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+          PACKAGE_NAME: ${{ matrix.package.name }}
+          PACKAGE_VERSION: ${{ steps.detect-version.outputs.version }}
+        run: |
+          package_file="${{ env.PackageDirectory }}/${PACKAGE_NAME}.${PACKAGE_VERSION}.nupkg"
+          if [ ! -f "$package_file" ]; then
+            echo "Package file not found: $package_file" >&2
+            find "${{ env.PackageDirectory }}" -type f -name '*.nupkg' -print >&2 || true
+            exit 1
+          fi
+          dotnet nuget push "$package_file" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Tag and push ${{ matrix.package.name }}
+        if: steps.detect-version.outputs.has-new-version == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.detect-version.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.detect-version.outputs.version }}
+          PACKAGE_NAME: ${{ matrix.package.name }}
+        run: |
+          git tag -a "$RELEASE_TAG" -m "$PACKAGE_NAME $RELEASE_VERSION"
+          git push origin "$RELEASE_TAG"
+
+      - name: Create GitHub release for ${{ matrix.package.name }}
+        if: steps.detect-version.outputs.has-new-version == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.detect-version.outputs.tag }}
+          CHANGELOG_FILE: ${{ matrix.package.changelog }}
+        run: |
+          if [ -f "$CHANGELOG_FILE" ]; then
+            awk -v defText="See $CHANGELOG_FILE" '
+              /^## / { if (found_version) exit; found_version=1; next }
+              found_version { print }
+              END { if (!found_version) print defText }
+            ' "$CHANGELOG_FILE" | sed '/[^[:space:]]/,$!d' | tac | sed '/[^[:space:]]/,$!d' | tac > release-notes.md
+          else
+            echo "See $CHANGELOG_FILE" > release-notes.md
+          fi
+
+          gh release create "$RELEASE_TAG" \
+            --target "${{ needs.version-bump.outputs.commit-sha }}" \
+            --title "$RELEASE_TAG" \
+            --notes-file release-notes.md
+
+      - name: Send failure event to PostHog
+        if: failure()
+        uses: PostHog/posthog-github-action@v1
+        with:
+          posthog-token: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
+          event: "posthog-dotnet-github-release-workflow-failure"
+          properties: >-
+            {
+              "commitSha": "${{ github.sha }}",
+              "jobStatus": "${{ job.status }}",
+              "ref": "${{ github.ref }}",
+              "phase": "publish",
+              "packageName": "${{ matrix.package.name }}",
+              "packageVersion": "${{ steps.detect-version.outputs.version }}"
+            }
+
+      - name: Notify Slack - Failed
+        if: failure() && needs.notify-approval-needed.outputs.slack_ts != ''
+        uses: posthog/.github/.github/actions/slack-thread-reply@main
+        with:
+          slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+          slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+          message: "❌ Failed to release `${{ matrix.package.name }}@${{ steps.detect-version.outputs.version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
           emoji_reaction: "x"
 
   notify-rejected:
     name: Notify Slack - Rejected
-    needs: [release, notify-approval-needed]
+    needs: [version-bump, notify-approval-needed]
     runs-on: ubuntu-latest
-    if: always() && (needs.release.result == 'failure' || needs.release.result == 'skipped') && needs.notify-approval-needed.outputs.slack_ts != ''
+    if: always() && (needs.version-bump.result == 'failure' || needs.version-bump.result == 'skipped') && needs.notify-approval-needed.outputs.slack_ts != ''
     steps:
       - name: Check for rejection
         id: check-rejection
@@ -237,9 +392,9 @@ jobs:
 
   notify-released:
     name: Notify Slack - Released
-    needs: [notify-approval-needed, release]
+    needs: [notify-approval-needed, publish]
     runs-on: ubuntu-latest
-    if: always() && needs.release.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
+    if: always() && needs.publish.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
     steps:
       - name: Notify Slack - Released
         uses: posthog/.github/.github/actions/slack-thread-reply@main
@@ -247,5 +402,5 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
           thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-          message: "🚀 posthog-dotnet released successfully!"
+          message: "🚀 Released updated posthog-dotnet packages successfully!"
           emoji_reaction: "rocket"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+This repository publishes multiple NuGet packages. See the package-specific changelogs for release notes:
+
+- [PostHog](src/PostHog/CHANGELOG.md)
+- [PostHog.AspNetCore](src/PostHog.AspNetCore/CHANGELOG.md)
+- [PostHog.AI](src/PostHog.AI/CHANGELOG.md)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>2.6.0</Version>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@ For documentation on the specific packages, see the README files in the respecti
 | [PostHog](src/PostHog/README.md) | [![NuGet version (PostHog)](https://img.shields.io/nuget/v/PostHog.svg?style=flat-square)](https://www.nuget.org/packages/PostHog/)                                  | The core library. Over time, this will support client environments such as Unit, Xamarin, etc.
 | [PostHog.AI](src/PostHog.AI/README.md) | [![NuGet version (PostHog.AI)](https://img.shields.io/nuget/v/PostHog.AI.svg?style=flat-square)](https://www.nuget.org/packages/PostHog.AI/) | AI Observability for OpenAI and other LLM providers.
 
-> [!WARNING]  
-> These packages are currently in a pre-release stage. We're making them available publicly to solicit 
-> feedback. While we always strive to maintain a high level of quality, use these packages at your own 
-> risk. There *will* be many breaking changes until we reach a stable release.
-
 ## Platform
 
 The core [PostHog](./src/PostHog/README.md) package targets `netstandard2.1` and `net8.0` for broad compatibility. The [PostHog.AspNetCore](src/PostHog.AspNetCore/README.md) package targets `net8.0`. The [PostHog.AI](src/PostHog.AI/README.md) package targets `netstandard2.1` and `net8.0` for broad compatibility.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,45 +1,85 @@
 # Releasing
 
-This repository uses [Changesets](https://github.com/changesets/changesets) for version management and an automated GitHub Actions workflow for releases.
+This repository uses [Changesets](https://github.com/changesets/changesets) for version management and an automated GitHub Actions workflow for NuGet releases.
 
-## How to Release
+## Packages
 
-### 1. Add a Changeset
+This repo publishes three NuGet packages independently:
 
-When making a change that should be released, add a changeset:
+| NuGet package | Changeset package | Version source | Project file |
+| --- | --- | --- | --- |
+| `PostHog` | `PostHog` | `src/PostHog/package.json` | `src/PostHog/PostHog.csproj` |
+| `PostHog.AspNetCore` | `PostHog.AspNetCore` | `src/PostHog.AspNetCore/package.json` | `src/PostHog.AspNetCore/PostHog.AspNetCore.csproj` |
+| `PostHog.AI` | `PostHog.AI` | `src/PostHog.AI/package.json` | `src/PostHog.AI/PostHog.AI.csproj` |
+
+`PostHog.AspNetCore` and `PostHog.AI` depend on `PostHog`. If a changeset bumps `PostHog`, Changesets will also patch-bump the dependent packages so their NuGet dependencies point at the new `PostHog` version.
+
+## How to release
+
+### 1. Add a changeset
+
+When making a releasable change, run:
 
 ```bash
 pnpm changeset
 ```
 
-This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
+Select the package or packages that changed:
 
-### 2. Merge the Pull Request
+- Core SDK change: select `PostHog`
+- ASP.NET Core integration change: select `PostHog.AspNetCore`
+- AI Observability change: select `PostHog.AI`
 
-After review, merge the PR to `main`. No GitHub release label is required.
+Then choose the bump type:
 
-A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
+- `patch`: bug fixes, documentation updates, dependency-only updates, and internal changes
+- `minor`: backwards-compatible features
+- `major`: breaking changes
 
-1. Checks for pending changesets
-2. Notifies the client libraries team in Slack for approval
-3. Waits for approval from a maintainer via the GitHub `Release` environment
-4. The workflow applies Changesets, syncs `Directory.Build.props`, publishes packages to NuGet, and creates a GitHub Release.
-5. Notifies Slack when the release completes or fails
+Commit the generated `.changeset/*.md` file with your PR.
 
-### Manual Trigger
+Example changeset for an AI-only patch release:
 
-You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
+```md
+---
+"PostHog.AI": patch
+---
 
-## Version Bumping
+Fix OpenAI tracing metadata.
+```
 
-Changesets determines the next version from the committed changeset files:
+### 2. Merge the PR
 
-- **patch**: bug fixes, documentation updates, and internal changes
-- **minor**: backwards-compatible features
-- **major**: breaking changes
+After review, merge the PR to `main`. A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
+
+1. Checks for pending changesets.
+2. Notifies the client libraries team in Slack for approval.
+3. Waits for approval from a maintainer via the GitHub `Release` environment.
+4. Runs `pnpm changeset version` to update the selected package `package.json` versions and changelogs.
+5. Syncs those versions into the matching `.csproj` files.
+6. Builds and tests the solution.
+7. Commits the version bump to `main`.
+8. Publishes only the packages whose package versions changed.
+9. Creates package-specific GitHub releases and tags, for example `PostHog-v2.6.1` or `PostHog.AI-v0.1.1`.
+
+### Manual trigger
+
+You can manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
+
+## Important notes
+
+- Do not edit `.csproj` package versions manually for a release. Edit the relevant package's `package.json` only if doing a one-off correction; normal releases should use `pnpm changeset`.
+- The root `package.json` is tooling-only and is not released.
+- The workflow publishes packages sequentially with `PostHog` first, because the other packages depend on it.
+- If only `PostHog.AI` changes, only `PostHog.AI` is versioned and published.
+- If `PostHog` changes, `PostHog.AspNetCore` and `PostHog.AI` receive patch dependency bumps and are published too.
 
 ## Troubleshooting
 
 ### No changesets found
 
 If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.
+
+### A package did not publish
+
+Check whether that package's `package.json` version changed in the version-bump commit. The publish job intentionally skips packages whose versions did not change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "posthog-dotnet",
-  "version": "2.6.0",
   "private": true,
   "description": "Release metadata and changesets for the PostHog .NET SDK",
   "packageManager": "pnpm@10.33.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,20 @@ importers:
         specifier: ^2.30.0
         version: 2.31.0
 
+  src/PostHog: {}
+
+  src/PostHog.AI:
+    dependencies:
+      PostHog:
+        specifier: workspace:*
+        version: link:../PostHog
+
+  src/PostHog.AspNetCore:
+    dependencies:
+      PostHog:
+        specifier: workspace:*
+        version: link:../PostHog
+
 packages:
 
   '@babel/runtime@7.29.2':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
-  - '.'
+  - 'src/PostHog'
+  - 'src/PostHog.AspNetCore'
+  - 'src/PostHog.AI'

--- a/src/PostHog.AI/CHANGELOG.md
+++ b/src/PostHog.AI/CHANGELOG.md
@@ -1,0 +1,3 @@
+# PostHog.AI
+
+Previous release notes are available on the [GitHub releases page](https://github.com/PostHog/posthog-dotnet/releases).

--- a/src/PostHog.AI/README.md
+++ b/src/PostHog.AI/README.md
@@ -2,6 +2,11 @@
 
 This package provides AI Observability for .NET applications using PostHog. It currently supports intercepting and tracing requests to OpenAI and Azure OpenAI.
 
+> [!WARNING]  
+> This package is currently in a pre-release stage. We're making it available publicly to solicit
+> feedback. While we always strive to maintain a high level of quality, use this package at your own
+> risk. There *will* be many breaking changes until we reach a stable release.
+
 ## Installation
 
 Install the `PostHog.AI` package via NuGet:

--- a/src/PostHog.AI/package.json
+++ b/src/PostHog.AI/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "PostHog.AI",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "PostHog": "workspace:*"
+  }
+}

--- a/src/PostHog.AspNetCore/CHANGELOG.md
+++ b/src/PostHog.AspNetCore/CHANGELOG.md
@@ -1,0 +1,3 @@
+# PostHog.AspNetCore
+
+Previous release notes are available on the [GitHub releases page](https://github.com/PostHog/posthog-dotnet/releases).

--- a/src/PostHog.AspNetCore/PostHog.AspNetCore.csproj
+++ b/src/PostHog.AspNetCore/PostHog.AspNetCore.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <Version>2.6.0</Version>
         <TargetFramework>net8.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>PostHog.AspNetCore</PackageId>

--- a/src/PostHog.AspNetCore/README.md
+++ b/src/PostHog.AspNetCore/README.md
@@ -3,11 +3,6 @@
 This is a client SDK for the PostHog API written in C#. This package depends on the PostHog package and provides 
 additional functionality for ASP.NET Core projects.
 
-> [!WARNING]  
-> This package is currently in a pre-release stage. We're making it available publicly to solicit
-> feedback. While we always strive to maintain a high level of quality, use this package at your own
-> risk. There *will* be many breaking changes until we reach a stable release.
-
 ## Installation
 
 Use the `dotnet` CLI to add the package to your project:

--- a/src/PostHog.AspNetCore/package.json
+++ b/src/PostHog.AspNetCore/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "PostHog.AspNetCore",
+  "version": "2.6.0",
+  "private": true,
+  "dependencies": {
+    "PostHog": "workspace:*"
+  }
+}

--- a/src/PostHog/CHANGELOG.md
+++ b/src/PostHog/CHANGELOG.md
@@ -1,0 +1,3 @@
+# PostHog
+
+Previous release notes are available on the [GitHub releases page](https://github.com/PostHog/posthog-dotnet/releases).

--- a/src/PostHog/PostHog.csproj
+++ b/src/PostHog/PostHog.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <Version>2.6.0</Version>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>PostHog</PackageId>

--- a/src/PostHog/README.md
+++ b/src/PostHog/README.md
@@ -2,11 +2,6 @@
 
 This is a client SDK for the PostHog API written in C#. This is the core implementation of PostHog.
 
-> [!WARNING]  
-> This package is currently in a pre-release stage. We're making it available publicly to solicit
-> feedback. While we always strive to maintain a high level of quality, use this package at your own
-> risk. There *will* be many breaking changes until we reach a stable release.
-
 ## Goals
 
 The goal of this package is to be usable in multiple .NET environments. At this moment, we are far short of that goal. We only support ASP.NET Core via [PostHog.AspNetCore](../PostHog.AspNetCore/README.md).

--- a/src/PostHog/package.json
+++ b/src/PostHog/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "PostHog",
+  "version": "2.6.0",
+  "private": true
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

The repo now has three NuGet packages, but the release workflow only treated the repository as a single Changesets package/version. `PostHog.AI` had a hardcoded `0.1.0` package version, so there was no automated path to bump and publish it independently. The root changelog now points readers to package-specific changelogs.

## :green_heart: How did you test it?

- `pnpm install --frozen-lockfile`
- Parsed `.github/workflows/release.yml` as YAML
- `dotnet build --configuration Release --no-restore`
- Simulated Changesets versioning for an AI-only patch release and verified it would build `PostHog.AI.0.1.1.nupkg`
- `dotnet test --configuration Release --no-build` was attempted, but local environment failed on missing x64 .NET host for netcoreapp3.1 and one existing unit assertion failure

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
