### PR TITLE
chore(ci): bump pinned posthog-sdk-test-harness SHA

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@1b56b38f46ac563ab2d5d7a8021740e8633a560b
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@39d05346c4638d24f94e591ab89c9c6fcdb52d6b
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."


### PR DESCRIPTION
Bumps the pinned SHA of `PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml` from `1b56b38f…` to current main HEAD `39d05346…`.

The old SHA predates
posthog-sdk-test-harness#18 (pinact rollout) which SHA-pinned the internal `actions/checkout@v4` reference. The org-wide "Require actions to be pinned to a full-length commit SHA" policy applies inside reusable
  workflows.