### PR TITLE
fix: no-op on PostHog API failures

### DIFF
--- a/.changeset/noop-api-failures.md
+++ b/.changeset/noop-api-failures.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Return no-op results instead of throwing from public APIs when PostHog API calls fail.

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -1189,7 +1189,7 @@ public sealed class PostHogClient : IPostHogClient
         {
             await _asyncBatchHandler.FlushAsync();
         }
-        catch (Exception e) when (e is not OperationCanceledException)
+        catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
         {
             _logger.LogErrorApiCallFailed(e, nameof(FlushAsync));
         }

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -23,7 +23,6 @@ public sealed class PostHogClient : IPostHogClient
     readonly IFeatureFlagCache _featureFlagsCache;
     readonly MemoryCache _featureFlagCalledEventCache;
     static readonly ApiResult NoOpApiResult = new(0);
-    static readonly Task<ApiResult> NoOpApiResultTask = Task.FromResult(NoOpApiResult);
     static readonly IReadOnlyDictionary<string, FeatureFlag> EmptyFeatureFlags = new Dictionary<string, FeatureFlag>(0);
 
     readonly TimeProvider _timeProvider;
@@ -173,7 +172,15 @@ public sealed class PostHogClient : IPostHogClient
             return NoOpApiResult;
         }
 
-        return await _apiClient.AliasAsync(previousId, newId, cancellationToken);
+        try
+        {
+            return await _apiClient.AliasAsync(previousId, newId, cancellationToken);
+        }
+        catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
+        {
+            _logger.LogErrorApiCallFailed(e, nameof(AliasAsync));
+            return NoOpApiResult;
+        }
     }
 
     /// <inheritdoc/>
@@ -188,15 +195,23 @@ public sealed class PostHogClient : IPostHogClient
             return NoOpApiResult;
         }
 
-        return await _apiClient.IdentifyAsync(
-            distinctId,
-            personPropertiesToSet,
-            personPropertiesToSetOnce,
-            cancellationToken);
+        try
+        {
+            return await _apiClient.IdentifyAsync(
+                distinctId,
+                personPropertiesToSet,
+                personPropertiesToSetOnce,
+                cancellationToken);
+        }
+        catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
+        {
+            _logger.LogErrorApiCallFailed(e, nameof(IdentifyAsync));
+            return NoOpApiResult;
+        }
     }
 
     /// <inheritdoc/>
-    public Task<ApiResult> GroupIdentifyAsync(
+    public async Task<ApiResult> GroupIdentifyAsync(
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
@@ -204,14 +219,22 @@ public sealed class PostHogClient : IPostHogClient
     {
         if (CheckDisabledAndLog(nameof(GroupIdentifyAsync)))
         {
-            return NoOpApiResultTask;
+            return NoOpApiResult;
         }
 
-        return _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken);
+        try
+        {
+            return await _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken);
+        }
+        catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
+        {
+            _logger.LogErrorApiCallFailed(e, nameof(GroupIdentifyAsync));
+            return NoOpApiResult;
+        }
     }
 
     /// <inheritdoc/>
-    public Task<ApiResult> GroupIdentifyAsync(
+    public async Task<ApiResult> GroupIdentifyAsync(
         string distinctId,
         string type,
         StringOrValue<int> key,
@@ -220,10 +243,18 @@ public sealed class PostHogClient : IPostHogClient
     {
         if (CheckDisabledAndLog(nameof(GroupIdentifyAsync)))
         {
-            return NoOpApiResultTask;
+            return NoOpApiResult;
         }
 
-        return _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken, distinctId);
+        try
+        {
+            return await _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken, distinctId);
+        }
+        catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
+        {
+            _logger.LogErrorApiCallFailed(e, nameof(GroupIdentifyAsync));
+            return NoOpApiResult;
+        }
     }
 
     /// <inheritdoc/>
@@ -510,7 +541,7 @@ public sealed class PostHogClient : IPostHogClient
             return null;
         }
 
-        LocalEvaluator? localEvaluator;
+        LocalEvaluator? localEvaluator = null;
         try
         {
             localEvaluator = await _featureFlagsLoader.GetFeatureFlagsForLocalEvaluationAsync(cancellationToken);
@@ -519,6 +550,10 @@ public sealed class PostHogClient : IPostHogClient
         {
             _logger.LogWarningQuotaExceeded(e);
             return null;
+        }
+        catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
+        {
+            _logger.LogErrorFailedToLoadFeatureFlags(e);
         }
 
         FeatureFlag? response = null;
@@ -928,6 +963,12 @@ public sealed class PostHogClient : IPostHogClient
                 errors.Add(FeatureFlagError.QuotaLimited);
                 fallbackToRemote = false;
             }
