### PR TITLE
feat(flags): support early_exit in local evaluation

### DIFF
--- a/.changeset/feature-flag-early-exit.md
+++ b/.changeset/feature-flag-early-exit.md
@@ -1,0 +1,5 @@
+---
+"PostHog": minor
+---
+
+Support the `early_exit` filter option in local feature flag evaluation, mirroring the server-side evaluation engine. When a flag's `filters.early_exit` is `true` and a condition group's property filters match (or the group has none) but the rollout percentage excludes the user, evaluation stops and the flag returns a definitive disabled result instead of falling through to later condition groups. A pure property-filter mismatch always falls through, even when `early_exit` is enabled. When the field is absent or `false`, existing behavior is preserved.

--- a/src/PostHog/Api/LocalEvaluationApiResult.cs
+++ b/src/PostHog/Api/LocalEvaluationApiResult.cs
@@ -146,6 +146,15 @@ internal record FeatureFlagFilters
     public int? AggregationGroupTypeIndex { get; init; }
 
     /// <summary>
+    /// When <c>true</c>, local condition evaluation stops and returns a definitive disabled result
+    /// as soon as a condition group's property filters match (or the group has no property filters)
+    /// but the rollout percentage excludes the user, instead of falling through to later condition
+    /// groups. Mirrors the server-side Rust evaluation engine. Defaults to <c>false</c> when absent.
+    /// </summary>
+    [JsonPropertyName("early_exit")]
+    public bool EarlyExit { get; init; }
+
+    /// <summary>
     /// Compares this instance to another <see cref="FeatureFlagFilters"/> for equality.
     /// </summary>
     /// <remarks>
@@ -168,14 +177,15 @@ internal record FeatureFlagFilters
         return Groups.ListsAreEqual(other.Groups)
                && Payloads.DictionariesAreEqual(other.Payloads)
                && Multivariate == other.Multivariate
-               && AggregationGroupTypeIndex == other.AggregationGroupTypeIndex;
+               && AggregationGroupTypeIndex == other.AggregationGroupTypeIndex
+               && EarlyExit == other.EarlyExit;
     }
 
     /// <summary>
     /// Serves as the default hash function.
     /// </summary>
     /// <returns>A hash code for the current object.</returns>
