### PR TITLE
fix: recover after flush handler exceptions

### DIFF
--- a/.changeset/happy-pens-attend.md
+++ b/.changeset/happy-pens-attend.md
@@ -1,0 +1,6 @@
+---
+"PostHog": patch
+"PostHog.AspNetCore": patch
+---
+
+Fix `AsyncBatchHandler` background flushing so transient batch send failures no longer permanently stop future flushes. `FlushAsync()` now also waits for an in-progress flush instead of returning early without doing work.

--- a/src/PostHog/Library/AsyncBatchHandler.cs
+++ b/src/PostHog/Library/AsyncBatchHandler.cs
@@ -210,7 +210,7 @@ internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAs
     async Task TryFlushBatchesAsync()
     {
         // Background flushes coalesce when another flush is already in progress.
-        if (!_flushLock.Wait(0))
+        if (!await _flushLock.WaitAsync(0))
         {
             return;
         }

--- a/src/PostHog/Library/AsyncBatchHandler.cs
+++ b/src/PostHog/Library/AsyncBatchHandler.cs
@@ -43,10 +43,10 @@ internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAs
     readonly PeriodicTimer _timer;
     readonly CancellationTokenSource _cancellationTokenSource = new();
     readonly SemaphoreSlim _flushSignal = new(0); // Used to signal when a flush is needed
+    readonly SemaphoreSlim _flushLock = new(1, 1); // Ensures only one flush drains the queue at a time.
     readonly Task _timerTask;
     readonly Task _flushSignalTask;
     volatile int _disposed;
-    volatile int _flushing;
 
     public AsyncBatchHandler(
         Func<IEnumerable<TItem>, Task> batchHandlerFunc,
@@ -132,27 +132,28 @@ internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAs
 
     async Task HandleFlushSignal(CancellationToken cancellationToken)
     {
-        try
+        while (!cancellationToken.IsCancellationRequested)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            try
             {
                 await _flushSignal.WaitAsync(cancellationToken);
-                await FlushBatchesAsync();
+                await TryFlushBatchesAsync();
             }
-        }
-        catch (OperationCanceledException)
-        {
-            _logger.LogTraceOperationCancelled(nameof(HandleFlushSignal));
-        }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogTraceOperationCancelled(nameof(HandleFlushSignal));
+                break;
+            }
 #pragma warning disable CA1031 // Do not catch general exception types
-        catch (Exception ex)
+            catch (Exception ex)
 #pragma warning restore CA1031
-        {
-            // When running locally we want this to throw so we can see the exception.
-            Debug.Assert(ex is not ArgumentException and not NullReferenceException,
-                $"Unexpected {ex.GetType().FullName} occurred during async batch handling.");
+            {
+                // When running locally we want this to throw so we can see the exception.
+                Debug.Assert(ex is not ArgumentException and not NullReferenceException,
+                    $"Unexpected {ex.GetType().FullName} occurred during async batch handling.");
 
-            _logger.LogErrorUnexpectedException(ex);
+                _logger.LogErrorUnexpectedException(ex);
+            }
         }
     }
 
@@ -195,25 +196,43 @@ internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAs
 
     async Task FlushBatchesAsync()
     {
-        // If we're flushing, don't start another flush.
-        if (Interlocked.CompareExchange(ref _flushing, 1, 0) == 1)
+        await _flushLock.WaitAsync();
+        try
+        {
+            await DrainBatchesAsync();
+        }
+        finally
+        {
+            _flushLock.Release();
+        }
+    }
+
+    async Task TryFlushBatchesAsync()
+    {
+        // Background flushes coalesce when another flush is already in progress.
+        if (!_flushLock.Wait(0))
         {
             return;
         }
 
         try
         {
-            var batchContext = _batchContextFunc();
-            while (_channel.Reader.TryReadBatch(_options.Value.MaxBatchSize, out var batch))
-            {
-                var tasks = batch.Select(item => item.ResolveItem(batchContext));
-                var resolved = await Task.WhenAll(tasks);
-                await SendBatch(resolved);
-            }
+            await DrainBatchesAsync();
         }
         finally
         {
-            Interlocked.Exchange(ref _flushing, 0);
+            _flushLock.Release();
+        }
+    }
+
+    async Task DrainBatchesAsync()
+    {
+        var batchContext = _batchContextFunc();
+        while (_channel.Reader.TryReadBatch(_options.Value.MaxBatchSize, out var batch))
+        {
+            var tasks = batch.Select(item => item.ResolveItem(batchContext));
+            var resolved = await Task.WhenAll(tasks);
+            await SendBatch(resolved);
         }
 
         return;
@@ -247,8 +266,7 @@ internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAs
         _logger.LogInfoDisposeAsyncCalled();
 
         // Cancel the token so both background loops exit, then wait for them to finish.
-        // This ensures any in-flight flush completes and _flushing returns to 0 before
-        // we attempt the final flush below.
+        // This ensures any in-flight flush completes before we attempt the final flush below.
         try
         {
             await _cancellationTokenSource.CancelAsync();
@@ -276,6 +294,10 @@ internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAs
                 $"Unexpected {e.GetType().FullName} occurred during async batch handling.");
 
             _logger.LogErrorUnexpectedException(e);
+        }
+        finally
+        {
+            _flushLock.Dispose();
         }
     }
 }