+            catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
+            {
+                _logger.LogErrorFailedToLoadFeatureFlags(e);
+                errors.Add(FeatureFlagError.UnknownError);
+                fallbackToRemote = options is not { OnlyEvaluateLocally: true };
+            }
         }
 
         // 2. Remote pass — only if we still need it.
@@ -1040,6 +1081,14 @@ public sealed class PostHogClient : IPostHogClient
                 _logger.LogWarningQuotaExceeded(e);
                 return EmptyFeatureFlags;
             }
+            catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
+            {
+                _logger.LogErrorFailedToLoadFeatureFlags(e);
+                if (options is { OnlyEvaluateLocally: true })
+                {
+                    return EmptyFeatureFlags;
+                }
+            }
         }
 
         try
@@ -1121,12 +1170,10 @@ public sealed class PostHogClient : IPostHogClient
         catch (ApiException e) when (e.ErrorType is "quota_limited")
         {
             _logger.LogWarningQuotaExceeded(e);
-            throw;
         }
         catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
         {
             _logger.LogErrorFailedToLoadFeatureFlags(e);
-            throw;
         }
     }
 
@@ -1138,7 +1185,14 @@ public sealed class PostHogClient : IPostHogClient
             return;
         }
 
-        await _asyncBatchHandler.FlushAsync();
+        try
+        {
+            await _asyncBatchHandler.FlushAsync();
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            _logger.LogErrorApiCallFailed(e, nameof(FlushAsync));
+        }
     }
 
     /// <inheritdoc/>
@@ -1161,6 +1215,11 @@ public sealed class PostHogClient : IPostHogClient
         catch (ApiException e) when (e.ErrorType is "quota_limited")
         {
             _logger.LogWarningQuotaExceeded(e);
+            return null;
+        }
+        catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
+        {
+            _logger.LogErrorFailedToLoadFeatureFlags(e);
             return null;
         }
     }
@@ -1361,4 +1420,10 @@ internal static partial class PostHogClientLoggerExtensions
         Level = LogLevel.Warning,
         Message = "[FEATURE FLAGS] distinctId is required to evaluate feature flags. Pass a distinctId explicitly or use PostHog request context for the current request.")]
     public static partial void LogWarningMissingFeatureFlagDistinctId(this ILogger<PostHogClient> logger);
+
+    [LoggerMessage(
+        EventId = 24,
+        Level = LogLevel.Error,
+        Message = "PostHog API call failed in {MethodName}; returning a no-op result.")]
+    public static partial void LogErrorApiCallFailed(this ILogger<PostHogClient> logger, Exception exception, string methodName);
 }

--- a/tests/UnitTests/Features/ETagSupportTests.cs
+++ b/tests/UnitTests/Features/ETagSupportTests.cs
@@ -154,9 +154,8 @@ public class ETagSupportTests
 
         await client.LoadFeatureFlagsAsync(CancellationToken.None); // Stores ETag
 
-        // This should throw quota_limited error and clear ETag
-        await Assert.ThrowsAsync<ApiException>(
-            () => client.LoadFeatureFlagsAsync(CancellationToken.None));
+        // Quota-limited errors should be swallowed by the public SDK method, while still clearing the ETag.
+        await client.LoadFeatureFlagsAsync(CancellationToken.None);
 
         // Next request should not have If-None-Match header (ETag was cleared)
         await client.LoadFeatureFlagsAsync(CancellationToken.None);

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -1103,52 +1103,115 @@ public class TheCaptureExceptionMethod
     [Fact]
     public async Task CaptureExceptionCauseIOFailureEmptyContext()
     {
-        FileStream? lockHandle = null;
-        var (container, requestHandler, client) = CreateClient();
+        var (_, requestHandler, client) = CreateClient();
+        var compiledThrower = await CreateDivideByZeroExceptionWithTempSourceFileAsync();
 
         try
         {
-            try
+            // Lock the source file exclusively so File.ReadAllLines(sourcePath) will throw IOException
+            // and as result frames will not contain source code context. Use a temp file so parallel
+            // target-framework test runs do not contend over this test source file.
+            await using var lockHandle = new FileStream(
+                compiledThrower.SourcePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.None);
+
+            client.CaptureException(compiledThrower.Exception, "some-distinct-id");
+            await client.FlushAsync();
+
+            var (_, batchItem, props) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: true));
+            var divideByZeroException = GetExceptionOfType(props, "System.DivideByZeroException");
+            var frames = GetStackFrames(divideByZeroException);
+
+            Assert.True(File.Exists(compiledThrower.SourcePath));
+            Assert.Equal("$exception", batchItem.GetProperty("event").GetString());
+
+            var sourceFrame = frames.FirstOrDefault(f =>
+                f.TryGetProperty("abs_path", out var absPath) &&
+                string.Equals(absPath.GetString(), compiledThrower.SourcePath, StringComparison.Ordinal));
+
+            // In Release builds, stack frames may not include source file paths due
+            // to JIT optimizations, making this scenario impossible to reproduce.
+            if (sourceFrame.ValueKind is JsonValueKind.Undefined)
             {
-                var zero = 0;
-                var result = 1 / zero;
+                return;
             }