-    public override int GetHashCode() => HashCode.Combine(Groups, Payloads, Multivariate, AggregationGroupTypeIndex);
+    public override int GetHashCode() => HashCode.Combine(Groups, Payloads, Multivariate, AggregationGroupTypeIndex, EarlyExit);
 }
 
 /// <summary>

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -269,66 +269,38 @@ internal sealed class LocalEvaluator
 
         foreach (var condition in flagConditions)
         {
-            try
+            // Per-condition aggregation overrides only when the condition explicitly
+            // sets its own AggregationGroupTypeIndex (mixed targeting). When absent,
+            // fall back to the flag-level aggregation so existing pure person and
+            // pure group flags keep their original behavior.
+            var conditionAggregation = condition.AggregationGroupTypeIndex ?? flagAggregation;
+
+            var effectiveProperties = properties;
+            var effectiveBucketingId = distinctId;
+
+            // The condition explicitly sets its own aggregation, different from the
+            // flag level. Re-resolve properties and bucketing id from the condition's
+            // group so this condition evaluates against that group.
+            // conditionAggregation is non-null here: if it were null and flagAggregation
+            // were also null they'd be equal, and the only way conditionAggregation can
+            // be null at all (after the ?? above) is that case.
+            if (conditionAggregation != flagAggregation)
             {
-                // Per-condition aggregation overrides only when the condition explicitly
-                // sets its own AggregationGroupTypeIndex (mixed targeting). When absent,
-                // fall back to the flag-level aggregation so existing pure person and
-                // pure group flags keep their original behavior.
-                var conditionAggregation = condition.AggregationGroupTypeIndex ?? flagAggregation;
-
-                var effectiveProperties = properties;
-                var effectiveBucketingId = distinctId;
-
-                // The condition explicitly sets its own aggregation, different from the
-                // flag level. Re-resolve properties and bucketing id from the condition's
-                // group so this condition evaluates against that group.
-                // conditionAggregation is non-null here: if it were null and flagAggregation
-                // were also null they'd be equal, and the only way conditionAggregation can
-                // be null at all (after the ?? above) is that case.
-                if (conditionAggregation != flagAggregation)
+                if (!_groupTypeMapping.TryGetValue(conditionAggregation!.Value, out var groupType)
+                    || groups is null
+                    || !groups.TryGetGroup(groupType, out var group))
                 {
-                    if (!_groupTypeMapping.TryGetValue(conditionAggregation!.Value, out var groupType)
-                        || groups is null
-                        || !groups.TryGetGroup(groupType, out var group))
-                    {
-                        // Skip this condition: group type unknown or not passed in.
-                        continue;
-                    }
-                    effectiveProperties = group.Properties;
-                    effectiveBucketingId = group.GroupKey;
-                }
-
-                var conditionResult = EvaluateConditionMatch(flag, effectiveBucketingId, condition, effectiveProperties, evaluationCache, groups);
-
-                // When early_exit is enabled and the condition's property filters matched (or
-                // there were none) but the rollout excluded the user, stop evaluating later
-                // condition groups and return a definitive disabled result. Mirrors the
-                // server-side Rust evaluation engine. A pure property-filter mismatch always
-                // falls through to the next condition group, even when early_exit is enabled.
-                if (earlyExit && conditionResult == ConditionMatchResult.OutOfRolloutBound)
-                {
-                    if (isInconclusive)
-                    {
-                        throw new InconclusiveMatchException("Can't determine if feature flag is enabled or not with given properties");
-                    }
-                    return false;
-                }
-
-                if (conditionResult != ConditionMatchResult.Match)
-                {
+                    // Skip this condition: group type unknown or not passed in.
                     continue;
                 }
+                effectiveProperties = group.Properties;
+                effectiveBucketingId = group.GroupKey;
+            }
 
-                var variantOverride = condition.Variant;
-                var variant = variantOverride is not null
-                              && flagVariants.Select(v => v.Key).Contains(variantOverride)
-                    ? variantOverride
-                    : GetMatchingVariant(flag, effectiveBucketingId);
-
-                return variant is not null
-                    ? new StringOrValue<bool>(variant)
-                    : true;
+            ConditionMatchResult? conditionResult = null;
+            try
+            {
+                conditionResult = EvaluateConditionMatch(flag, effectiveBucketingId, condition, effectiveProperties, evaluationCache, groups);
             }
             catch (RequiresServerEvaluationException)
             {
@@ -341,6 +313,43 @@ internal sealed class LocalEvaluator
                 // Track that we had an inconclusive match, but try other conditions
                 isInconclusive = true;
             }
+
+            if (conditionResult is null)
+            {
+                // EvaluateConditionMatch threw InconclusiveMatchException above.
+                continue;
+            }
+
+            // When early_exit is enabled and the condition's property filters matched (or
+            // there were none) but the rollout excluded the user, stop evaluating later
+            // condition groups and return a definitive disabled result. Mirrors the
+            // server-side Rust evaluation engine. A pure property-filter mismatch always
+            // falls through to the next condition group, even when early_exit is enabled.
+            // This check is intentionally outside the try-catch so the throw propagates
+            // to the caller and isn't re-caught as a regular inconclusive match.
+            if (earlyExit && conditionResult == ConditionMatchResult.OutOfRolloutBound)
+            {
+                if (isInconclusive)
+                {
+                    throw new InconclusiveMatchException("Can't determine if feature flag is enabled or not with given properties");
+                }
+                return false;
+            }
+
+            if (conditionResult != ConditionMatchResult.Match)
+            {
+                continue;
+            }
+
+            var variantOverride = condition.Variant;
+            var variant = variantOverride is not null
+                          && flagVariants.Select(v => v.Key).Contains(variantOverride)
+                ? variantOverride
+                : GetMatchingVariant(flag, effectiveBucketingId);
+
+            return variant is not null
+                ? new StringOrValue<bool>(variant)
+                : true;
         }
 
         if (isInconclusive)

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -301,18 +301,18 @@ internal sealed class LocalEvaluator
 
                 var conditionResult = EvaluateConditionMatch(flag, effectiveBucketingId, condition, effectiveProperties, evaluationCache, groups);
 
