### PR TITLE
chore: validate PR titles with conventional commits

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,25 @@
+name: Lint PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-pr:
+    name: Validate PR title against Conventional Commits
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # pin v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,12 +15,7 @@ concurrency:
 jobs:
   lint-pr:
     name: Validate PR title against Conventional Commits
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # pin v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+    uses: PostHog/.github/.github/workflows/semantic-pr-title.yml@926dd076f0c796f7531177ae5cfcf1cf7cf0aeb3

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+      - reopened
       - synchronize
 
 concurrency:


### PR DESCRIPTION
## :bulb: Motivation and Context

Our changelog automation uses merged PR titles to determine changelog candidates/entries. Enforcing Conventional Commit PR titles across SDK repos keeps titles structured and easier to classify consistently.

## :green_heart: How did you test it?

- Parsed the new workflow YAML locally with PyYAML.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] No changeset/Sampo entry needed for this CI-only change.
