### PR TITLE
Allow PostHog packages to release individually

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ This repo publishes three NuGet packages independently:
 | `PostHog.AspNetCore` | `PostHog.AspNetCore` | `src/PostHog.AspNetCore/package.json` | `src/PostHog.AspNetCore/PostHog.AspNetCore.csproj` |
 | `PostHog.AI` | `PostHog.AI` | `src/PostHog.AI/package.json` | `src/PostHog.AI/PostHog.AI.csproj` |
 
-`PostHog.AspNetCore` and `PostHog.AI` depend on `PostHog`. If a changeset bumps `PostHog`, Changesets will also patch-bump the dependent packages so their NuGet dependencies point at the new `PostHog` version.
+The package-specific `package.json` files are Changesets metadata only. They intentionally do not declare internal package dependencies, so Changesets releases only the packages selected by changesets. The actual NuGet package dependencies come from the `.csproj` project references when packages are built.
 
 ## How to release
 
@@ -72,7 +72,8 @@ You can manually trigger the release workflow from the Actions tab with `workflo
 - The root `package.json` is tooling-only and is not released.
 - The workflow publishes packages sequentially with `PostHog` first, because the other packages depend on it.
 - If only `PostHog.AI` changes, only `PostHog.AI` is versioned and published.
-- If `PostHog` changes, `PostHog.AspNetCore` and `PostHog.AI` receive patch dependency bumps and are published too.
+- If only `PostHog` changes, only `PostHog` is versioned and published, including for major releases.
+- Do not add internal `dependencies` entries to the package-specific `package.json` files unless you intentionally want Changesets to couple those packages' releases.
 
 ## Troubleshooting
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,17 +14,9 @@ importers:
 
   src/PostHog: {}
 
-  src/PostHog.AI:
-    dependencies:
-      PostHog:
-        specifier: workspace:^
-        version: link:../PostHog
+  src/PostHog.AI: {}
 
-  src/PostHog.AspNetCore:
-    dependencies:
-      PostHog:
-        specifier: workspace:^
-        version: link:../PostHog
+  src/PostHog.AspNetCore: {}
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,13 +17,13 @@ importers:
   src/PostHog.AI:
     dependencies:
       PostHog:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../PostHog
 
   src/PostHog.AspNetCore:
     dependencies:
       PostHog:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../PostHog
 
 packages:

--- a/src/PostHog.AI/package.json
+++ b/src/PostHog.AI/package.json
@@ -1,8 +1,5 @@
 {
   "name": "PostHog.AI",
   "version": "0.1.1",
-  "private": true,
-  "dependencies": {
-    "PostHog": "workspace:^"
-  }
+  "private": true
 }

--- a/src/PostHog.AI/package.json
+++ b/src/PostHog.AI/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.1",
   "private": true,
   "dependencies": {
-    "PostHog": "workspace:*"
+    "PostHog": "workspace:^"
   }
 }

--- a/src/PostHog.AspNetCore/package.json
+++ b/src/PostHog.AspNetCore/package.json
@@ -1,8 +1,5 @@
 {
   "name": "PostHog.AspNetCore",
   "version": "2.6.1",
-  "private": true,
-  "dependencies": {
-    "PostHog": "workspace:^"
-  }
+  "private": true
 }

--- a/src/PostHog.AspNetCore/package.json
+++ b/src/PostHog.AspNetCore/package.json
@@ -3,6 +3,6 @@
   "version": "2.6.1",
   "private": true,
   "dependencies": {
-    "PostHog": "workspace:*"
+    "PostHog": "workspace:^"
   }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
A changeset that only bumped `PostHog` caused `PostHog.AspNetCore` and `PostHog.AI` to be versioned and released too, because their Changesets metadata used `workspace:*` for the internal `PostHog` dependency.

Switching those internal dependency ranges to `workspace:^` keeps compatible `PostHog` patch/minor releases from forcing dependency-only bumps of the dependent packages, so each package can be released individually unless it has its own changeset or the dependency update falls outside the compatible range.

## :green_heart: How did you test it?

- `pnpm install --frozen-lockfile`
- Temporarily added a test changeset for only `PostHog`, ran `pnpm changeset version`, and verified only `src/PostHog/package.json` / `src/PostHog/CHANGELOG.md` changed for the release; `PostHog.AspNetCore` and `PostHog.AI` were not version-bumped. Reverted the temporary generated files before committing.
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check README.md#publishing-releases -->