+                // When early_exit is enabled and the condition's property filters matched (or
+                // there were none) but the rollout excluded the user, stop evaluating later
+                // condition groups and return a definitive disabled result. Mirrors the
+                // server-side Rust evaluation engine. A pure property-filter mismatch always
+                // falls through to the next condition group, even when early_exit is enabled.
+                if (earlyExit && conditionResult == ConditionMatchResult.OutOfRolloutBound)
+                {
+                    return false;
+                }
+
                 if (conditionResult != ConditionMatchResult.Match)
                 {
-                    // When early_exit is enabled and the condition's property filters matched (or
-                    // there were none) but the rollout excluded the user, stop evaluating later
-                    // condition groups and return a definitive disabled result. Mirrors the
-                    // server-side Rust evaluation engine. A pure property-filter mismatch always
-                    // falls through to the next condition group, even when early_exit is enabled.
-                    if (earlyExit && conditionResult == ConditionMatchResult.OutOfRolloutBound)
-                    {
-                        return false;
-                    }
-
                     continue;
                 }
 

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -338,7 +338,14 @@ internal sealed class LocalEvaluator
             catch (InconclusiveMatchException)
             {
                 // Evaluation error (bad regex, invalid date, missing property, etc.)
-                // Track that we had an inconclusive match, but try other conditions
+                // If early_exit is enabled and a prior condition was already inconclusive,
+                // we cannot safely skip to later groups — re-throw so the caller falls back
+                // to the server, which mirrors what would have happened had the rollout
+                // boundary short-circuited first.
+                if (earlyExit && isInconclusive)
+                {
+                    throw new InconclusiveMatchException("Can't determine if feature flag is enabled or not with given properties");
+                }
                 isInconclusive = true;
             }
         }

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -308,6 +308,10 @@ internal sealed class LocalEvaluator
                 // falls through to the next condition group, even when early_exit is enabled.
                 if (earlyExit && conditionResult == ConditionMatchResult.OutOfRolloutBound)
                 {
+                    if (isInconclusive)
+                    {
+                        throw new InconclusiveMatchException("Can't determine if feature flag is enabled or not with given properties");
+                    }
                     return false;
                 }
 

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -338,14 +338,7 @@ internal sealed class LocalEvaluator
             catch (InconclusiveMatchException)
             {
                 // Evaluation error (bad regex, invalid date, missing property, etc.)
-                // If early_exit is enabled and a prior condition was already inconclusive,
-                // we cannot safely skip to later groups — re-throw so the caller falls back
-                // to the server, which mirrors what would have happened had the rollout
-                // boundary short-circuited first.
-                if (earlyExit && isInconclusive)
-                {
-                    throw new InconclusiveMatchException("Can't determine if feature flag is enabled or not with given properties");
-                }
+                // Track that we had an inconclusive match, but try other conditions
                 isInconclusive = true;
             }
         }

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -263,6 +263,7 @@ internal sealed class LocalEvaluator
         var filters = flag.Filters;
         var flagConditions = filters?.Groups ?? [];
         var flagAggregation = filters?.AggregationGroupTypeIndex;
+        var earlyExit = filters?.EarlyExit ?? false;
         var isInconclusive = false;
         var flagVariants = filters?.Multivariate?.Variants ?? [];
 
@@ -298,10 +299,20 @@ internal sealed class LocalEvaluator
                     effectiveBucketingId = group.GroupKey;
                 }
 
-                // if any one condition resolves to True, we can short circuit and return
-                // the matching variant
-                if (!IsConditionMatch(flag, effectiveBucketingId, condition, effectiveProperties, evaluationCache, groups))
+                var conditionResult = EvaluateConditionMatch(flag, effectiveBucketingId, condition, effectiveProperties, evaluationCache, groups);
+
+                if (conditionResult != ConditionMatchResult.Match)
                 {
+                    // When early_exit is enabled and the condition's property filters matched (or
+                    // there were none) but the rollout excluded the user, stop evaluating later
+                    // condition groups and return a definitive disabled result. Mirrors the
+                    // server-side Rust evaluation engine. A pure property-filter mismatch always
+                    // falls through to the next condition group, even when early_exit is enabled.
+                    if (earlyExit && conditionResult == ConditionMatchResult.OutOfRolloutBound)
+                    {
+                        return false;
+                    }
+
                     continue;
                 }
 