--- a/tests/UnitTests/Library/AsyncBatchHandlerTests.cs
+++ b/tests/UnitTests/Library/AsyncBatchHandlerTests.cs
@@ -148,6 +148,89 @@ public class TheEnqueueMethod
     }
 
     [Fact]
+    public async Task BackgroundFlushContinuesAfterException()
+    {
+        var options = new FakeOptions<PostHogOptions>(new()
+        {
+            FlushAt = 2,
+            MaxBatchSize = 2,
+            FlushInterval = TimeSpan.FromHours(3)
+        });
+        var items = new List<int>();
+        var firstFlushStarted = new TaskCompletionSource();
+        var secondFlushCompleted = new TaskCompletionSource();
+        int callCount = 0;
+
+        Func<IEnumerable<int>, Task> handlerFunc = batch =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                firstFlushStarted.SetResult();
+                throw new InvalidOperationException("Test exception");
+            }
+
+            items.AddRange(batch);
+            secondFlushCompleted.SetResult();
+            return Task.CompletedTask;
+        };
+
+        await using var batchHandler = new AsyncBatchHandler<int, object>(
+            handlerFunc,
+            () => new object(),
+            new FakeTimeProvider(),
+            options);
+
+        batchHandler.Enqueue(Task.FromResult(1));
+        batchHandler.Enqueue(Task.FromResult(2));
+        await CompleteWithin(firstFlushStarted.Task, TimeSpan.FromSeconds(1));
+
+        batchHandler.Enqueue(Task.FromResult(3));
+        batchHandler.Enqueue(Task.FromResult(4));
+        await CompleteWithin(secondFlushCompleted.Task, TimeSpan.FromSeconds(1));
+
+        Assert.Equal([3, 4], items);
+    }
+
+    [Fact]
+    public async Task FlushAsyncWaitsForInProgressFlush()
+    {
+        var options = new FakeOptions<PostHogOptions>(new()
+        {
+            FlushAt = 1,
+            FlushInterval = TimeSpan.FromHours(3)
+        });
+        var items = new List<int>();
+        var flushStarted = new TaskCompletionSource();
+        var flushCanProceed = new TaskCompletionSource();
+
+        Func<IEnumerable<int>, Task> handlerFunc = async batch =>
+        {
+            flushStarted.SetResult();
+            await flushCanProceed.Task;
+            items.AddRange(batch);
+        };
+
+        await using var batchHandler = new AsyncBatchHandler<int, object>(
+            handlerFunc,
+            () => new object(),
+            new FakeTimeProvider(),
+            options);
+
+        batchHandler.Enqueue(Task.FromResult(42));
+        await CompleteWithin(flushStarted.Task, TimeSpan.FromSeconds(1));
+
+        var flushTask = batchHandler.FlushAsync();
+        var completedEarly = await Task.WhenAny(flushTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        Assert.NotSame(flushTask, completedEarly);
+
+        flushCanProceed.SetResult();
+        await CompleteWithin(flushTask, TimeSpan.FromSeconds(1));
+
+        Assert.Equal([42], items);
+    }
+
+    [Fact]
     public async Task DropsOlderEventsWhenMaxQueueMet()
     {
         var timeProvider = new FakeTimeProvider();
@@ -259,6 +342,17 @@ public class TheEnqueueMethod
         batchHandler.Enqueue(Task.FromResult(3));
 
         Assert.Equal(0, batchHandler.Count);
+    }
+
+    static async Task CompleteWithin(Task task, TimeSpan timeout)
+    {
+        var completedTask = await Task.WhenAny(task, Task.Delay(timeout));
+        if (completedTask != task)
+        {
+            throw new TimeoutException("The operation timed out.");
+        }
+
+        await task;
     }
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #199.

`AsyncBatchHandler.HandleFlushSignal` previously wrapped the entire flush loop in a single `try/catch`. If a batch send threw after HTTP retries were exhausted, the exception was logged but the background flush processor exited permanently. Future timer/`FlushAt` signals would release the semaphore, but nothing consumed those signals, so events could
silently accumulate until a restart.

This change:

- keeps `HandleFlushSignal` running after per-flush exceptions by catching/logging inside the loop
- only treats `OperationCanceledException` as loop termination when the handler's own cancellation token is canceled, so HTTP timeouts or other cancellation-like send failures do not permanently stop the loop
- replaces the `_flushing` interlocked gate with a `SemaphoreSlim` flush lock
- preserves background flush coalescing when another flush is already running
- makes explicit `FlushAsync()` wait for an in-progress flush instead of returning early without doing work


## :green_heart: How did you test it?

- Added regression coverage:
  - `BackgroundFlushContinuesAfterException`
  - `FlushAsyncWaitsForInProgressFlush`
 - Verified the new regression test fails on `origin/main` before the fix.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check README.md#publishing-releases -->
