### PR TITLE
feat: add feature flag evaluation contexts

### DIFF
--- a/.changeset/few-flags-dance.md
+++ b/.changeset/few-flags-dance.md
@@ -1,5 +1,6 @@
 ---
 "PostHog": minor
+"PostHog.AspNetCore": minor
 ---
 
 Add feature flag evaluation contexts via `PostHogOptions.EvaluationContexts`. `/flags` requests now send `evaluation_contexts` when configured.

--- a/.changeset/few-flags-dance.md
+++ b/.changeset/few-flags-dance.md
@@ -1,0 +1,5 @@
+---
+"PostHog": minor
+---
+
+Add feature flag evaluation contexts via `PostHogOptions.EvaluationContexts`. `/flags` requests now send `evaluation_contexts` when configured.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ if (await posthog.IsFeatureEnabledAsync(
 > [!NOTE]
 > Specifying `PersonProperties` and `GroupProperties` is necessary when using local evaluation of feature flags.
 
+#### Evaluation contexts
+
+You can configure SDK-level feature flag evaluation contexts to only evaluate flags intended for this application,
+platform, or product area.
+
+```csharp
+services.AddPostHog(options =>
+{
+    options.ProjectToken = "YOUR_PROJECT_TOKEN";
+    options.EvaluationContexts = ["main-app", "api", "backend"];
+});
+```
+
+Flags without evaluation contexts continue to evaluate for all SDKs. Flags with contexts evaluate only when at least
+one configured context matches.
+
 ### Get a single Feature Flag
 
 Some feature flags may have associated payloads.

--- a/src/PostHog.AspNetCore/README.md
+++ b/src/PostHog.AspNetCore/README.md
@@ -253,6 +253,22 @@ options: new AllFeatureFlagsOptions
 });
 ```
 
+### Evaluation contexts
+
+Configure SDK-level feature flag evaluation contexts to only evaluate flags intended for this application,
+platform, or product area.
+
+```csharp
+builder.Services.AddPostHog(options =>
+{
+    options.ProjectToken = "YOUR_PROJECT_TOKEN";
+    options.EvaluationContexts = ["main-app", "api", "backend"];
+});
+```
+
+Flags without evaluation contexts continue to evaluate for all SDKs. Flags with contexts evaluate only when at least
+one configured context matches.
+
 ## Feature Management
 
 `PostHog.AspNetCore` supports .NET Feature Management. This allows you to use the &lt;feature /&gt; tag helper and 

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -133,6 +133,11 @@ internal sealed class PostHogApiClient : IDisposable
             payload["flag_keys_to_evaluate"] = flagKeysToEvaluate;
         }
 
+        if (_options.Value.EvaluationContexts is { Count: > 0 } evaluationContexts)
+        {
+            payload["evaluation_contexts"] = evaluationContexts;
+        }
+
         groupProperties?.AddToPayload(payload);
 
         PrepareAndMutatePayload(payload);

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -59,6 +59,15 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
     public string? PersonalApiKey { get; set; }
 
     /// <summary>
+    /// Evaluation contexts for feature flags.
+    /// </summary>
+    /// <remarks>
+    /// When set, only feature flags with no evaluation contexts or at least one matching context will be evaluated
+    /// for this SDK instance. Use this to isolate flags by application, platform, or product area.
+    /// </remarks>
+    public IReadOnlyList<string>? EvaluationContexts { get; set; }
+
+    /// <summary>
     /// Whether this client is disabled and should no-op instead of sending data to PostHog. (Default: false)
     /// </summary>
     /// <remarks>

--- a/tests/UnitTests/Config/RegistrationTests.cs
+++ b/tests/UnitTests/Config/RegistrationTests.cs
@@ -48,6 +48,8 @@ public class TheAddPostHogMethod
                 ["PostHogTest:FeatureFlagPollInterval"] = "00:00:10",
                 ["PostHogTest:FlushAt"] = "10",
                 ["PostHogTest:MaxBatchSize"] = "99",
+                ["PostHogTest:EvaluationContexts:0"] = "main-app",
+                ["PostHogTest:EvaluationContexts:1"] = "api",
                 ["PostHogTest:SuperProperties:Castle"] = "Winterfell",
                 ["PostHogTest:SuperProperties:Family"] = "Starks"
             })
@@ -73,6 +75,7 @@ public class TheAddPostHogMethod
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
         Assert.Equal(10, options.FlushAt);
         Assert.Equal(99, options.MaxBatchSize);
+        Assert.Equal(new[] { "main-app", "api" }, options.EvaluationContexts);
         Assert.Equal(new()
         {
             ["Castle"] = "Winterfell",

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -80,6 +80,46 @@ public class TheEvaluateFlagsAsyncMethod
     }
 
     [Fact]
+    public async Task SendsEvaluationContextsToFlagsRequestBody()
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.EvaluationContexts = ["production", "backend"];
+        }));
+        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {"flag-a": true}}""");
+        var client = container.Activate<PostHogClient>();
+
+        await client.EvaluateFlagsAsync("user-1", options: null, CancellationToken.None);
+
+        var request = flagsHandler.ReceivedRequests.Single();
+        var body = await request.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var evaluationContexts = doc.RootElement.GetProperty("evaluation_contexts")
+            .EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty)
+            .ToArray();
+        Assert.Equal(new[] { "production", "backend" }, evaluationContexts);
+    }
+
+    [Fact]
+    public async Task OmitsEvaluationContextsWhenEmpty()
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.EvaluationContexts = [];
+        }));
+        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {"flag-a": true}}""");
+        var client = container.Activate<PostHogClient>();
+
+        await client.EvaluateFlagsAsync("user-1", options: null, CancellationToken.None);
+
+        var request = flagsHandler.ReceivedRequests.Single();
+        var body = await request.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.False(doc.RootElement.TryGetProperty("evaluation_contexts", out _));
+    }
+
+    [Fact]
     public async Task OnlyEvaluateLocallyDoesNotHitRemote()
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -79,34 +79,22 @@ public class TheEvaluateFlagsAsyncMethod
         Assert.Equal(new[] { "flag-a", "flag-b" }, flagKeys);
     }
 
-    [Fact]
-    public async Task SendsEvaluationContextsToFlagsRequestBody()
+    public static IEnumerable<object?[]> EvaluationContextsRequestBodyCases()
     {
-        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
-        {
-            options.EvaluationContexts = ["production", "backend"];
-        }));
-        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {"flag-a": true}}""");
-        var client = container.Activate<PostHogClient>();
-
-        await client.EvaluateFlagsAsync("user-1", options: null, CancellationToken.None);
-
-        var request = flagsHandler.ReceivedRequests.Single();
-        var body = await request.Content!.ReadAsStringAsync();
-        using var doc = JsonDocument.Parse(body);
-        var evaluationContexts = doc.RootElement.GetProperty("evaluation_contexts")
-            .EnumerateArray()
-            .Select(e => e.GetString() ?? string.Empty)
-            .ToArray();
-        Assert.Equal(new[] { "production", "backend" }, evaluationContexts);
+        yield return [new[] { "production", "backend" }, new[] { "production", "backend" }];
+        yield return [Array.Empty<string>(), null];
+        yield return [null, null];
     }
 
-    [Fact]
-    public async Task OmitsEvaluationContextsWhenEmpty()
+    [Theory]
+    [MemberData(nameof(EvaluationContextsRequestBodyCases))]
+    public async Task SendsEvaluationContextsToFlagsRequestBodyWhenConfigured(
+        string[]? configuredEvaluationContexts,
+        string[]? expectedEvaluationContexts)
     {
         var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
         {
-            options.EvaluationContexts = [];
+            options.EvaluationContexts = configuredEvaluationContexts;
         }));
         var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {"flag-a": true}}""");
         var client = container.Activate<PostHogClient>();
@@ -116,7 +104,19 @@ public class TheEvaluateFlagsAsyncMethod
         var request = flagsHandler.ReceivedRequests.Single();
         var body = await request.Content!.ReadAsStringAsync();
         using var doc = JsonDocument.Parse(body);
-        Assert.False(doc.RootElement.TryGetProperty("evaluation_contexts", out _));
+
+        if (expectedEvaluationContexts is null)
+        {
+            Assert.False(doc.RootElement.TryGetProperty("evaluation_contexts", out _));
+        }
+        else
+        {
+            var evaluationContexts = doc.RootElement.GetProperty("evaluation_contexts")
+                .EnumerateArray()
+                .Select(e => e.GetString() ?? string.Empty)
+                .ToArray();
+            Assert.Equal(expectedEvaluationContexts, evaluationContexts);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds SDK-level feature flag evaluation contexts to PostHog .NET so `/flags` requests can be scoped to the application, platform, or product area that should evaluate a flag.

This matches the existing cross-SDK behavior in PostHog JS/Node and Android/server: configured contexts are sent as top-level `evaluation_contexts`, while null or empty configuration omits the field.

Resolves https://github.com/PostHog/posthog-dotnet/issues/202

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj -f net8.0 --filter "FullyQualifiedName~FeatureFlagEvaluationsTests|FullyQualifiedName~RegistrationTests"`

Also ran the full net8.0 unit suite locally; it currently has 2 unrelated existing error-tracking failures in `PostHogClientTests` outside this PR's diff.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