@@ -338,7 +349,33 @@ internal sealed class LocalEvaluator
         return false;
     }
 
-    bool IsConditionMatch(
+    /// <summary>
+    /// The tri-state outcome of evaluating a single condition group, mirroring the server-side
+    /// Rust evaluation engine. Used to distinguish a property-filter mismatch from a
+    /// rollout-percentage exclusion so that the <c>early_exit</c> behavior can short-circuit
+    /// only on the latter.
+    /// </summary>
+    enum ConditionMatchResult
+    {
+        /// <summary>
+        /// Property filters matched (or there were none) AND the rollout included the user.
+        /// </summary>
+        Match,
+
+        /// <summary>
+        /// A property filter did not match. Always falls through to the next condition group,
+        /// even when <c>early_exit</c> is enabled.
+        /// </summary>
+        NoMatch,
+
+        /// <summary>
+        /// Property filters matched (or there were none) but the rollout excluded the user.
+        /// When <c>early_exit</c> is enabled, this produces a definitive disabled result.
+        /// </summary>
+        OutOfRolloutBound
+    }
+
+    ConditionMatchResult EvaluateConditionMatch(
         LocalFeatureFlag flag,
         string distinctId,
         FeatureFlagGroup condition,
@@ -356,17 +393,20 @@ internal sealed class LocalEvaluator
                     _ => MatchProperty(property, distinctId, properties)
                 }).Any(isMatch => !isMatch))
             {
-                return false;
+                return ConditionMatchResult.NoMatch;
             }
         }
 
+        // Property filters matched (or there were none). Now check the rollout percentage.
         if (rolloutPercentage is 100)
         {
-            return true;
+            return ConditionMatchResult.Match;
         }
 
         var hashValue = Hash(flag.Key, distinctId);
-        return !(hashValue > rolloutPercentage / 100.0);
+        return hashValue > rolloutPercentage / 100.0
+            ? ConditionMatchResult.OutOfRolloutBound
+            : ConditionMatchResult.Match;
     }
 
     static string? GetMatchingVariant(LocalFeatureFlag flag, string distinctId)

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -2955,4 +2955,85 @@ public class TheEarlyExitBehavior
             distinctId: "1234",
             personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" }));
     }
+
+    [Fact]
+    public void ReturnsMatchWhenMultipleInconclusiveGroupsPrecedeMatchingGroup()
+    {
+        // earlyExit only short-circuits on OutOfRolloutBound — multiple inconclusive groups
+        // followed by a definitive match should still return true.
+        var flags = new LocalEvaluationApiResult
+        {
+            Flags =
+            [
+                new LocalFeatureFlag
+                {
+                    Id = 42,
+                    TeamId = 23,
+                    Name = "early-exit-feature-flag",
+                    Key = "early-exit",
+                    Filters = new FeatureFlagFilters
+                    {
+                        EarlyExit = true,
+                        Groups =
+                        [
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "missing_property_1",
+                                        Value = new PropertyFilterValue("some_value"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            },
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "missing_property_2",
+                                        Value = new PropertyFilterValue("some_value"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            },
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "email",
+                                        Value = new PropertyFilterValue("tyrion@example.com"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            }
+                        ]
+                    }
+                }
+            ],
+            GroupTypeMapping = new Dictionary<string, string>()
+        };
+
+        var localEvaluator = new LocalEvaluator(flags);
+
+        // Two inconclusive groups never hit a rollout boundary, so earlyExit doesn't
+        // short-circuit — the third group matches and returns true.
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
+
+        Assert.True(result.Value);
+    }
 }

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -2705,9 +2705,9 @@ public class TheEarlyExitBehavior
     }
 
     [Theory]