-            catch (DivideByZeroException ex)
-            {
-                var st = new System.Diagnostics.StackTrace(ex, true);
-                var path = st.GetFrames()
-                    .Select(f => f?.GetFileName())
-                    .FirstOrDefault(p => !string.IsNullOrEmpty(p) && File.Exists(p));
 
-                // In Release builds, stack frames may not include source file paths due
-                // to JIT optimizations, making this scenario impossible to reproduce.
-                if (path is null)
-                {
-                    return;
-                }
-
-                // Lock the source file exclusively so File.ReadAllLines(path) will throw IOException
-                // and as result frames will not contain source code context
-                lockHandle = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
-
-                client.CaptureException(ex, "some-distinct-id");
-                await client.FlushAsync();
-
-                var received = requestHandler.GetReceivedRequestBody(indented: true);
-                var (_, batchItem, props) = ParseSingleEvent(received);
-                var divideByZeroException = GetExceptionOfType(props, "System.DivideByZeroException");
-                var frames = GetStackFrames(divideByZeroException);
-
-                Assert.True(File.Exists(path));
-                Assert.Equal("$exception", batchItem.GetProperty("event").GetString());
-                AssertContextEmpty(frames[0]);
-            }
+            AssertContextEmpty(sourceFrame);
         }
         finally
         {
-            if (lockHandle != null)
+            File.Delete(compiledThrower.SourcePath);
+        }
+    }
+
+    private static async Task<(string SourcePath, DivideByZeroException Exception, AssemblyLoadContext LoadContext)>
+        CreateDivideByZeroExceptionWithTempSourceFileAsync()
+    {
+        var sourcePath = Path.Combine(Path.GetTempPath(), $"PostHogClientTests-{Guid.NewGuid():N}.cs");
+        var code =
+            """
+            using System;
+            public static class Thrower
             {
-                await lockHandle.DisposeAsync();
+                public static void Boom()
+                {
+                    int zero = 0;
+                    var _ = 1 / zero;
+                }
+            }
+            """;
+
+        await File.WriteAllTextAsync(sourcePath, code, Encoding.UTF8);
+
+        var shouldDeleteSource = true;
+        try
+        {
+            var parse = CSharpParseOptions.Default;
+            var tree = CSharpSyntaxTree.ParseText(SourceText.From(code, Encoding.UTF8), parse, path: sourcePath);
+            var trustedPlatformAssemblies = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!).Split(Path.PathSeparator);
+
+            var refs = trustedPlatformAssemblies
+                .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                .GroupBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase)
+                .Select(g => MetadataReference.CreateFromFile(g.First()));
+
+            var comp = CSharpCompilation.Create(
+                $"ThrowerAsm{Guid.NewGuid():N}",
+                [tree],
+                refs,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Debug));
+
+            using var pe = new MemoryStream();
+            using var pdb = new MemoryStream();
+            var emit = comp.Emit(pe, pdb, options: new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb));
+            Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+
+            pe.Position = 0;
+            pdb.Position = 0;
+
+            var assemblyLoadContext = new AssemblyLoadContext($"ThrowerCtx{Guid.NewGuid():N}", isCollectible: true);
+            var assembly = assemblyLoadContext.LoadFromStream(pe, pdb);
+            var boom = assembly.GetType("Thrower")!.GetMethod("Boom", BindingFlags.Public | BindingFlags.Static)!;
+
+            try
+            {
+                boom.Invoke(null, null);
+            }
+            catch (TargetInvocationException tie) when (tie.InnerException is DivideByZeroException ex)
+            {
+                shouldDeleteSource = false;
+                return (sourcePath, ex, assemblyLoadContext);
+            }
+
+            throw new InvalidOperationException("Expected Thrower.Boom to throw a DivideByZeroException.");
+        }
+        finally
+        {
+            if (shouldDeleteSource)
+            {
+                File.Delete(sourcePath);
             }
         }
     }

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS0618 // Tests/samples retain coverage of the deprecated single-flag API surface.
+using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
@@ -1598,6 +1599,84 @@ public class TheDisabledClient
         var errorLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Error);
         Assert.DoesNotContain(errorLogs, log => log.EventId.Id == 14);
     }
