### PR TITLE
fix: include group context in $feature_flag_called dedupe key

### DIFF
--- a/.changeset/include-group-context-in-flag-called-dedupe.md
+++ b/.changeset/include-group-context-in-flag-called-dedupe.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Include group context in the `$feature_flag_called` dedupe cache key so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinctId, featureKey, response)` was seen under. The groups are canonicalized order-independently (`OrderBy(GroupType, StringComparer.Ordinal)`) so two equal collections built in different insertion orders still dedupe.

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -733,7 +733,7 @@ public sealed class PostHogClient : IPostHogClient
 
         _featureFlagCalledEventCache.GetOrCreate(
             key: (distinctId, featureKey, cacheKeyValue, groupsCacheKey),
-            // This factory only runs when the (distinct id, key, value, groups) tuple is not yet cached.
+            // This factory only runs when the (distinctId, featureKey, cacheKeyValue, groupsCacheKey) tuple is not yet cached.
             // Group context is included so group-scoped flags fire a separate event for each group
             // a user is evaluated under, instead of dedup-ing across groups.
             factory: cacheEntry =>
@@ -765,8 +765,8 @@ public sealed class PostHogClient : IPostHogClient
 
     // Build a canonical string for the groups collection that is order-independent
     // so two equal sets of groups always produce the same dedup cache key.
-    // Returns the empty string when no groups were passed, which keeps the legacy
-    // "no groups" dedupe shape for callers that don't pass a GroupCollection.
+    // Returns the empty string when no groups were passed, preserving the
+    // no-groups dedupe shape for callers that don't pass a GroupCollection.
     static string CanonicalGroupsCacheKey(GroupCollection? groups)
     {
         if (groups is null || groups.Count == 0)
@@ -774,9 +774,8 @@ public sealed class PostHogClient : IPostHogClient
             return string.Empty;
         }
         var pairs = groups
-            .Select(g => (g.GroupType, g.GroupKey))
-            .OrderBy(p => p.GroupType, StringComparer.Ordinal)
-            .Select(p => p.GroupType + "=" + p.GroupKey);
+            .OrderBy(g => g.GroupType, StringComparer.Ordinal)
+            .Select(g => Uri.EscapeDataString(g.GroupType) + "=" + Uri.EscapeDataString(g.GroupKey));
         return string.Join(";", pairs);
     }
 

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -729,9 +729,13 @@ public sealed class PostHogClient : IPostHogClient
         GroupCollection? groups,
         CancellationToken cancellationToken)
     {
+        var groupsCacheKey = CanonicalGroupsCacheKey(groups);
+
         _featureFlagCalledEventCache.GetOrCreate(
-            key: (distinctId, featureKey, cacheKeyValue),
-            // This factory only runs when the (distinct id, key, value) tuple is not yet cached.
+            key: (distinctId, featureKey, cacheKeyValue, groupsCacheKey),
+            // This factory only runs when the (distinct id, key, value, groups) tuple is not yet cached.
+            // Group context is included so group-scoped flags fire a separate event for each group
+            // a user is evaluated under, instead of dedup-ing across groups.
             factory: cacheEntry =>
             {
                 cacheEntry.SetSize(1);
@@ -757,6 +761,23 @@ public sealed class PostHogClient : IPostHogClient
                     _options.Value.FeatureFlagSentCacheCompactionPercentage),
                 cancellationToken);
         }
+    }
+
+    // Build a canonical string for the groups collection that is order-independent
+    // so two equal sets of groups always produce the same dedup cache key.
+    // Returns the empty string when no groups were passed, which keeps the legacy
+    // "no groups" dedupe shape for callers that don't pass a GroupCollection.
+    static string CanonicalGroupsCacheKey(GroupCollection? groups)
+    {
+        if (groups is null || groups.Count == 0)
+        {
+            return string.Empty;
+        }
+        var pairs = groups
+            .Select(g => (g.GroupType, g.GroupKey))
+            .OrderBy(p => p.GroupType, StringComparer.Ordinal)
+            .Select(p => p.GroupType + "=" + p.GroupKey);
+        return string.Join(";", pairs);
     }
 
     sealed class EvaluationsHost : IFeatureFlagEvaluationsHost

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -295,6 +295,82 @@ public class TheIsFeatureFlagEnabledAsyncMethod
     }
 
     [Fact]
+    public async Task CapturesSeparateFeatureFlagCalledEventsPerGroupContext()
+    {
+        var container = new TestContainer();
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddRepeatedFlagsResponse(2, """{"featureFlags": {"flag-key": true}}""");
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        // Same user, same flag, same response — but two different group contexts.
+        var optionsA = new FeatureFlagOptions { Groups = new GroupCollection() };
+        optionsA.Groups!.Add(new Group("organization", "org-a"));
+        var optionsB = new FeatureFlagOptions { Groups = new GroupCollection() };
+        optionsB.Groups!.Add(new Group("organization", "org-b"));
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", optionsA, CancellationToken.None));
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", optionsB, CancellationToken.None));
+
+        await client.FlushAsync();
+        var body = captureRequestHandler.GetReceivedRequestBody(indented: false);
+        var matches = System.Text.RegularExpressions.Regex.Matches(body, "\\$feature_flag_called");
+        Assert.Equal(2, matches.Count);
+        Assert.Contains("\"organization\":\"org-a\"", body, StringComparison.Ordinal);
+        Assert.Contains("\"organization\":\"org-b\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DedupesFeatureFlagCalledAcrossRepeatedCallsUnderSameGroupContext()
+    {
+        var container = new TestContainer();
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddRepeatedFlagsResponse(3, """{"featureFlags": {"flag-key": true}}""");
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        var options = new FeatureFlagOptions { Groups = new GroupCollection() };
+        options.Groups!.Add(new Group("organization", "org-a"));
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", options, CancellationToken.None));
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", options, CancellationToken.None));
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", options, CancellationToken.None));
+
+        await client.FlushAsync();
+        var body = captureRequestHandler.GetReceivedRequestBody(indented: false);
+        var matches = System.Text.RegularExpressions.Regex.Matches(body, "\\$feature_flag_called");
+        Assert.Single(matches);
+    }
+
+    [Fact]
+    public async Task DedupesFeatureFlagCalledAcrossGroupInsertionOrder()
+    {
+        var container = new TestContainer();
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddRepeatedFlagsResponse(2, """{"featureFlags": {"flag-key": true}}""");
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        // Same groups, two different insertion orders. The dedup key is canonicalized so both
+        // calls produce a cache hit.
+        var optionsA = new FeatureFlagOptions { Groups = new GroupCollection() };
+        optionsA.Groups!.Add(new Group("organization", "org-a"));
+        optionsA.Groups!.Add(new Group("team", "red"));
+
+        var optionsB = new FeatureFlagOptions { Groups = new GroupCollection() };
+        optionsB.Groups!.Add(new Group("team", "red"));
+        optionsB.Groups!.Add(new Group("organization", "org-a"));
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", optionsA, CancellationToken.None));
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", optionsB, CancellationToken.None));
+
+        await client.FlushAsync();
+        var body = captureRequestHandler.GetReceivedRequestBody(indented: false);
+        var matches = System.Text.RegularExpressions.Regex.Matches(body, "\\$feature_flag_called");
+        Assert.Single(matches);
+    }
+
+    [Fact]
     public async Task DoesNotCaptureFeatureFlagCalledEventWhenSendFeatureFlagsFalse()
     {
         var container = new TestContainer();

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -294,80 +294,61 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             , received);
     }
 
-    [Fact]
-    public async Task CapturesSeparateFeatureFlagCalledEventsPerGroupContext()
+    public static IEnumerable<object[]> GroupContextDedupeScenarios =>
+    [
+        // Different group contexts produce separate events.
+        [
+            new GroupCollection[]
+            {
+                new() { new Group("organization", "org-a") },
+                new() { new Group("organization", "org-b") },
+            },
+            2,
+        ],
+        // Repeated calls under the same group context dedupe to one event.
+        [
+            new GroupCollection[]
+            {
+                new() { new Group("organization", "org-a") },
+                new() { new Group("organization", "org-a") },
+                new() { new Group("organization", "org-a") },
+            },
+            1,
+        ],
+        // Same groups in different insertion order dedupe to one event because the
+        // dedup key is canonicalized.
+        [
+            new GroupCollection[]
+            {
+                new() { new Group("organization", "org-a"), new Group("team", "red") },
+                new() { new Group("team", "red"), new Group("organization", "org-a") },
+            },
+            1,
+        ],
+    ];
+
+    [Theory]
+    [MemberData(nameof(GroupContextDedupeScenarios))]
+    public async Task DedupesFeatureFlagCalledByGroupContext(
+        GroupCollection[] groupsPerCall,
+        int expectedMatchCount)
     {
         var container = new TestContainer();
         var messageHandler = container.FakeHttpMessageHandler;
-        messageHandler.AddRepeatedFlagsResponse(2, """{"featureFlags": {"flag-key": true}}""");
+        messageHandler.AddRepeatedFlagsResponse(groupsPerCall.Length, """{"featureFlags": {"flag-key": true}}""");
         var captureRequestHandler = messageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
 
-        // Same user, same flag, same response — but two different group contexts.
-        var optionsA = new FeatureFlagOptions { Groups = new GroupCollection() };
-        optionsA.Groups!.Add(new Group("organization", "org-a"));
-        var optionsB = new FeatureFlagOptions { Groups = new GroupCollection() };
-        optionsB.Groups!.Add(new Group("organization", "org-b"));
-
-        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", optionsA, CancellationToken.None));
-        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", optionsB, CancellationToken.None));
+        foreach (var groups in groupsPerCall)
+        {
+            var options = new FeatureFlagOptions { Groups = groups };
+            Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", options, CancellationToken.None));
+        }
 
         await client.FlushAsync();
         var body = captureRequestHandler.GetReceivedRequestBody(indented: false);
         var matches = System.Text.RegularExpressions.Regex.Matches(body, "\\$feature_flag_called");
-        Assert.Equal(2, matches.Count);
-        Assert.Contains("\"organization\":\"org-a\"", body, StringComparison.Ordinal);
-        Assert.Contains("\"organization\":\"org-b\"", body, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public async Task DedupesFeatureFlagCalledAcrossRepeatedCallsUnderSameGroupContext()
-    {
-        var container = new TestContainer();
-        var messageHandler = container.FakeHttpMessageHandler;
-        messageHandler.AddRepeatedFlagsResponse(3, """{"featureFlags": {"flag-key": true}}""");
-        var captureRequestHandler = messageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var options = new FeatureFlagOptions { Groups = new GroupCollection() };
-        options.Groups!.Add(new Group("organization", "org-a"));
-
-        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", options, CancellationToken.None));
-        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", options, CancellationToken.None));
-        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", options, CancellationToken.None));
-
-        await client.FlushAsync();
-        var body = captureRequestHandler.GetReceivedRequestBody(indented: false);
-        var matches = System.Text.RegularExpressions.Regex.Matches(body, "\\$feature_flag_called");
-        Assert.Single(matches);
-    }
-
-    [Fact]
-    public async Task DedupesFeatureFlagCalledAcrossGroupInsertionOrder()
-    {
-        var container = new TestContainer();
-        var messageHandler = container.FakeHttpMessageHandler;
-        messageHandler.AddRepeatedFlagsResponse(2, """{"featureFlags": {"flag-key": true}}""");
-        var captureRequestHandler = messageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        // Same groups, two different insertion orders. The dedup key is canonicalized so both
-        // calls produce a cache hit.
-        var optionsA = new FeatureFlagOptions { Groups = new GroupCollection() };
-        optionsA.Groups!.Add(new Group("organization", "org-a"));
-        optionsA.Groups!.Add(new Group("team", "red"));
-
-        var optionsB = new FeatureFlagOptions { Groups = new GroupCollection() };
-        optionsB.Groups!.Add(new Group("team", "red"));
-        optionsB.Groups!.Add(new Group("organization", "org-a"));
-
-        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", optionsA, CancellationToken.None));
-        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "user-1", optionsB, CancellationToken.None));
-
-        await client.FlushAsync();
-        var body = captureRequestHandler.GetReceivedRequestBody(indented: false);
-        var matches = System.Text.RegularExpressions.Regex.Matches(body, "\\$feature_flag_called");
-        Assert.Single(matches);
+        Assert.Equal(expectedMatchCount, matches.Count);
     }
 
     [Fact]


### PR DESCRIPTION
## :bulb: Motivation and Context

In `PostHogClient.TryCaptureDedupedFeatureFlagCalledEvent` (`src/PostHog/PostHogClient.cs`), the per-`distinctId` `MemoryCache` key only included `(distinctId, featureKey, cacheKeyValue)`. For group-scoped flags this meant that when the same user was evaluated under a different group, no new `$feature_flag_called` event was fired — causing per-group exposure undercount for experiments scoped to a group key.

Mirrors the posthog-node fix in PostHog/posthog-js#3658 (which closes PostHog/posthog-js#3651). Both SDKs share the same dedupe shape, so backend evaluation needs the same change.

## :green_heart: How did you test it?

Added three xUnit tests in `tests/UnitTests/Features/FeatureFlagsTests.cs`:

- `CapturesSeparateFeatureFlagCalledEventsPerGroupContext` — same user, same flag, two different group contexts → two events fired.
- `DedupesFeatureFlagCalledAcrossRepeatedCallsUnderSameGroupContext` — repeated access under the same group → one event.
- `DedupesFeatureFlagCalledAcrossGroupInsertionOrder` — same groups added in different insertion order → one event (canonicalized via `OrderBy(GroupType, StringComparer.Ordinal)`).

`dotnet test --filter "FullyQualifiedName~Feature"` is green: 322 tests pass on net8.0, 312 on netcoreapp3.1.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*