-    [InlineData(true,  "tyrion@example.com",  false)] // matching props + rollout 0 => OUT_OF_ROLLOUT_BOUND, early-exits
-    [InlineData(false, "tyrion@example.com",  true)]  // earlyExit=false => falls through to second group
-    [InlineData(true,  "nobody@example.com",  true)]  // property mismatch => NO_MATCH, always falls through
+    [InlineData(true, "tyrion@example.com", false)] // matching props + rollout 0 => OUT_OF_ROLLOUT_BOUND, early-exits
+    [InlineData(false, "tyrion@example.com", true)]  // earlyExit=false => falls through to second group
+    [InlineData(true, "nobody@example.com", true)]  // property mismatch => NO_MATCH, always falls through
     public void EarlyExitReturnsExpectedResult(bool earlyExit, string firstGroupEmailFilter, bool expected)
     {
         var flags = CreateFlags(

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -2725,6 +2725,57 @@ public class TheEarlyExitBehavior
     }
 
     [Fact]
+    public void EarlyExitDeserializesFromJsonAndEarlyExits()
+    {
+        // Verifies that "early_exit": true round-trips through JSON correctly. A typo in the
+        // [JsonPropertyName] attribute would silently deserialize to false and disable the
+        // feature in production while all object-initializer tests still pass.
+        var json = """
+        {
+            "flags": [
+                {
+                    "id": 42,
+                    "team_id": 23,
+                    "name": "early-exit-feature-flag",
+                    "key": "early-exit",
+                    "active": true,
+                    "filters": {
+                        "early_exit": true,
+                        "groups": [
+                            {
+                                "properties": [
+                                    { "type": "person", "key": "email", "value": "tyrion@example.com", "operator": "exact" }
+                                ],
+                                "rollout_percentage": 0
+                            },
+                            {
+                                "properties": [
+                                    { "type": "person", "key": "email", "value": "tyrion@example.com", "operator": "exact" }
+                                ],
+                                "rollout_percentage": 100
+                            }
+                        ]
+                    }
+                }
+            ],
+            "group_type_mapping": {}
+        }
+        """;
+
+        var flags = JsonSerializer.Deserialize<LocalEvaluationApiResult>(json, JsonSerializerHelper.Options)!;
+        var localEvaluator = new LocalEvaluator(flags);
+
+        // early_exit=true + rollout 0 on first group (OUT_OF_ROLLOUT_BOUND) must short-circuit
+        // and return false, never reaching the second group with rollout 100.
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
+
+        Assert.False(result.Value);
+    }
+
+    [Fact]
     public void FallsThroughToLaterMatchingGroupWhenEarlyExitUnset()
     {
         // Regression: with no `early_exit` field present, existing behavior is preserved and
@@ -2822,6 +2873,81 @@ public class TheEarlyExitBehavior
             ],
             GroupTypeMapping = new Dictionary<string, string>()
         };
+        var localEvaluator = new LocalEvaluator(flags);
+
+        Assert.Throws<InconclusiveMatchException>(() => localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" }));
+    }
+
+    [Fact]
+    public void ThrowsInconclusiveWhenEarlyExitOutOfRolloutHasLaterMatchingGroup()
+    {
+        var flags = new LocalEvaluationApiResult
+        {
+            Flags =
+            [
+                new LocalFeatureFlag
+                {
+                    Id = 42,
+                    TeamId = 23,
+                    Name = "early-exit-feature-flag",
+                    Key = "early-exit",
+                    Filters = new FeatureFlagFilters
+                    {
+                        EarlyExit = true,
+                        Groups =
+                        [
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "missing_property",
+                                        Value = new PropertyFilterValue("some_value"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            },
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "email",
+                                        Value = new PropertyFilterValue("tyrion@example.com"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 0
+                            },
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "email",
+                                        Value = new PropertyFilterValue("tyrion@example.com"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            }
+                        ]
+                    }
+                }
+            ],
+            GroupTypeMapping = new Dictionary<string, string>()
+        };
+
         var localEvaluator = new LocalEvaluator(flags);
 
         Assert.Throws<InconclusiveMatchException>(() => localEvaluator.EvaluateFeatureFlag(

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -2776,4 +2776,25 @@ public class TheEarlyExitBehavior
 
         Assert.True(result.Value);
     }
+
+    // distinctId "1234" with key "early-exit" hashes to ~0.518, so rollout values 0 and 50
+    // both exclude this user, confirming the trigger is rollout exclusion, not rollout == 0.
+    [Theory]
+    [InlineData(0)]
+    [InlineData(50)]
+    public void EarlyExitsForAnyRolloutThatExcludesUser(int firstGroupRollout)
+    {
+        var flags = CreateFlags(
+            earlyExit: true,
+            firstGroupRolloutPercentage: firstGroupRollout,
+            firstGroupEmailFilter: "tyrion@example.com");
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
+
+        Assert.False(result.Value);
+    }
 }

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -2601,3 +2601,179 @@ public class TheMatchesDependencyValueMethod
         Assert.Equal(shouldMatch, result);
     }
 }