+}
+
+public class TheApiFailureNoOpBehavior
+{
+    [Fact]
+    public async Task DirectIngestionMethodsReturnNoOpResultOnApiError()
+    {
+        var container = new TestContainer();
+        var aliasHandler = container.FakeHttpMessageHandler.AddResponse(
+            new Uri("https://us.i.posthog.com/capture"),
+            HttpMethod.Post,
+            UnauthorizedResponse());
+        var identifyHandler = container.FakeHttpMessageHandler.AddResponse(
+            new Uri("https://us.i.posthog.com/capture"),
+            HttpMethod.Post,
+            UnauthorizedResponse());
+        var groupHandler = container.FakeHttpMessageHandler.AddResponse(
+            new Uri("https://us.i.posthog.com/capture"),
+            HttpMethod.Post,
+            UnauthorizedResponse());
+        var groupWithDistinctIdHandler = container.FakeHttpMessageHandler.AddResponse(
+            new Uri("https://us.i.posthog.com/capture"),
+            HttpMethod.Post,
+            UnauthorizedResponse());
+        var client = container.Activate<PostHogClient>();
+
+        var aliasResult = await client.AliasAsync("previous-id", "new-id", CancellationToken.None);
+        var identifyResult = await client.IdentifyAsync("distinct-id");
+        var groupResult = await client.GroupIdentifyAsync("organization", "id:5", null, CancellationToken.None);
+        var groupWithDistinctIdResult = await client.GroupIdentifyAsync("distinct-id", "organization", "id:5", null, CancellationToken.None);
+
+        Assert.Equal(0, aliasResult.Status);
+        Assert.Equal(0, identifyResult.Status);
+        Assert.Equal(0, groupResult.Status);
+        Assert.Equal(0, groupWithDistinctIdResult.Status);
+        Assert.Single(aliasHandler.ReceivedRequests);
+        Assert.Single(identifyHandler.ReceivedRequests);
+        Assert.Single(groupHandler.ReceivedRequests);
+        Assert.Single(groupWithDistinctIdHandler.ReceivedRequests);
+    }
+
+    [Fact]
+    public async Task FlushAsyncDoesNotThrowOnApiError()
+    {
+        var container = new TestContainer();
+        var batchHandler = container.FakeHttpMessageHandler.AddResponse(
+            new Uri("https://us.i.posthog.com/batch"),
+            HttpMethod.Post,
+            UnauthorizedResponse());
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(client.Capture("distinct-id", "some-event"));
+        await client.FlushAsync();
+
+        Assert.Single(batchHandler.ReceivedRequests);
+    }
+
+    [Fact]
+    public async Task LoadFeatureFlagsAsyncDoesNotThrowOnApiError()
+    {
+        var container = new TestContainer("fake-personal-api-key");
+        var localEvaluationHandler = container.FakeHttpMessageHandler.AddResponse(
+            FakeHttpMessageHandlerExtensions.LocalEvaluationUrl,
+            HttpMethod.Get,
+            UnauthorizedResponse());
+        var client = container.Activate<PostHogClient>();
+
+        await client.LoadFeatureFlagsAsync();
+
+        Assert.Single(localEvaluationHandler.ReceivedRequests);
+    }
+
+    static HttpResponseMessage UnauthorizedResponse() => new(HttpStatusCode.Unauthorized)
+    {
+        Content = new StringContent("""
+            {"detail":"Invalid project token"}
+            """, Encoding.UTF8, "application/json")
+    };
 }
 
 public class ThePersonalApiKeyProtectedMethods


### PR DESCRIPTION
## :bulb: Motivation and Context

The .NET SDK should not crash the host application when PostHog is non-operational, including invalid project tokens or API/auth failures. Some public methods awaited API calls directly and could surface exceptions to the caller.

Changes:
- Return `ApiResult(0)` from direct ingestion APIs when PostHog API calls fail.
- Swallow/log API failures from `FlushAsync`, `LoadFeatureFlagsAsync`, and local feature flag loading paths while returning safe defaults.
- Update ETag quota-limit expectations to match no-throw public API behavior.
- Add regression coverage for direct ingestion, flush, and local flag loading API failures.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --no-restore --filter "FullyQualifiedName~TheApiFailureNoOpBehavior|FullyQualifiedName~TheDisabledClient|FullyQualifiedName~TheLoadFeatureFlagsAsyncMethod|FullyQualifiedName~ETagSupport"`
- `dotnet test tests/UnitTests/UnitTests.csproj --no-restore --filter "FullyQualifiedName~TheQuotaLimitBehavior|FullyQualifiedName~FeatureFlagsTests"`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