+
+public class TheEarlyExitBehavior
+{
+    // Builds a flag with two condition groups. The first group's rollout and property value
+    // are parameterized so we can model OUT_OF_ROLLOUT_BOUND (rollout 0, matching props) vs.
+    // NO_MATCH (rollout 0, non-matching props). The second group always has matching
+    // properties and rollout 100, so it matches if reached.
+    static LocalEvaluationApiResult CreateFlags(
+        bool earlyExit,
+        int firstGroupRolloutPercentage,
+        string firstGroupEmailFilter)
+    {
+        return new LocalEvaluationApiResult
+        {
+            Flags =
+            [
+                new LocalFeatureFlag
+                {
+                    Id = 42,
+                    TeamId = 23,
+                    Name = "early-exit-feature-flag",
+                    Key = "early-exit",
+                    Filters = new FeatureFlagFilters
+                    {
+                        EarlyExit = earlyExit,
+                        Groups =
+                        [
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "email",
+                                        Value = new PropertyFilterValue(firstGroupEmailFilter),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = firstGroupRolloutPercentage
+                            },
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "email",
+                                        Value = new PropertyFilterValue("tyrion@example.com"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            }
+                        ]
+                    }
+                }
+            ],
+            GroupTypeMapping = new Dictionary<string, string>()
+        };
+    }
+
+    static LocalEvaluationApiResult CreateFlagsWithoutEarlyExitField(
+        int firstGroupRolloutPercentage,
+        string firstGroupEmailFilter)
+    {
+        // Round-trips through JSON without an `early_exit` field present, exercising the
+        // default (absent) deserialization path.
+        var json = $$"""
+        {
+            "flags": [
+                {
+                    "id": 42,
+                    "team_id": 23,
+                    "name": "early-exit-feature-flag",
+                    "key": "early-exit",
+                    "active": true,
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [
+                                    { "type": "person", "key": "email", "value": "{{firstGroupEmailFilter}}", "operator": "exact" }
+                                ],
+                                "rollout_percentage": {{firstGroupRolloutPercentage}}
+                            },
+                            {
+                                "properties": [
+                                    { "type": "person", "key": "email", "value": "tyrion@example.com", "operator": "exact" }
+                                ],
+                                "rollout_percentage": 100
+                            }
+                        ]
+                    }
+                }
+            ],
+            "group_type_mapping": {}
+        }
+        """;
+
+        return JsonSerializer.Deserialize<LocalEvaluationApiResult>(json, JsonSerializerHelper.Options)!;
+    }
+
+    [Fact]
+    public void ReturnsFalseWithoutEvaluatingLaterMatchingGroupWhenEarlyExitEnabled()
+    {
+        // First group: matching properties but rollout 0 => OUT_OF_ROLLOUT_BOUND.
+        // Second group: matching properties + rollout 100 => would match if reached.
+        var flags = CreateFlags(
+            earlyExit: true,
+            firstGroupRolloutPercentage: 0,
+            firstGroupEmailFilter: "tyrion@example.com");
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
+
+        Assert.False(result.Value);
+    }
+
+    [Fact]
+    public void FallsThroughToLaterMatchingGroupWhenEarlyExitUnset()
+    {
+        // Regression: with no `early_exit` field present, existing behavior is preserved and
+        // the second matching group makes the flag enabled.
+        var flags = CreateFlagsWithoutEarlyExitField(
+            firstGroupRolloutPercentage: 0,
+            firstGroupEmailFilter: "tyrion@example.com");
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
+
+        Assert.True(result.Value);
+    }
+
+    [Fact]
+    public void FallsThroughToLaterMatchingGroupWhenEarlyExitExplicitlyFalse()
+    {
+        var flags = CreateFlags(
+            earlyExit: false,
+            firstGroupRolloutPercentage: 0,
+            firstGroupEmailFilter: "tyrion@example.com");
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
+
+        Assert.True(result.Value);
+    }
+
+    [Fact]
+    public void DoesNotEarlyExitOnPropertyFilterFailureEvenWhenEnabled()
+    {
+        // First group: NON-matching properties (rollout 0) => NO_MATCH, which always falls
+        // through, even when early_exit is enabled. Second group matches => flag enabled.
+        var flags = CreateFlags(
+            earlyExit: true,
+            firstGroupRolloutPercentage: 0,
+            firstGroupEmailFilter: "nobody@example.com");
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
+
+        Assert.True(result.Value);
+    }
+}

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -2704,15 +2704,16 @@ public class TheEarlyExitBehavior
         return JsonSerializer.Deserialize<LocalEvaluationApiResult>(json, JsonSerializerHelper.Options)!;
     }
 
-    [Fact]
-    public void ReturnsFalseWithoutEvaluatingLaterMatchingGroupWhenEarlyExitEnabled()
+    [Theory]
+    [InlineData(true,  "tyrion@example.com",  false)] // matching props + rollout 0 => OUT_OF_ROLLOUT_BOUND, early-exits
+    [InlineData(false, "tyrion@example.com",  true)]  // earlyExit=false => falls through to second group
+    [InlineData(true,  "nobody@example.com",  true)]  // property mismatch => NO_MATCH, always falls through
+    public void EarlyExitReturnsExpectedResult(bool earlyExit, string firstGroupEmailFilter, bool expected)
     {
-        // First group: matching properties but rollout 0 => OUT_OF_ROLLOUT_BOUND.
-        // Second group: matching properties + rollout 100 => would match if reached.
         var flags = CreateFlags(
-            earlyExit: true,
+            earlyExit: earlyExit,
             firstGroupRolloutPercentage: 0,
-            firstGroupEmailFilter: "tyrion@example.com");
+            firstGroupEmailFilter: firstGroupEmailFilter);
         var localEvaluator = new LocalEvaluator(flags);
 
         var result = localEvaluator.EvaluateFeatureFlag(
@@ -2720,7 +2721,7 @@ public class TheEarlyExitBehavior
             distinctId: "1234",
             personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
 
-        Assert.False(result.Value);
+        Assert.Equal(expected, result.Value);
     }
 
     [Fact]
@@ -2731,42 +2732,6 @@ public class TheEarlyExitBehavior
         var flags = CreateFlagsWithoutEarlyExitField(
             firstGroupRolloutPercentage: 0,
             firstGroupEmailFilter: "tyrion@example.com");
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "early-exit",
-            distinctId: "1234",
-            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
-
-        Assert.True(result.Value);
-    }
-
-    [Fact]
-    public void FallsThroughToLaterMatchingGroupWhenEarlyExitExplicitlyFalse()
-    {
-        var flags = CreateFlags(
-            earlyExit: false,
-            firstGroupRolloutPercentage: 0,
-            firstGroupEmailFilter: "tyrion@example.com");
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "early-exit",
-            distinctId: "1234",
-            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" });
-
-        Assert.True(result.Value);
-    }
-
-    [Fact]
-    public void DoesNotEarlyExitOnPropertyFilterFailureEvenWhenEnabled()
-    {
-        // First group: NON-matching properties (rollout 0) => NO_MATCH, which always falls
-        // through, even when early_exit is enabled. Second group matches => flag enabled.
-        var flags = CreateFlags(
-            earlyExit: true,
-            firstGroupRolloutPercentage: 0,
-            firstGroupEmailFilter: "nobody@example.com");
         var localEvaluator = new LocalEvaluator(flags);
 
         var result = localEvaluator.EvaluateFeatureFlag(

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -2762,4 +2762,71 @@ public class TheEarlyExitBehavior
 
         Assert.False(result.Value);
     }
+
+    [Fact]
+    public void ThrowsInconclusiveWhenEarlyExitMasksInconclusiveCondition()
+    {
+        // Regression: if an earlier condition is inconclusive (missing property) and a later
+        // condition hits OutOfRolloutBound with early_exit=true, the early-exit must not
+        // swallow the prior inconclusive state — it must still fall back to server evaluation.
+        var flags = new LocalEvaluationApiResult
+        {
+            Flags =
+            [
+                new LocalFeatureFlag
+                {
+                    Id = 42,
+                    TeamId = 23,
+                    Name = "early-exit-feature-flag",
+                    Key = "early-exit",
+                    Filters = new FeatureFlagFilters
+                    {
+                        EarlyExit = true,
+                        Groups =
+                        [
+                            // Condition 1: requires a property the caller does not supply
+                            // → InconclusiveMatchException (missing property)
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "missing_property",
+                                        Value = new PropertyFilterValue("some_value"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 100
+                            },
+                            // Condition 2: property matches but rollout excludes the user
+                            // → OutOfRolloutBound (rollout 0, distinctId "1234")
+                            new FeatureFlagGroup
+                            {
+                                Properties =
+                                [
+                                    new PropertyFilter
+                                    {
+                                        Type = FilterType.Person,
+                                        Key = "email",
+                                        Value = new PropertyFilterValue("tyrion@example.com"),
+                                        Operator = ComparisonOperator.Exact
+                                    }
+                                ],
+                                RolloutPercentage = 0
+                            }
+                        ]
+                    }
+                }
+            ],
+            GroupTypeMapping = new Dictionary<string, string>()
+        };
+        var localEvaluator = new LocalEvaluator(flags);
+
+        Assert.Throws<InconclusiveMatchException>(() => localEvaluator.EvaluateFeatureFlag(
+            key: "early-exit",
+            distinctId: "1234",
+            personProperties: new Dictionary<string, object?> { ["email"] = "tyrion@example.com" }));
+    }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog added an "early exit" option to feature flags in the server-side (Rust) evaluation engine, and this has already been ported to posthog-node and posthog-python. This PR ports the same behavior to the .NET SDK's local feature flag evaluation.

When a flag's `filters.early_exit` is `true`, local condition evaluation must stop and return a definitive disabled result as soon as a condition group's property filters match (or the group has no property filters) but the rollout percentage excludes the user — instead of falling through to evaluate later condition groups.

The three per-group outcomes are now modeled explicitly, mirroring the Rust engine:

- **MATCH** — property filters matched (or none) AND rollout included the user → flag matches (existing behavior).
- **NO_MATCH** — a property filter did not match → always continue to the next group, even when `early_exit` is enabled.
- **OUT_OF_ROLLOUT_BOUND** — property filters matched (or none) but the rollout excluded the user → with `early_exit` enabled, return a definitive disabled result immediately.

When `early_exit` is absent or `false`, existing behavior is preserved exactly.

### Changes

- Added the `early_exit` field (`EarlyExit`, JSON `early_exit`, default `false`) to `FeatureFlagFilters`, including equality/hash-code.
- Converted the single-group matcher `IsConditionMatch` (bool) into `EvaluateConditionMatch` returning a tri-state `ConditionMatchResult` enum, distinguishing rollout-exclusion (`hash > rollout/100`) from property-mismatch.
- Short-circuit to `false` in the condition-group loop when `early_exit` is on and the outcome is `OutOfRolloutBound`.

## :green_heart: How did you test it?

Added unit tests in `TheEarlyExitBehavior` covering:

1. `early_exit` enabled → `false` without evaluating a later matching group (first group: matching props + rollout 0; second group: matching props + rollout 100).
2. `early_exit` unset (absent in JSON) → falls through to the matching second group (`true`) — regression.
3. `early_exit` explicitly `false` → falls through (`true`).
4. Property-filter failure (not rollout) does NOT early-exit even when `early_exit` is enabled → falls through (`true`).

All 889 existing unit tests still pass (`dotnet test`, net8.0). Release build is clean across all target frameworks with warnings-as-errors, and `dotnet format --verify-no-changes` reports no formatting issues.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
