### PR TITLE
refactor: reduce dry4dotnet duplication

### DIFF
--- a/.changeset/dry-owls-refactor.md
+++ b/.changeset/dry-owls-refactor.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Refactor duplicate internal SDK code paths without changing public API behavior.

--- a/samples/PostHog.Example.Console/Program.cs
+++ b/samples/PostHog.Example.Console/Program.cs
@@ -149,14 +149,20 @@ static string Prompt(string message)
     return Console.ReadLine()?.Trim() ?? string.Empty;
 }
 
-static async Task RunCaptureExamples(PostHogClient posthog)
+static string StartExampleSection(string title)
 {
     Console.WriteLine("\n" + new string('=', 60));
-    Console.WriteLine("CAPTURE EVENTS");
+    Console.WriteLine(title);
     Console.WriteLine(new string('=', 60));
 
     var distinctId = $"user_{Guid.NewGuid():N}";
     Console.WriteLine($"\nUsing distinct ID: {distinctId}");
+    return distinctId;
+}
+
+static async Task RunCaptureExamples(PostHogClient posthog)
+{
+    var distinctId = StartExampleSection("CAPTURE EVENTS");
 
     // Simple capture
     Console.WriteLine("\n📤 Capturing 'page_view' event…");
@@ -191,12 +197,7 @@ static async Task RunCaptureExamples(PostHogClient posthog)
 
 static async Task RunIdentifyExamples(PostHogClient posthog)
 {
-    Console.WriteLine("\n" + new string('=', 60));
-    Console.WriteLine("IDENTIFY USERS");
-    Console.WriteLine(new string('=', 60));
-
-    var distinctId = $"user_{Guid.NewGuid():N}";
-    Console.WriteLine($"\nUsing distinct ID: {distinctId}");
+    var distinctId = StartExampleSection("IDENTIFY USERS");
 
     // Identify with properties
     Console.WriteLine("\n👤 Identifying user with properties…");
@@ -232,12 +233,7 @@ static async Task RunIdentifyExamples(PostHogClient posthog)
 
 static async Task RunFeatureFlagExamples(PostHogClient posthog)
 {
-    Console.WriteLine("\n" + new string('=', 60));
-    Console.WriteLine("FEATURE FLAGS");
-    Console.WriteLine(new string('=', 60));
-
-    var distinctId = $"user_{Guid.NewGuid():N}";
-    Console.WriteLine($"\nUsing distinct ID: {distinctId}");
+    var distinctId = StartExampleSection("FEATURE FLAGS");
 
     // Check a simple boolean flag
     Console.WriteLine("\n🚩 Checking feature flag 'new-dashboard'…");

--- a/src/PostHog/Capture/CaptureExtensions.cs
+++ b/src/PostHog/Capture/CaptureExtensions.cs
@@ -331,15 +331,22 @@ public static class CaptureExtensions
         string pagePath,
         Dictionary<string, object>? properties,
         bool sendFeatureFlags)
+    {
+        if (!sendFeatureFlags)
+        {
+            return client.CapturePageView(distinctId, pagePath, properties);
+        }
+
 #pragma warning disable CS0618
-        => NotNull(client).CaptureSpecialEvent(
+        return NotNull(client).CaptureSpecialEvent(
             distinctId,
             eventName: "$pageview",
             eventPropertyName: "$current_url",
             eventPropertyValue: pagePath,
             properties,
-            sendFeatureFlags);
+            sendFeatureFlags: true);
 #pragma warning restore CS0618
+    }
 
     /// <summary>
     /// Captures a Page View ($pageview) event.
@@ -516,12 +523,15 @@ public static class CaptureExtensions
         string distinctId,
         string surveyId,
         Dictionary<string, object>? properties)
-        => NotNull(client).CaptureSpecialEvent(
+    {
+        const string eventName = "survey dismissed";
+        return NotNull(client).CaptureSpecialEvent(
             distinctId,
-            eventName: "survey dismissed",
+            eventName,
             eventPropertyName: "$survey_id",
             eventPropertyValue: surveyId,
             properties);
+    }
 
     static bool CaptureSpecialEvent(
         this IPostHogClient client,

--- a/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
+++ b/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
@@ -25,11 +25,7 @@ public static class GroupIdentifyAsyncExtensions
         StringOrValue<int> key,
         string name,
         Dictionary<string, object>? properties)
-    {
-        properties ??= new Dictionary<string, object>();
-        properties["name"] = name;
-        return await NotNull(client).GroupIdentifyAsync(type, key, properties, CancellationToken.None);
-    }
+        => await client.GroupIdentifyAsync(type, key, name, properties, CancellationToken.None);
 
     /// <summary>
     /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
@@ -49,11 +45,7 @@ public static class GroupIdentifyAsyncExtensions
         StringOrValue<int> key,
         string name,
         Dictionary<string, object>? properties)
-    {
-        properties ??= new Dictionary<string, object>();
-        properties["name"] = name;
-        return await NotNull(client).GroupIdentifyAsync(distinctId, type, key, properties, CancellationToken.None);
-    }
+        => await client.GroupIdentifyAsync(distinctId, type, key, name, properties, CancellationToken.None);
 
     /// <summary>
     /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
@@ -73,11 +65,7 @@ public static class GroupIdentifyAsyncExtensions
         string name,
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
-    {
-        properties ??= new Dictionary<string, object>();
-        properties["name"] = name;
-        return await NotNull(client).GroupIdentifyAsync(type, key, properties, cancellationToken);
-    }
+        => await GroupIdentifyWithNameAsync(NotNull(client), distinctId: null, type, key, name, properties, cancellationToken);
 
     /// <summary>
     /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
@@ -99,11 +87,7 @@ public static class GroupIdentifyAsyncExtensions
         string name,
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
-    {
-        properties ??= new Dictionary<string, object>();
-        properties["name"] = name;
-        return await NotNull(client).GroupIdentifyAsync(distinctId, type, key, properties, cancellationToken);
-    }
+        => await GroupIdentifyWithNameAsync(NotNull(client), distinctId, type, key, name, properties, cancellationToken);
 
     /// <summary>
     /// Sets a groups properties, which allows asking questions like "Who are the most active companies"
@@ -147,4 +131,21 @@ public static class GroupIdentifyAsyncExtensions
             key,
             name,
             properties: new Dictionary<string, object>());
+
+    static async Task<ApiResult> GroupIdentifyWithNameAsync(
+        IPostHogClient client,
+        string? distinctId,
+        string type,
+        StringOrValue<int> key,
+        string name,
+        Dictionary<string, object>? properties,
+        CancellationToken cancellationToken)
+    {
+        properties ??= new Dictionary<string, object>();
+        properties["name"] = name;
+
+        return distinctId is null
+            ? await client.GroupIdentifyAsync(type, key, properties, cancellationToken)
+            : await client.GroupIdentifyAsync(distinctId, type, key, properties, cancellationToken);
+    }
 }

--- a/src/PostHog/NoOpPostHogClient.cs
+++ b/src/PostHog/NoOpPostHogClient.cs
@@ -32,7 +32,7 @@ internal sealed class NoOpPostHogClient : IPostHogClient, IFeatureFlagEvaluation
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
-        => GroupIdentifyAsync(string.Empty, type, key, properties, cancellationToken);
+        => NoOpApiResultTask;
 
     public Task<ApiResult> GroupIdentifyAsync(
         string distinctId,
@@ -76,7 +76,7 @@ internal sealed class NoOpPostHogClient : IPostHogClient, IFeatureFlagEvaluation
         GroupCollection? groups,
         FeatureFlagEvaluations? flags,
         DateTimeOffset? timestamp = null)
-        => Capture(distinctId, exception?.GetType().FullName ?? string.Empty, properties, groups, flags, timestamp);
+        => false;
 
     public Task<bool> IsFeatureEnabledAsync(
         string featureKey,

--- a/src/PostHog/NoOpPostHogClient.cs
+++ b/src/PostHog/NoOpPostHogClient.cs
@@ -9,6 +9,7 @@ namespace PostHog.Sdk;
 internal sealed class NoOpPostHogClient : IPostHogClient, IFeatureFlagEvaluationsHost
 {
     static readonly IReadOnlyDictionary<string, FeatureFlag> EmptyFeatureFlags = new Dictionary<string, FeatureFlag>();
+    static readonly Task<ApiResult> NoOpApiResultTask = Task.FromResult(new ApiResult(0));
 
     NoOpPostHogClient()
     {
@@ -17,21 +18,21 @@ internal sealed class NoOpPostHogClient : IPostHogClient, IFeatureFlagEvaluation
     internal static NoOpPostHogClient Instance { get; } = new();
 
     public Task<ApiResult> AliasAsync(string previousId, string newId, CancellationToken cancellationToken)
-        => Task.FromResult(new ApiResult(0));
+        => NoOpApiResultTask;
 
     public Task<ApiResult> IdentifyAsync(
         string distinctId,
         Dictionary<string, object>? personPropertiesToSet,
         Dictionary<string, object>? personPropertiesToSetOnce,
         CancellationToken cancellationToken)
-        => Task.FromResult(new ApiResult(0));
+        => NoOpApiResultTask;
 
     public Task<ApiResult> GroupIdentifyAsync(
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
-        => Task.FromResult(new ApiResult(0));
+        => GroupIdentifyAsync(string.Empty, type, key, properties, cancellationToken);
 
     public Task<ApiResult> GroupIdentifyAsync(
         string distinctId,
@@ -39,7 +40,7 @@ internal sealed class NoOpPostHogClient : IPostHogClient, IFeatureFlagEvaluation
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
-        => Task.FromResult(new ApiResult(0));
+        => NoOpApiResultTask;
 
     public bool Capture(
         string distinctId,
@@ -48,7 +49,7 @@ internal sealed class NoOpPostHogClient : IPostHogClient, IFeatureFlagEvaluation
         GroupCollection? groups,
         bool sendFeatureFlags,
         DateTimeOffset? timestamp = null)
-        => false;
+        => Capture(distinctId, eventName, properties, groups, flags: null, timestamp);
 
     public bool Capture(
         string distinctId,
@@ -66,7 +67,7 @@ internal sealed class NoOpPostHogClient : IPostHogClient, IFeatureFlagEvaluation
         GroupCollection? groups,
         bool sendFeatureFlags,
         DateTimeOffset? timestamp = null)
-        => false;
+        => CaptureException(exception, distinctId, properties, groups, flags: null, timestamp);
 
     public bool CaptureException(
         Exception exception,
@@ -75,7 +76,7 @@ internal sealed class NoOpPostHogClient : IPostHogClient, IFeatureFlagEvaluation
         GroupCollection? groups,
         FeatureFlagEvaluations? flags,
         DateTimeOffset? timestamp = null)
-        => false;
+        => Capture(distinctId, exception?.GetType().FullName ?? string.Empty, properties, groups, flags, timestamp);
 
     public Task<bool> IsFeatureEnabledAsync(
         string featureKey,

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -216,22 +216,7 @@ public sealed class PostHogClient : IPostHogClient
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
-    {
-        if (CheckDisabledAndLog(nameof(GroupIdentifyAsync)))
-        {
-            return NoOpApiResult;
-        }
-
-        try
-        {
-            return await _apiClient.GroupIdentifyAsync(type, key, properties, cancellationToken);
-        }
-        catch (Exception e) when (e is not ArgumentException and not NullReferenceException and not OperationCanceledException)
-        {
-            _logger.LogErrorApiCallFailed(e, nameof(GroupIdentifyAsync));
-            return NoOpApiResult;
-        }
-    }
+        => await GroupIdentifyCoreAsync(type, key, properties, distinctId: null, cancellationToken);
 
     /// <inheritdoc/>
     public async Task<ApiResult> GroupIdentifyAsync(
@@ -239,6 +224,14 @@ public sealed class PostHogClient : IPostHogClient
         string type,
         StringOrValue<int> key,
         Dictionary<string, object>? properties,
+        CancellationToken cancellationToken)
+        => await GroupIdentifyCoreAsync(type, key, properties, distinctId, cancellationToken);
+
+    async Task<ApiResult> GroupIdentifyCoreAsync(
+        string type,
+        StringOrValue<int> key,
+        Dictionary<string, object>? properties,
+        string? distinctId,
         CancellationToken cancellationToken)
     {
         if (CheckDisabledAndLog(nameof(GroupIdentifyAsync)))

--- a/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
+++ b/tests/TestLibrary/Fakes/FakeHttpMessageHandlerExtensions.cs
@@ -12,14 +12,16 @@ internal static class FakeHttpMessageHandlerExtensions
     static readonly Uri FlagsUrl = new("https://us.i.posthog.com/flags/?v=2");
 
     public static FakeHttpMessageHandler.RequestHandler AddCaptureResponse(this FakeHttpMessageHandler handler) =>
-        handler.AddResponse(
-            new Uri("https://us.i.posthog.com/capture"),
-            HttpMethod.Post,
-            responseBody: new { status = 1 });
+        handler.AddIngestionResponse("capture");
 
     public static FakeHttpMessageHandler.RequestHandler AddBatchResponse(this FakeHttpMessageHandler handler) =>
+        handler.AddIngestionResponse("batch");
+
+    static FakeHttpMessageHandler.RequestHandler AddIngestionResponse(
+        this FakeHttpMessageHandler handler,
+        string endpoint) =>
         handler.AddResponse(
-            new Uri("https://us.i.posthog.com/batch"),
+            new Uri($"https://us.i.posthog.com/{endpoint}"),
             HttpMethod.Post,
             responseBody: new { status = 1 });
 
@@ -156,10 +158,7 @@ internal static class FakeHttpMessageHandlerExtensions
         this FakeHttpMessageHandler handler,
         string key,
         string responseBody) =>
-        handler.AddResponse(
-            new Uri($"https://us.i.posthog.com/api/projects/@current/feature_flags/{key}/remote_config?token=fake-project-token"),
-            HttpMethod.Get,
-            responseBody: responseBody);
+        handler.AddRemoteConfigResponse(key, responseBody);
 
     static T Deserialize<T>(string json) => JsonSerializer.Deserialize<T>(json, JsonSerializerHelper.Options)
         ?? throw new ArgumentException("Json is invalid and deserializes to null", nameof(json));

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -3912,172 +3912,121 @@ public class FeatureFlagErrorTracking
 {
     [Fact]
     public async Task IncludesFlagMissingErrorWhenFlagNotInResponse()
-    {
-        var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {}}""");
-        var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var result = await client.GetFeatureFlagAsync("missing-flag", "distinct-id");
-
-        Assert.False(result);
-        await client.FlushAsync();
-        var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.Contains("\"$feature_flag_error\": \"flag_missing\"", received, StringComparison.Ordinal);
-    }
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponse("""{"featureFlags": {}}"""),
+            featureKey: "missing-flag",
+            expectedResult: false,
+            expectedError: "flag_missing");
 
     [Fact]
     public async Task IncludesErrorsWhileComputingFlagsErrorWhenErrorsWhileComputingFlagsIsTrue()
-    {
-        var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponse(
-            """
-            {
-                "featureFlags": {"some-flag": true},
-                "errorsWhileComputingFlags": true
-            }
-            """
-        );
-        var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var result = await client.GetFeatureFlagAsync("some-flag", "distinct-id");
-
-        Assert.True(result);
-        await client.FlushAsync();
-        var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.Contains("\"$feature_flag_error\": \"errors_while_computing_flags\"", received, StringComparison.Ordinal);
-    }
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponse(
+                """
+                {
+                    "featureFlags": {"some-flag": true},
+                    "errorsWhileComputingFlags": true
+                }
+                """),
+            featureKey: "some-flag",
+            expectedResult: true,
+            expectedError: "errors_while_computing_flags");
 
     [Fact]
     public async Task IncludesQuotaLimitedErrorWhenQuotaLimitedContainsFeatureFlags()
-    {
-        var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponse(
-            """
-            {
-                "featureFlags": {},
-                "quotaLimited": ["feature_flags"]
-            }
-            """
-        );
-        var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var result = await client.GetFeatureFlagAsync("some-flag", "distinct-id");
-
-        Assert.False(result);
-        await client.FlushAsync();
-        var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.Contains("\"$feature_flag_error\": \"quota_limited,flag_missing\"", received, StringComparison.Ordinal);
-    }
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponse(
+                """
+                {
+                    "featureFlags": {},
+                    "quotaLimited": ["feature_flags"]
+                }
+                """),
+            featureKey: "some-flag",
+            expectedResult: false,
+            expectedError: "quota_limited,flag_missing");
 
     [Fact]
     public async Task IncludesUnknownErrorWhenUnexpectedExceptionOccurs()
-    {
-        var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponseException(new InvalidOperationException("Unexpected error"));
-        var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var result = await client.GetFeatureFlagAsync("some-flag", "distinct-id");
-
-        Assert.False(result);
-        await client.FlushAsync();
-        var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.Contains("\"$feature_flag_error\": \"unknown_error\"", received, StringComparison.Ordinal);
-    }
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponseException(new InvalidOperationException("Unexpected error")),
+            featureKey: "some-flag",
+            expectedResult: false,
+            expectedError: "unknown_error");
 
     [Fact]
     public async Task JoinsMultipleErrorsWithCommas()
-    {
-        var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponse(
-            """
-            {
-                "featureFlags": {},
-                "errorsWhileComputingFlags": true
-            }
-            """
-        );
-        var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var result = await client.GetFeatureFlagAsync("missing-flag", "distinct-id");
-
-        Assert.False(result);
-        await client.FlushAsync();
-        var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.Contains("\"$feature_flag_error\": \"errors_while_computing_flags,flag_missing\"", received, StringComparison.Ordinal);
-    }
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponse(
+                """
+                {
+                    "featureFlags": {},
+                    "errorsWhileComputingFlags": true
+                }
+                """),
+            featureKey: "missing-flag",
+            expectedResult: false,
+            expectedError: "errors_while_computing_flags,flag_missing");
 
     [Fact]
     public async Task DoesNotIncludeErrorPropertyWhenNoErrors()
-    {
-        var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponse(
-            """
-            {"featureFlags": {"some-flag": true}}
-            """
-        );
-        var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var result = await client.GetFeatureFlagAsync("some-flag", "distinct-id");
-
-        Assert.True(result);
-        await client.FlushAsync();
-        var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.DoesNotContain("$feature_flag_error", received, StringComparison.Ordinal);
-    }
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponse("""{"featureFlags": {"some-flag": true}}"""),
+            featureKey: "some-flag",
+            expectedResult: true,
+            expectedError: null);
 
     [Fact]
     public async Task IncludesTimeoutErrorWhenRequestTimesOut()
-    {
-        var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponseException(new TaskCanceledException("Request timed out"));
-        var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var result = await client.GetFeatureFlagAsync("some-flag", "distinct-id");
-
-        Assert.False(result);
-        await client.FlushAsync();
-        var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.Contains("\"$feature_flag_error\": \"timeout\"", received, StringComparison.Ordinal);
-    }
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponseException(new TaskCanceledException("Request timed out")),
+            featureKey: "some-flag",
+            expectedResult: false,
+            expectedError: "timeout");
 
     [Fact]
     public async Task IncludesConnectionErrorWhenNetworkFails()
-    {
-        var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponseException(new HttpRequestException("Network error"));
-        var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        var result = await client.GetFeatureFlagAsync("some-flag", "distinct-id");
-
-        Assert.False(result);
-        await client.FlushAsync();
-        var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.Contains("\"$feature_flag_error\": \"connection_error\"", received, StringComparison.Ordinal);
-    }
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponseException(new HttpRequestException("Network error")),
+            featureKey: "some-flag",
+            expectedResult: false,
+            expectedError: "connection_error");
 
     [Fact]
     public async Task IncludesApiErrorWithStatusCodeWhenApiFails()
+        => await AssertCapturedFeatureFlagErrorAsync(
+            handler => handler.AddFlagsResponseException(
+                new ApiException(null, System.Net.HttpStatusCode.InternalServerError, null)),
+            featureKey: "some-flag",
+            expectedResult: false,
+            expectedError: "api_error_500");
+
+    static async Task AssertCapturedFeatureFlagErrorAsync(
+        Action<FakeHttpMessageHandler> arrangeFlagsResponse,
+        string featureKey,
+        bool expectedResult,
+        string? expectedError)
     {
         var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponseException(
-            new ApiException(null, System.Net.HttpStatusCode.InternalServerError, null));
+        arrangeFlagsResponse(container.FakeHttpMessageHandler);
         var captureRequestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
 
-        var result = await client.GetFeatureFlagAsync("some-flag", "distinct-id");
+        var result = await client.GetFeatureFlagAsync(featureKey, "distinct-id");
 
-        Assert.False(result);
+        Assert.NotNull(result);
+        Assert.Equal(expectedResult, result.IsEnabled);
         await client.FlushAsync();
         var received = captureRequestHandler.GetReceivedRequestBody(indented: true);
-        Assert.Contains("\"$feature_flag_error\": \"api_error_500\"", received, StringComparison.Ordinal);
+
+        if (expectedError is null)
+        {
+            Assert.DoesNotContain("$feature_flag_error", received, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Contains($"\"$feature_flag_error\": \"{expectedError}\"", received, StringComparison.Ordinal);
+        }
     }
 
     [Fact]

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -1874,204 +1874,30 @@ public class TheSemverOperators
     [InlineData("v1.2.3", ComparisonOperator.SemverEquals, "1.2.3", true)]
     [InlineData("1.2.3-alpha", ComparisonOperator.SemverEquals, "1.2.3", true)] // Pre-release stripped
     [InlineData("1.2.3", ComparisonOperator.SemverEquals, "1.2.3-beta", true)]  // Pre-release stripped
-    public void HandlesSemverEqualsOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Not equal tests
     [InlineData("1.2.3", ComparisonOperator.SemverNotEquals, "1.2.3", false)]
     [InlineData("1.2.3", ComparisonOperator.SemverNotEquals, "1.2.4", true)]
     [InlineData("1.2.3", ComparisonOperator.SemverNotEquals, "1.2.2", true)]
     [InlineData("2.0.0", ComparisonOperator.SemverNotEquals, "1.0.0", true)]
-    public void HandlesSemverNotEqualsOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Greater than tests
     [InlineData("1.2.4", ComparisonOperator.SemverGreaterThan, "1.2.3", true)]
     [InlineData("1.2.3", ComparisonOperator.SemverGreaterThan, "1.2.3", false)]
     [InlineData("1.2.2", ComparisonOperator.SemverGreaterThan, "1.2.3", false)]
     [InlineData("2.0.0", ComparisonOperator.SemverGreaterThan, "1.9.9", true)]
     [InlineData("1.3.0", ComparisonOperator.SemverGreaterThan, "1.2.99", true)]
-    public void HandlesSemverGreaterThanOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Greater than or equal tests
     [InlineData("1.2.4", ComparisonOperator.SemverGreaterThanOrEquals, "1.2.3", true)]
     [InlineData("1.2.3", ComparisonOperator.SemverGreaterThanOrEquals, "1.2.3", true)]
     [InlineData("1.2.2", ComparisonOperator.SemverGreaterThanOrEquals, "1.2.3", false)]
-    public void HandlesSemverGreaterThanOrEqualsOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Less than tests
     [InlineData("1.2.2", ComparisonOperator.SemverLessThan, "1.2.3", true)]
     [InlineData("1.2.3", ComparisonOperator.SemverLessThan, "1.2.3", false)]
     [InlineData("1.2.4", ComparisonOperator.SemverLessThan, "1.2.3", false)]
     [InlineData("1.9.9", ComparisonOperator.SemverLessThan, "2.0.0", true)]
-    public void HandlesSemverLessThanOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Less than or equal tests
     [InlineData("1.2.2", ComparisonOperator.SemverLessThanOrEquals, "1.2.3", true)]
     [InlineData("1.2.3", ComparisonOperator.SemverLessThanOrEquals, "1.2.3", true)]
     [InlineData("1.2.4", ComparisonOperator.SemverLessThanOrEquals, "1.2.3", false)]
-    public void HandlesSemverLessThanOrEqualsOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Tilde operator tests: ~X.Y.Z means >=X.Y.Z and <X.Y+1.0
     [InlineData("1.2.3", ComparisonOperator.SemverTilde, "1.2.3", true)]  // At lower bound
     [InlineData("1.2.4", ComparisonOperator.SemverTilde, "1.2.3", true)]  // Within range
@@ -2079,35 +1905,6 @@ public class TheSemverOperators
     [InlineData("1.3.0", ComparisonOperator.SemverTilde, "1.2.3", false)] // At upper bound (exclusive)
     [InlineData("1.2.2", ComparisonOperator.SemverTilde, "1.2.3", false)] // Below range
     [InlineData("2.0.0", ComparisonOperator.SemverTilde, "1.2.3", false)] // Above range
-    public void HandlesSemverTildeOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Caret operator tests for major > 0: ^X.Y.Z means >=X.Y.Z and <X+1.0.0
     [InlineData("1.2.3", ComparisonOperator.SemverCaret, "1.2.3", true)]  // At lower bound
     [InlineData("1.2.4", ComparisonOperator.SemverCaret, "1.2.3", true)]  // Within range
@@ -2115,35 +1912,6 @@ public class TheSemverOperators
     [InlineData("2.0.0", ComparisonOperator.SemverCaret, "1.2.3", false)] // At upper bound (exclusive)
     [InlineData("1.2.2", ComparisonOperator.SemverCaret, "1.2.3", false)] // Below range
     [InlineData("3.0.0", ComparisonOperator.SemverCaret, "1.2.3", false)] // Above range
-    public void HandlesSemverCaretOperatorWithMajorGreaterThanZero(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Caret operator tests for major = 0, minor > 0: ^0.Y.Z means >=0.Y.Z and <0.Y+1.0
     [InlineData("0.2.3", ComparisonOperator.SemverCaret, "0.2.3", true)]  // At lower bound
     [InlineData("0.2.4", ComparisonOperator.SemverCaret, "0.2.3", true)]  // Within range
@@ -2151,148 +1919,29 @@ public class TheSemverOperators
     [InlineData("0.3.0", ComparisonOperator.SemverCaret, "0.2.3", false)] // At upper bound (exclusive)
     [InlineData("0.2.2", ComparisonOperator.SemverCaret, "0.2.3", false)] // Below range
     [InlineData("1.0.0", ComparisonOperator.SemverCaret, "0.2.3", false)] // Above range
-    public void HandlesSemverCaretOperatorWithMajorZeroMinorGreaterThanZero(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Caret operator tests for major = 0, minor = 0: ^0.0.Z means >=0.0.Z and <0.0.Z+1
     [InlineData("0.0.3", ComparisonOperator.SemverCaret, "0.0.3", true)]  // At lower bound
     [InlineData("0.0.4", ComparisonOperator.SemverCaret, "0.0.3", false)] // At upper bound (exclusive)
     [InlineData("0.0.2", ComparisonOperator.SemverCaret, "0.0.3", false)] // Below range
     [InlineData("0.1.0", ComparisonOperator.SemverCaret, "0.0.3", false)] // Above range
-    public void HandlesSemverCaretOperatorWithMajorAndMinorZero(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
-    // Wildcard operator tests: "X.*" means >=X.0.0 and <X+1.0.0
+    // Wildcard operator tests
     [InlineData("1.0.0", ComparisonOperator.SemverWildcard, "1.*", true)]
     [InlineData("1.5.3", ComparisonOperator.SemverWildcard, "1.*", true)]
     [InlineData("1.99.99", ComparisonOperator.SemverWildcard, "1.*", true)]
     [InlineData("2.0.0", ComparisonOperator.SemverWildcard, "1.*", false)]
     [InlineData("0.9.9", ComparisonOperator.SemverWildcard, "1.*", false)]
-    public void HandlesSemverWildcardMajorOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
-    // Wildcard operator tests: "X.Y.*" means >=X.Y.0 and <X.Y+1.0
     [InlineData("1.2.0", ComparisonOperator.SemverWildcard, "1.2.*", true)]
     [InlineData("1.2.99", ComparisonOperator.SemverWildcard, "1.2.*", true)]
     [InlineData("1.3.0", ComparisonOperator.SemverWildcard, "1.2.*", false)]
     [InlineData("1.1.99", ComparisonOperator.SemverWildcard, "1.2.*", false)]
-    public void HandlesSemverWildcardMinorOperator(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
-    {
-        var flags = CreateFlags(
-            key: "version",
-            properties: [
-                new PropertyFilter
-                {
-                    Type = FilterType.Person,
-                    Key = "app_version",
-                    Value = new PropertyFilterValue(filterValue),
-                    Operator = comparison
-                }
-            ]
-        );
-        var properties = new Dictionary<string, object?>
-        {
-            ["app_version"] = overrideValue
-        };
-        var localEvaluator = new LocalEvaluator(flags);
-
-        var result = localEvaluator.EvaluateFeatureFlag(
-            key: "version",
-            distinctId: "distinct-id",
-            personProperties: properties);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
     // Special version parsing tests
-    [InlineData("v1.2.3", ComparisonOperator.SemverEquals, "1.2.3", true)]     // v-prefix
     [InlineData("1.2.3", ComparisonOperator.SemverEquals, "v1.2.3", true)]     // v-prefix in filter
-    [InlineData("1.2.3-alpha", ComparisonOperator.SemverEquals, "1.2.3", true)] // Pre-release stripped
     [InlineData("1.2.3+build", ComparisonOperator.SemverEquals, "1.2.3", true)] // Build metadata stripped
     [InlineData("  1.2.3  ", ComparisonOperator.SemverEquals, "1.2.3", true)]   // Whitespace stripped
     [InlineData("1.2", ComparisonOperator.SemverEquals, "1.2.0", true)]         // Partial version
     [InlineData("1", ComparisonOperator.SemverEquals, "1.0.0", true)]           // Partial version
     [InlineData("1.2.3.4", ComparisonOperator.SemverEquals, "1.2.3", true)]     // Extra parts ignored
-    public void HandlesSpecialVersionFormats(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
+    public void EvaluatesSemverOperators(string overrideValue, ComparisonOperator comparison, string filterValue, bool expected)
     {
         var flags = CreateFlags(
             key: "version",

--- a/tests/UnitTests/Library/SemanticVersionTests.cs
+++ b/tests/UnitTests/Library/SemanticVersionTests.cs
@@ -10,50 +10,14 @@ public class TheTryParseMethod
     [InlineData("0.0.0", 0, 0, 0)]
     [InlineData("10.20.30", 10, 20, 30)]
     [InlineData("999.999.999", 999, 999, 999)]
-    public void ParsesValidVersions(string input, int expectedMajor, int expectedMinor, int expectedPatch)
-    {
-        var result = SemanticVersion.TryParse(input, out var version);
-
-        Assert.True(result);
-        Assert.NotNull(version);
-        Assert.Equal(expectedMajor, version.Value.Major);
-        Assert.Equal(expectedMinor, version.Value.Minor);
-        Assert.Equal(expectedPatch, version.Value.Patch);
-    }
-
-    [Theory]
     // v-prefix handling
     [InlineData("v1.2.3", 1, 2, 3)]
     [InlineData("V1.2.3", 1, 2, 3)]
     [InlineData("v0.0.1", 0, 0, 1)]
-    public void StripsVPrefix(string input, int expectedMajor, int expectedMinor, int expectedPatch)
-    {
-        var result = SemanticVersion.TryParse(input, out var version);
-
-        Assert.True(result);
-        Assert.NotNull(version);
-        Assert.Equal(expectedMajor, version.Value.Major);
-        Assert.Equal(expectedMinor, version.Value.Minor);
-        Assert.Equal(expectedPatch, version.Value.Patch);
-    }
-
-    [Theory]
     // Whitespace handling
     [InlineData("  1.2.3  ", 1, 2, 3)]
-    [InlineData("\t1.2.3\t", 1, 2, 3)]
+    [InlineData("	1.2.3	", 1, 2, 3)]
     [InlineData("  v1.2.3  ", 1, 2, 3)]
-    public void StripsWhitespace(string input, int expectedMajor, int expectedMinor, int expectedPatch)
-    {
-        var result = SemanticVersion.TryParse(input, out var version);
-
-        Assert.True(result);
-        Assert.NotNull(version);
-        Assert.Equal(expectedMajor, version.Value.Major);
-        Assert.Equal(expectedMinor, version.Value.Minor);
-        Assert.Equal(expectedPatch, version.Value.Patch);
-    }
-
-    [Theory]
     // Pre-release and build metadata stripping
     [InlineData("1.2.3-alpha", 1, 2, 3)]
     [InlineData("1.2.3-alpha.1", 1, 2, 3)]
@@ -62,57 +26,21 @@ public class TheTryParseMethod
     [InlineData("1.2.3-alpha+build", 1, 2, 3)]
     [InlineData("1.2.3-beta.2+build.456", 1, 2, 3)]
     [InlineData("v1.2.3-rc1", 1, 2, 3)]
-    public void StripsPreReleaseAndBuildMetadata(string input, int expectedMajor, int expectedMinor, int expectedPatch)
-    {
-        var result = SemanticVersion.TryParse(input, out var version);
-
-        Assert.True(result);
-        Assert.NotNull(version);
-        Assert.Equal(expectedMajor, version.Value.Major);
-        Assert.Equal(expectedMinor, version.Value.Minor);
-        Assert.Equal(expectedPatch, version.Value.Patch);
-    }
-
-    [Theory]
     // Partial versions (missing components default to 0)
     [InlineData("1", 1, 0, 0)]
     [InlineData("1.2", 1, 2, 0)]
     [InlineData("v1", 1, 0, 0)]
     [InlineData("v1.2", 1, 2, 0)]
-    public void DefaultsMissingComponentsToZero(string input, int expectedMajor, int expectedMinor, int expectedPatch)
-    {
-        var result = SemanticVersion.TryParse(input, out var version);
-
-        Assert.True(result);
-        Assert.NotNull(version);
-        Assert.Equal(expectedMajor, version.Value.Major);
-        Assert.Equal(expectedMinor, version.Value.Minor);
-        Assert.Equal(expectedPatch, version.Value.Patch);
-    }
-
-    [Theory]
     // Extra components beyond the third are ignored
     [InlineData("1.2.3.4", 1, 2, 3)]
     [InlineData("1.2.3.4.5", 1, 2, 3)]
     [InlineData("1.2.3.4.5.6", 1, 2, 3)]
-    public void IgnoresExtraComponents(string input, int expectedMajor, int expectedMinor, int expectedPatch)
-    {
-        var result = SemanticVersion.TryParse(input, out var version);
-
-        Assert.True(result);
-        Assert.NotNull(version);
-        Assert.Equal(expectedMajor, version.Value.Major);
-        Assert.Equal(expectedMinor, version.Value.Minor);
-        Assert.Equal(expectedPatch, version.Value.Patch);
-    }
-
-    [Theory]
     // Literal "0" components are valid per semver 2.0.0
     [InlineData("0.0.1", 0, 0, 1)]
     [InlineData("0.1.0", 0, 1, 0)]
     [InlineData("1.0.0", 1, 0, 0)]
     [InlineData("1.2.0", 1, 2, 0)]
-    public void ParsesLiteralZeroComponents(string input, int expectedMajor, int expectedMinor, int expectedPatch)
+    public void ParsesValidInputs(string input, int expectedMajor, int expectedMinor, int expectedPatch)
     {
         var result = SemanticVersion.TryParse(input, out var version);
 
@@ -171,148 +99,50 @@ public class TheCompareToMethod
     [InlineData("0.0.0", "0.0.0", 0)]
     [InlineData("v1.2.3", "1.2.3", 0)]
     [InlineData("1.2.3-alpha", "1.2.3", 0)] // Pre-release stripped, so equal
-    public void ReturnsZeroForEqualVersions(string left, string right, int expected)
-    {
-        Assert.True(SemanticVersion.TryParse(left, out var leftVersion));
-        Assert.True(SemanticVersion.TryParse(right, out var rightVersion));
-
-        Assert.NotNull(leftVersion);
-        Assert.NotNull(rightVersion);
-        Assert.Equal(expected, leftVersion.Value.CompareTo(rightVersion.Value));
-    }
-
-    [Theory]
     // Greater than comparisons
     [InlineData("2.0.0", "1.0.0", 1)]
     [InlineData("1.2.0", "1.1.0", 1)]
     [InlineData("1.2.4", "1.2.3", 1)]
     [InlineData("2.0.0", "1.9.9", 1)]
     [InlineData("1.0.0", "0.9.9", 1)]
-    public void ReturnsPositiveWhenLeftIsGreater(string left, string right, int expected)
-    {
-        Assert.True(SemanticVersion.TryParse(left, out var leftVersion));
-        Assert.True(SemanticVersion.TryParse(right, out var rightVersion));
-
-        Assert.NotNull(leftVersion);
-        Assert.NotNull(rightVersion);
-        Assert.Equal(expected, Math.Sign(leftVersion.Value.CompareTo(rightVersion.Value)));
-    }
-
-    [Theory]
     // Less than comparisons
     [InlineData("1.0.0", "2.0.0", -1)]
     [InlineData("1.1.0", "1.2.0", -1)]
     [InlineData("1.2.3", "1.2.4", -1)]
     [InlineData("1.9.9", "2.0.0", -1)]
     [InlineData("0.9.9", "1.0.0", -1)]
-    public void ReturnsNegativeWhenLeftIsLess(string left, string right, int expected)
+    public void ComparesVersions(string left, string right, int expectedSign)
     {
         Assert.True(SemanticVersion.TryParse(left, out var leftVersion));
         Assert.True(SemanticVersion.TryParse(right, out var rightVersion));
 
         Assert.NotNull(leftVersion);
         Assert.NotNull(rightVersion);
-        Assert.Equal(expected, Math.Sign(leftVersion.Value.CompareTo(rightVersion.Value)));
+        Assert.Equal(expectedSign, Math.Sign(leftVersion.Value.CompareTo(rightVersion.Value)));
     }
 }
 
-public class TheGetTildeBoundsMethod
+public class TheVersionRangeBoundsMethods
 {
     [Theory]
     // ~X.Y.Z means >=X.Y.Z and <X.Y+1.0
-    [InlineData("1.2.3", "1.2.3", "1.3.0")]
-    [InlineData("1.0.0", "1.0.0", "1.1.0")]
-    [InlineData("0.2.3", "0.2.3", "0.3.0")]
-    [InlineData("0.0.1", "0.0.1", "0.1.0")]
-    public void CalculatesCorrectTildeBounds(string input, string expectedLower, string expectedUpper)
-    {
-        Assert.True(SemanticVersion.TryParse(input, out var version));
-        Assert.True(SemanticVersion.TryParse(expectedLower, out var expectedLowerVersion));
-        Assert.True(SemanticVersion.TryParse(expectedUpper, out var expectedUpperVersion));
-
-        Assert.NotNull(version);
-        Assert.NotNull(expectedLowerVersion);
-        Assert.NotNull(expectedUpperVersion);
-
-        var (lower, upper) = version.Value.GetTildeBounds();
-
-        Assert.Equal(expectedLowerVersion.Value, lower);
-        Assert.Equal(expectedUpperVersion.Value, upper);
-    }
-
-    [Theory]
-    // Test range matching for tilde
-    [InlineData("1.2.3", "1.2.3", true)]  // At lower bound
-    [InlineData("1.2.3", "1.2.4", true)]  // Within range
-    [InlineData("1.2.3", "1.2.99", true)] // Within range
-    [InlineData("1.2.3", "1.3.0", false)] // At upper bound (exclusive)
-    [InlineData("1.2.3", "1.2.2", false)] // Below range
-    [InlineData("1.2.3", "2.0.0", false)] // Above range
-    public void TildeBoundsMatchCorrectly(string baseVersion, string testVersion, bool expectedInRange)
-    {
-        Assert.True(SemanticVersion.TryParse(baseVersion, out var baseVer));
-        Assert.True(SemanticVersion.TryParse(testVersion, out var testVer));
-
-        Assert.NotNull(baseVer);
-        Assert.NotNull(testVer);
-
-        var (lower, upper) = baseVer.Value.GetTildeBounds();
-        var inRange = testVer.Value.IsInRange(lower, upper);
-
-        Assert.Equal(expectedInRange, inRange);
-    }
-}
-
-public class TheGetCaretBoundsMethod
-{
-    [Theory]
+    [InlineData("tilde", "1.2.3", "1.2.3", "1.3.0")]
+    [InlineData("tilde", "1.0.0", "1.0.0", "1.1.0")]
+    [InlineData("tilde", "0.2.3", "0.2.3", "0.3.0")]
+    [InlineData("tilde", "0.0.1", "0.0.1", "0.1.0")]
     // ^X.Y.Z where X > 0 → >=X.Y.Z <X+1.0.0
-    [InlineData("1.2.3", "1.2.3", "2.0.0")]
-    [InlineData("1.0.0", "1.0.0", "2.0.0")]
-    [InlineData("2.5.10", "2.5.10", "3.0.0")]
-    public void CalculatesCorrectCaretBoundsForMajorGreaterThanZero(string input, string expectedLower, string expectedUpper)
-    {
-        Assert.True(SemanticVersion.TryParse(input, out var version));
-        Assert.True(SemanticVersion.TryParse(expectedLower, out var expectedLowerVersion));
-        Assert.True(SemanticVersion.TryParse(expectedUpper, out var expectedUpperVersion));
-
-        Assert.NotNull(version);
-        Assert.NotNull(expectedLowerVersion);
-        Assert.NotNull(expectedUpperVersion);
-
-        var (lower, upper) = version.Value.GetCaretBounds();
-
-        Assert.Equal(expectedLowerVersion.Value, lower);
-        Assert.Equal(expectedUpperVersion.Value, upper);
-    }
-
-    [Theory]
+    [InlineData("caret", "1.2.3", "1.2.3", "2.0.0")]
+    [InlineData("caret", "1.0.0", "1.0.0", "2.0.0")]
+    [InlineData("caret", "2.5.10", "2.5.10", "3.0.0")]
     // ^0.Y.Z where Y > 0 → >=0.Y.Z <0.Y+1.0
-    [InlineData("0.2.3", "0.2.3", "0.3.0")]
-    [InlineData("0.1.0", "0.1.0", "0.2.0")]
-    [InlineData("0.5.10", "0.5.10", "0.6.0")]
-    public void CalculatesCorrectCaretBoundsForMajorZeroMinorGreaterThanZero(string input, string expectedLower, string expectedUpper)
-    {
-        Assert.True(SemanticVersion.TryParse(input, out var version));
-        Assert.True(SemanticVersion.TryParse(expectedLower, out var expectedLowerVersion));
-        Assert.True(SemanticVersion.TryParse(expectedUpper, out var expectedUpperVersion));
-
-        Assert.NotNull(version);
-        Assert.NotNull(expectedLowerVersion);
-        Assert.NotNull(expectedUpperVersion);
-
-        var (lower, upper) = version.Value.GetCaretBounds();
-
-        Assert.Equal(expectedLowerVersion.Value, lower);
-        Assert.Equal(expectedUpperVersion.Value, upper);
-    }
-
-    [Theory]
+    [InlineData("caret", "0.2.3", "0.2.3", "0.3.0")]
+    [InlineData("caret", "0.1.0", "0.1.0", "0.2.0")]
+    [InlineData("caret", "0.5.10", "0.5.10", "0.6.0")]
     // ^0.0.Z → >=0.0.Z <0.0.Z+1
-    [InlineData("0.0.3", "0.0.3", "0.0.4")]
-    [InlineData("0.0.0", "0.0.0", "0.0.1")]
-    [InlineData("0.0.10", "0.0.10", "0.0.11")]
-    public void CalculatesCorrectCaretBoundsForMajorAndMinorZero(string input, string expectedLower, string expectedUpper)
+    [InlineData("caret", "0.0.3", "0.0.3", "0.0.4")]
+    [InlineData("caret", "0.0.0", "0.0.0", "0.0.1")]
+    [InlineData("caret", "0.0.10", "0.0.10", "0.0.11")]
+    public void CalculatesCorrectBounds(string kind, string input, string expectedLower, string expectedUpper)
     {
         Assert.True(SemanticVersion.TryParse(input, out var version));
         Assert.True(SemanticVersion.TryParse(expectedLower, out var expectedLowerVersion));
@@ -322,21 +152,42 @@ public class TheGetCaretBoundsMethod
         Assert.NotNull(expectedLowerVersion);
         Assert.NotNull(expectedUpperVersion);
 
-        var (lower, upper) = version.Value.GetCaretBounds();
+        var (lower, upper) = kind == "tilde"
+            ? version.Value.GetTildeBounds()
+            : version.Value.GetCaretBounds();
 
         Assert.Equal(expectedLowerVersion.Value, lower);
         Assert.Equal(expectedUpperVersion.Value, upper);
     }
 
     [Theory]
-    // Test range matching for caret with major > 0
-    [InlineData("1.2.3", "1.2.3", true)]   // At lower bound
-    [InlineData("1.2.3", "1.2.4", true)]   // Within range
-    [InlineData("1.2.3", "1.9.9", true)]   // Within range
-    [InlineData("1.2.3", "2.0.0", false)]  // At upper bound (exclusive)
-    [InlineData("1.2.3", "1.2.2", false)]  // Below range
-    [InlineData("1.2.3", "3.0.0", false)]  // Above range
-    public void CaretBoundsMatchCorrectlyForMajorGreaterThanZero(string baseVersion, string testVersion, bool expectedInRange)
+    // Tilde range matching
+    [InlineData("tilde", "1.2.3", "1.2.3", true)]
+    [InlineData("tilde", "1.2.3", "1.2.4", true)]
+    [InlineData("tilde", "1.2.3", "1.2.99", true)]
+    [InlineData("tilde", "1.2.3", "1.3.0", false)]
+    [InlineData("tilde", "1.2.3", "1.2.2", false)]
+    [InlineData("tilde", "1.2.3", "2.0.0", false)]
+    // Caret range matching with major > 0
+    [InlineData("caret", "1.2.3", "1.2.3", true)]
+    [InlineData("caret", "1.2.3", "1.2.4", true)]
+    [InlineData("caret", "1.2.3", "1.9.9", true)]
+    [InlineData("caret", "1.2.3", "2.0.0", false)]
+    [InlineData("caret", "1.2.3", "1.2.2", false)]
+    [InlineData("caret", "1.2.3", "3.0.0", false)]
+    // Caret range matching with major = 0, minor > 0
+    [InlineData("caret", "0.2.3", "0.2.3", true)]
+    [InlineData("caret", "0.2.3", "0.2.4", true)]
+    [InlineData("caret", "0.2.3", "0.2.99", true)]
+    [InlineData("caret", "0.2.3", "0.3.0", false)]
+    [InlineData("caret", "0.2.3", "0.2.2", false)]
+    [InlineData("caret", "0.2.3", "1.0.0", false)]
+    // Caret range matching with major = 0, minor = 0
+    [InlineData("caret", "0.0.3", "0.0.3", true)]
+    [InlineData("caret", "0.0.3", "0.0.4", false)]
+    [InlineData("caret", "0.0.3", "0.0.2", false)]
+    [InlineData("caret", "0.0.3", "0.1.0", false)]
+    public void BoundsMatchCorrectly(string kind, string baseVersion, string testVersion, bool expectedInRange)
     {
         Assert.True(SemanticVersion.TryParse(baseVersion, out var baseVer));
         Assert.True(SemanticVersion.TryParse(testVersion, out var testVer));
@@ -344,49 +195,9 @@ public class TheGetCaretBoundsMethod
         Assert.NotNull(baseVer);
         Assert.NotNull(testVer);
 
-        var (lower, upper) = baseVer.Value.GetCaretBounds();
-        var inRange = testVer.Value.IsInRange(lower, upper);
-
-        Assert.Equal(expectedInRange, inRange);
-    }
-
-    [Theory]
-    // Test range matching for caret with major = 0, minor > 0
-    [InlineData("0.2.3", "0.2.3", true)]   // At lower bound
-    [InlineData("0.2.3", "0.2.4", true)]   // Within range
-    [InlineData("0.2.3", "0.2.99", true)]  // Within range
-    [InlineData("0.2.3", "0.3.0", false)]  // At upper bound (exclusive)
-    [InlineData("0.2.3", "0.2.2", false)]  // Below range
-    [InlineData("0.2.3", "1.0.0", false)]  // Above range
-    public void CaretBoundsMatchCorrectlyForMajorZeroMinorGreaterThanZero(string baseVersion, string testVersion, bool expectedInRange)
-    {
-        Assert.True(SemanticVersion.TryParse(baseVersion, out var baseVer));
-        Assert.True(SemanticVersion.TryParse(testVersion, out var testVer));
-
-        Assert.NotNull(baseVer);
-        Assert.NotNull(testVer);
-
-        var (lower, upper) = baseVer.Value.GetCaretBounds();
-        var inRange = testVer.Value.IsInRange(lower, upper);
-
-        Assert.Equal(expectedInRange, inRange);
-    }
-
-    [Theory]
-    // Test range matching for caret with major = 0, minor = 0
-    [InlineData("0.0.3", "0.0.3", true)]   // At lower bound
-    [InlineData("0.0.3", "0.0.4", false)]  // At upper bound (exclusive)
-    [InlineData("0.0.3", "0.0.2", false)]  // Below range
-    [InlineData("0.0.3", "0.1.0", false)]  // Above range
-    public void CaretBoundsMatchCorrectlyForMajorAndMinorZero(string baseVersion, string testVersion, bool expectedInRange)
-    {
-        Assert.True(SemanticVersion.TryParse(baseVersion, out var baseVer));
-        Assert.True(SemanticVersion.TryParse(testVersion, out var testVer));
-
-        Assert.NotNull(baseVer);
-        Assert.NotNull(testVer);
-
-        var (lower, upper) = baseVer.Value.GetCaretBounds();
+        var (lower, upper) = kind == "tilde"
+            ? baseVer.Value.GetTildeBounds()
+            : baseVer.Value.GetCaretBounds();
         var inRange = testVer.Value.IsInRange(lower, upper);
 
         Assert.Equal(expectedInRange, inRange);
@@ -401,66 +212,18 @@ public class TheTryParseWildcardMethod
     [InlineData("2.*", "2.0.0", "3.0.0")]
     [InlineData("0.*", "0.0.0", "1.0.0")]
     [InlineData("v1.*", "1.0.0", "2.0.0")]
-    public void ParsesXWildcardPattern(string pattern, string expectedLower, string expectedUpper)
-    {
-        var result = SemanticVersion.TryParseWildcard(pattern, out var lower, out var upper);
-
-        Assert.True(result);
-        Assert.NotNull(lower);
-        Assert.NotNull(upper);
-
-        Assert.True(SemanticVersion.TryParse(expectedLower, out var expectedLowerVersion));
-        Assert.True(SemanticVersion.TryParse(expectedUpper, out var expectedUpperVersion));
-
-        Assert.Equal(expectedLowerVersion!.Value, lower.Value);
-        Assert.Equal(expectedUpperVersion!.Value, upper.Value);
-    }
-
-    [Theory]
     // "X.Y.*" pattern → >=X.Y.0 <X.Y+1.0
     [InlineData("1.2.*", "1.2.0", "1.3.0")]
     [InlineData("1.0.*", "1.0.0", "1.1.0")]
     [InlineData("0.2.*", "0.2.0", "0.3.0")]
     [InlineData("v1.2.*", "1.2.0", "1.3.0")]
-    public void ParsesXYWildcardPattern(string pattern, string expectedLower, string expectedUpper)
-    {
-        var result = SemanticVersion.TryParseWildcard(pattern, out var lower, out var upper);
-
-        Assert.True(result);
-        Assert.NotNull(lower);
-        Assert.NotNull(upper);
-
-        Assert.True(SemanticVersion.TryParse(expectedLower, out var expectedLowerVersion));
-        Assert.True(SemanticVersion.TryParse(expectedUpper, out var expectedUpperVersion));
-
-        Assert.Equal(expectedLowerVersion!.Value, lower.Value);
-        Assert.Equal(expectedUpperVersion!.Value, upper.Value);
-    }
-
-    [Theory]
     // "X" pattern (without explicit wildcard) → >=X.0.0 <X+1.0.0
     [InlineData("1", "1.0.0", "2.0.0")]
     [InlineData("2", "2.0.0", "3.0.0")]
-    public void ParsesImplicitMajorWildcard(string pattern, string expectedLower, string expectedUpper)
-    {
-        var result = SemanticVersion.TryParseWildcard(pattern, out var lower, out var upper);
-
-        Assert.True(result);
-        Assert.NotNull(lower);
-        Assert.NotNull(upper);
-
-        Assert.True(SemanticVersion.TryParse(expectedLower, out var expectedLowerVersion));
-        Assert.True(SemanticVersion.TryParse(expectedUpper, out var expectedUpperVersion));
-
-        Assert.Equal(expectedLowerVersion!.Value, lower.Value);
-        Assert.Equal(expectedUpperVersion!.Value, upper.Value);
-    }
-
-    [Theory]
     // "X.Y" pattern (without explicit wildcard) → >=X.Y.0 <X.Y+1.0
     [InlineData("1.2", "1.2.0", "1.3.0")]
     [InlineData("0.5", "0.5.0", "0.6.0")]
-    public void ParsesImplicitMinorWildcard(string pattern, string expectedLower, string expectedUpper)
+    public void ParsesWildcardPatterns(string pattern, string expectedLower, string expectedUpper)
     {
         var result = SemanticVersion.TryParseWildcard(pattern, out var lower, out var upper);
 
@@ -533,59 +296,34 @@ public class TheTryParseWildcardMethod
 public class TheOperatorOverloads
 {
     [Theory]
-    [InlineData("1.2.3", "1.2.4", true)]
-    [InlineData("1.2.3", "1.2.3", false)]
-    [InlineData("1.2.4", "1.2.3", false)]
-    public void LessThanOperatorWorks(string left, string right, bool expected)
+    [InlineData("<", "1.2.3", "1.2.4", true)]
+    [InlineData("<", "1.2.3", "1.2.3", false)]
+    [InlineData("<", "1.2.4", "1.2.3", false)]
+    [InlineData("<=", "1.2.3", "1.2.4", true)]
+    [InlineData("<=", "1.2.3", "1.2.3", true)]
+    [InlineData("<=", "1.2.4", "1.2.3", false)]
+    [InlineData(">", "1.2.4", "1.2.3", true)]
+    [InlineData(">", "1.2.3", "1.2.3", false)]
+    [InlineData(">", "1.2.3", "1.2.4", false)]
+    [InlineData(">=", "1.2.4", "1.2.3", true)]
+    [InlineData(">=", "1.2.3", "1.2.3", true)]
+    [InlineData(">=", "1.2.3", "1.2.4", false)]
+    public void ComparisonOperatorsWork(string operatorName, string left, string right, bool expected)
     {
         Assert.True(SemanticVersion.TryParse(left, out var leftVersion));
         Assert.True(SemanticVersion.TryParse(right, out var rightVersion));
 
         Assert.NotNull(leftVersion);
         Assert.NotNull(rightVersion);
-        Assert.Equal(expected, leftVersion.Value < rightVersion.Value);
-    }
 
-    [Theory]
-    [InlineData("1.2.3", "1.2.4", true)]
-    [InlineData("1.2.3", "1.2.3", true)]
-    [InlineData("1.2.4", "1.2.3", false)]
-    public void LessThanOrEqualOperatorWorks(string left, string right, bool expected)
-    {
-        Assert.True(SemanticVersion.TryParse(left, out var leftVersion));
-        Assert.True(SemanticVersion.TryParse(right, out var rightVersion));
-
-        Assert.NotNull(leftVersion);
-        Assert.NotNull(rightVersion);
-        Assert.Equal(expected, leftVersion.Value <= rightVersion.Value);
-    }
-
-    [Theory]
-    [InlineData("1.2.4", "1.2.3", true)]
-    [InlineData("1.2.3", "1.2.3", false)]
-    [InlineData("1.2.3", "1.2.4", false)]
-    public void GreaterThanOperatorWorks(string left, string right, bool expected)
-    {
-        Assert.True(SemanticVersion.TryParse(left, out var leftVersion));
-        Assert.True(SemanticVersion.TryParse(right, out var rightVersion));
-
-        Assert.NotNull(leftVersion);
-        Assert.NotNull(rightVersion);
-        Assert.Equal(expected, leftVersion.Value > rightVersion.Value);
-    }
-
-    [Theory]
-    [InlineData("1.2.4", "1.2.3", true)]
-    [InlineData("1.2.3", "1.2.3", true)]
-    [InlineData("1.2.3", "1.2.4", false)]
-    public void GreaterThanOrEqualOperatorWorks(string left, string right, bool expected)
-    {
-        Assert.True(SemanticVersion.TryParse(left, out var leftVersion));
-        Assert.True(SemanticVersion.TryParse(right, out var rightVersion));
-
-        Assert.NotNull(leftVersion);
-        Assert.NotNull(rightVersion);
-        Assert.Equal(expected, leftVersion.Value >= rightVersion.Value);
+        var actual = operatorName switch
+        {
+            "<" => leftVersion.Value < rightVersion.Value,
+            "<=" => leftVersion.Value <= rightVersion.Value,
+            ">" => leftVersion.Value > rightVersion.Value,
+            _ => leftVersion.Value >= rightVersion.Value
+        };
+        Assert.Equal(expected, actual);
     }
 }
 

--- a/tests/UnitTests/Library/SemanticVersionTests.cs
+++ b/tests/UnitTests/Library/SemanticVersionTests.cs
@@ -16,7 +16,7 @@ public class TheTryParseMethod
     [InlineData("v0.0.1", 0, 0, 1)]
     // Whitespace handling
     [InlineData("  1.2.3  ", 1, 2, 3)]
-    [InlineData("	1.2.3	", 1, 2, 3)]
+    [InlineData("\t1.2.3\t", 1, 2, 3)]
     [InlineData("  v1.2.3  ", 1, 2, 3)]
     // Pre-release and build metadata stripping
     [InlineData("1.2.3-alpha", 1, 2, 3)]
@@ -152,9 +152,7 @@ public class TheVersionRangeBoundsMethods
         Assert.NotNull(expectedLowerVersion);
         Assert.NotNull(expectedUpperVersion);
 
-        var (lower, upper) = kind == "tilde"
-            ? version.Value.GetTildeBounds()
-            : version.Value.GetCaretBounds();
+        var (lower, upper) = GetBounds(kind, version.Value);
 
         Assert.Equal(expectedLowerVersion.Value, lower);
         Assert.Equal(expectedUpperVersion.Value, upper);
@@ -195,13 +193,19 @@ public class TheVersionRangeBoundsMethods
         Assert.NotNull(baseVer);
         Assert.NotNull(testVer);
 
-        var (lower, upper) = kind == "tilde"
-            ? baseVer.Value.GetTildeBounds()
-            : baseVer.Value.GetCaretBounds();
+        var (lower, upper) = GetBounds(kind, baseVer.Value);
         var inRange = testVer.Value.IsInRange(lower, upper);
 
         Assert.Equal(expectedInRange, inRange);
     }
+
+    static (SemanticVersion Lower, SemanticVersion Upper) GetBounds(string kind, SemanticVersion version)
+        => kind switch
+        {
+            "tilde" => version.GetTildeBounds(),
+            "caret" => version.GetCaretBounds(),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+        };
 }
 
 public class TheTryParseWildcardMethod
@@ -321,7 +325,8 @@ public class TheOperatorOverloads
             "<" => leftVersion.Value < rightVersion.Value,
             "<=" => leftVersion.Value <= rightVersion.Value,
             ">" => leftVersion.Value > rightVersion.Value,
-            _ => leftVersion.Value >= rightVersion.Value
+            ">=" => leftVersion.Value >= rightVersion.Value,
+            _ => throw new ArgumentOutOfRangeException(nameof(operatorName), operatorName, null)
         };
         Assert.Equal(expected, actual);
     }

--- a/tests/UnitTests/Library/SemanticVersionTests.cs
+++ b/tests/UnitTests/Library/SemanticVersionTests.cs
@@ -122,27 +122,80 @@ public class TheCompareToMethod
     }
 }
 
-public class TheVersionRangeBoundsMethods
+public class TheGetTildeBoundsMethod : RangeBoundsMethodTests
 {
     [Theory]
     // ~X.Y.Z means >=X.Y.Z and <X.Y+1.0
-    [InlineData("tilde", "1.2.3", "1.2.3", "1.3.0")]
-    [InlineData("tilde", "1.0.0", "1.0.0", "1.1.0")]
-    [InlineData("tilde", "0.2.3", "0.2.3", "0.3.0")]
-    [InlineData("tilde", "0.0.1", "0.0.1", "0.1.0")]
+    [InlineData("1.2.3", "1.2.3", "1.3.0")]
+    [InlineData("1.0.0", "1.0.0", "1.1.0")]
+    [InlineData("0.2.3", "0.2.3", "0.3.0")]
+    [InlineData("0.0.1", "0.0.1", "0.1.0")]
+    public void CalculatesCorrectBounds(string input, string expectedLower, string expectedUpper)
+        => AssertBounds(input, expectedLower, expectedUpper);
+
+    [Theory]
+    // Tilde range matching
+    [InlineData("1.2.3", "1.2.3", true)]
+    [InlineData("1.2.3", "1.2.4", true)]
+    [InlineData("1.2.3", "1.2.99", true)]
+    [InlineData("1.2.3", "1.3.0", false)]
+    [InlineData("1.2.3", "1.2.2", false)]
+    [InlineData("1.2.3", "2.0.0", false)]
+    public void BoundsMatchCorrectly(string baseVersion, string testVersion, bool expectedInRange)
+        => AssertInRange(baseVersion, testVersion, expectedInRange);
+
+    private protected override (SemanticVersion Lower, SemanticVersion Upper) GetBounds(SemanticVersion version)
+        => version.GetTildeBounds();
+}
+
+public class TheGetCaretBoundsMethod : RangeBoundsMethodTests
+{
+    [Theory]
     // ^X.Y.Z where X > 0 → >=X.Y.Z <X+1.0.0
-    [InlineData("caret", "1.2.3", "1.2.3", "2.0.0")]
-    [InlineData("caret", "1.0.0", "1.0.0", "2.0.0")]
-    [InlineData("caret", "2.5.10", "2.5.10", "3.0.0")]
+    [InlineData("1.2.3", "1.2.3", "2.0.0")]
+    [InlineData("1.0.0", "1.0.0", "2.0.0")]
+    [InlineData("2.5.10", "2.5.10", "3.0.0")]
     // ^0.Y.Z where Y > 0 → >=0.Y.Z <0.Y+1.0
-    [InlineData("caret", "0.2.3", "0.2.3", "0.3.0")]
-    [InlineData("caret", "0.1.0", "0.1.0", "0.2.0")]
-    [InlineData("caret", "0.5.10", "0.5.10", "0.6.0")]
+    [InlineData("0.2.3", "0.2.3", "0.3.0")]
+    [InlineData("0.1.0", "0.1.0", "0.2.0")]
+    [InlineData("0.5.10", "0.5.10", "0.6.0")]
     // ^0.0.Z → >=0.0.Z <0.0.Z+1
-    [InlineData("caret", "0.0.3", "0.0.3", "0.0.4")]
-    [InlineData("caret", "0.0.0", "0.0.0", "0.0.1")]
-    [InlineData("caret", "0.0.10", "0.0.10", "0.0.11")]
-    public void CalculatesCorrectBounds(string kind, string input, string expectedLower, string expectedUpper)
+    [InlineData("0.0.3", "0.0.3", "0.0.4")]
+    [InlineData("0.0.0", "0.0.0", "0.0.1")]
+    [InlineData("0.0.10", "0.0.10", "0.0.11")]
+    public void CalculatesCorrectBounds(string input, string expectedLower, string expectedUpper)
+        => AssertBounds(input, expectedLower, expectedUpper);
+
+    [Theory]
+    // Caret range matching with major > 0
+    [InlineData("1.2.3", "1.2.3", true)]
+    [InlineData("1.2.3", "1.2.4", true)]
+    [InlineData("1.2.3", "1.9.9", true)]
+    [InlineData("1.2.3", "2.0.0", false)]
+    [InlineData("1.2.3", "1.2.2", false)]
+    [InlineData("1.2.3", "3.0.0", false)]
+    // Caret range matching with major = 0, minor > 0
+    [InlineData("0.2.3", "0.2.3", true)]
+    [InlineData("0.2.3", "0.2.4", true)]
+    [InlineData("0.2.3", "0.2.99", true)]
+    [InlineData("0.2.3", "0.3.0", false)]
+    [InlineData("0.2.3", "0.2.2", false)]
+    [InlineData("0.2.3", "1.0.0", false)]
+    // Caret range matching with major = 0, minor = 0
+    [InlineData("0.0.3", "0.0.3", true)]
+    [InlineData("0.0.3", "0.0.4", false)]
+    [InlineData("0.0.3", "0.0.2", false)]
+    [InlineData("0.0.3", "0.1.0", false)]
+    public void BoundsMatchCorrectly(string baseVersion, string testVersion, bool expectedInRange)
+        => AssertInRange(baseVersion, testVersion, expectedInRange);
+
+    private protected override (SemanticVersion Lower, SemanticVersion Upper) GetBounds(SemanticVersion version)
+        => version.GetCaretBounds();
+}
+
+public abstract class RangeBoundsMethodTests
+{
+    protected void AssertBounds(string input, string expectedLower, string expectedUpper)
     {
         Assert.True(SemanticVersion.TryParse(input, out var version));
         Assert.True(SemanticVersion.TryParse(expectedLower, out var expectedLowerVersion));
@@ -152,40 +205,13 @@ public class TheVersionRangeBoundsMethods
         Assert.NotNull(expectedLowerVersion);
         Assert.NotNull(expectedUpperVersion);
 
-        var (lower, upper) = GetBounds(kind, version.Value);
+        var (lower, upper) = GetBounds(version.Value);
 
         Assert.Equal(expectedLowerVersion.Value, lower);
         Assert.Equal(expectedUpperVersion.Value, upper);
     }
 
-    [Theory]
-    // Tilde range matching
-    [InlineData("tilde", "1.2.3", "1.2.3", true)]
-    [InlineData("tilde", "1.2.3", "1.2.4", true)]
-    [InlineData("tilde", "1.2.3", "1.2.99", true)]
-    [InlineData("tilde", "1.2.3", "1.3.0", false)]
-    [InlineData("tilde", "1.2.3", "1.2.2", false)]
-    [InlineData("tilde", "1.2.3", "2.0.0", false)]
-    // Caret range matching with major > 0
-    [InlineData("caret", "1.2.3", "1.2.3", true)]
-    [InlineData("caret", "1.2.3", "1.2.4", true)]
-    [InlineData("caret", "1.2.3", "1.9.9", true)]
-    [InlineData("caret", "1.2.3", "2.0.0", false)]
-    [InlineData("caret", "1.2.3", "1.2.2", false)]
-    [InlineData("caret", "1.2.3", "3.0.0", false)]
-    // Caret range matching with major = 0, minor > 0
-    [InlineData("caret", "0.2.3", "0.2.3", true)]
-    [InlineData("caret", "0.2.3", "0.2.4", true)]
-    [InlineData("caret", "0.2.3", "0.2.99", true)]
-    [InlineData("caret", "0.2.3", "0.3.0", false)]
-    [InlineData("caret", "0.2.3", "0.2.2", false)]
-    [InlineData("caret", "0.2.3", "1.0.0", false)]
-    // Caret range matching with major = 0, minor = 0
-    [InlineData("caret", "0.0.3", "0.0.3", true)]
-    [InlineData("caret", "0.0.3", "0.0.4", false)]
-    [InlineData("caret", "0.0.3", "0.0.2", false)]
-    [InlineData("caret", "0.0.3", "0.1.0", false)]
-    public void BoundsMatchCorrectly(string kind, string baseVersion, string testVersion, bool expectedInRange)
+    protected void AssertInRange(string baseVersion, string testVersion, bool expectedInRange)
     {
         Assert.True(SemanticVersion.TryParse(baseVersion, out var baseVer));
         Assert.True(SemanticVersion.TryParse(testVersion, out var testVer));
@@ -193,19 +219,13 @@ public class TheVersionRangeBoundsMethods
         Assert.NotNull(baseVer);
         Assert.NotNull(testVer);
 
-        var (lower, upper) = GetBounds(kind, baseVer.Value);
+        var (lower, upper) = GetBounds(baseVer.Value);
         var inRange = testVer.Value.IsInRange(lower, upper);
 
         Assert.Equal(expectedInRange, inRange);
     }
 
-    static (SemanticVersion Lower, SemanticVersion Upper) GetBounds(string kind, SemanticVersion version)
-        => kind switch
-        {
-            "tilde" => version.GetTildeBounds(),
-            "caret" => version.GetCaretBounds(),
-            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
-        };
+    private protected abstract (SemanticVersion Lower, SemanticVersion Upper) GetBounds(SemanticVersion version);
 }
 
 public class TheTryParseWildcardMethod

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PostHog;
+using PostHog.Sdk;
 using PostHog.Versioning;
 using UnitTests.Fakes;
 
@@ -243,6 +244,65 @@ public class TheIdentifyGroupAsyncMethod
                        """, received);
     }
 
+    [Fact]
+    public async Task CancellationTokenOverloadOverwritesNameProperty()
+    {
+        var container = new TestContainer();
+        var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
+        var client = container.Activate<PostHogClient>();
+        var properties = new Dictionary<string, object>
+        {
+            ["name"] = "Old Name",
+            ["tier"] = "enterprise"
+        };
+
+        var result = await client.GroupIdentifyAsync(
+            type: "organization",
+            key: "id:5",
+            name: "PostHog",
+            properties,
+            CancellationToken.None);
+
+        Assert.Equal(1, result.Status);
+        Assert.Equal("PostHog", properties["name"]);
+        using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
+        var root = document.RootElement;
+        var groupSet = root.GetProperty("properties").GetProperty("$group_set");
+        Assert.Equal("$organization_id:5", root.GetProperty("distinct_id").GetString());
+        Assert.Equal("PostHog", groupSet.GetProperty("name").GetString());
+        Assert.Equal("enterprise", groupSet.GetProperty("tier").GetString());
+    }
+
+    [Fact]
+    public async Task DistinctIdCancellationTokenOverloadOverwritesNameProperty()
+    {
+        var container = new TestContainer();
+        var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
+        var client = container.Activate<PostHogClient>();
+        var properties = new Dictionary<string, object>
+        {
+            ["name"] = "Old Name",
+            ["tier"] = "enterprise"
+        };
+
+        var result = await client.GroupIdentifyAsync(
+            distinctId: "custom_distinct_id",
+            type: "organization",
+            key: "id:5",
+            name: "PostHog",
+            properties,
+            CancellationToken.None);
+
+        Assert.Equal(1, result.Status);
+        Assert.Equal("PostHog", properties["name"]);
+        using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
+        var root = document.RootElement;
+        var groupSet = root.GetProperty("properties").GetProperty("$group_set");
+        Assert.Equal("custom_distinct_id", root.GetProperty("distinct_id").GetString());
+        Assert.Equal("PostHog", groupSet.GetProperty("name").GetString());
+        Assert.Equal("enterprise", groupSet.GetProperty("tier").GetString());
+    }
+
     [Fact] // Ported from PostHog/posthog-python test_basic_group_identify
     public async Task SendsCorrectPayloadWithUserProvidedDistinctId()
     {
@@ -277,6 +337,79 @@ public class TheIdentifyGroupAsyncMethod
                          "timestamp": "2024-01-21T19:08:23\u002B00:00"
                        }
                        """, received);
+    }
+}
+
+public class TheCapturePageViewMethod
+{
+    [Fact]
+    public async Task SendFeatureFlagsFalseUsesPageViewPayloadWithoutFeatureFlagProperties()
+    {
+        var container = new TestContainer();
+        var batchHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        var captured = client.CapturePageView(
+            distinctId: "distinct-id",
+            pagePath: "/pricing",
+            properties: new Dictionary<string, object> { ["source"] = "test" },
+            sendFeatureFlags: false);
+
+        Assert.True(captured);
+        await client.FlushAsync();
+        var batchItem = GetOnlyBatchItem(batchHandler);
+        var properties = batchItem.GetProperty("properties");
+        Assert.Equal("$pageview", batchItem.GetProperty("event").GetString());
+        Assert.Equal("distinct-id", batchItem.GetProperty("distinct_id").GetString());
+        Assert.Equal("/pricing", properties.GetProperty("$current_url").GetString());
+        Assert.Equal("test", properties.GetProperty("source").GetString());
+        Assert.False(properties.TryGetProperty("$active_feature_flags", out _));
+        Assert.False(properties.TryGetProperty("$feature/flag1", out _));
+    }
+
+    [Fact]
+    public async Task SendFeatureFlagsTrueAddsFeatureFlagPropertiesToPageViewPayload()
+    {
+        var container = new TestContainer();
+        var batchHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
+            """
+            {
+                "featureFlags": {
+                    "flag1": true,
+                    "flag2": false,
+                    "flag3": "variant"
+                }
+            }
+            """);
+        var client = container.Activate<PostHogClient>();
+
+        var captured = client.CapturePageView(
+            distinctId: "distinct-id",
+            pagePath: "/pricing",
+            properties: new Dictionary<string, object> { ["source"] = "test" },
+            sendFeatureFlags: true);
+
+        Assert.True(captured);
+        await client.FlushAsync();
+        Assert.Single(flagsHandler.ReceivedRequests);
+        var properties = GetOnlyBatchItem(batchHandler).GetProperty("properties");
+        Assert.Equal("/pricing", properties.GetProperty("$current_url").GetString());
+        Assert.True(properties.GetProperty("$feature/flag1").GetBoolean());
+        Assert.False(properties.GetProperty("$feature/flag2").GetBoolean());
+        Assert.Equal("variant", properties.GetProperty("$feature/flag3").GetString());
+        Assert.Contains(
+            properties.GetProperty("$active_feature_flags").EnumerateArray(),
+            flag => flag.GetString() == "flag1");
+        Assert.Contains(
+            properties.GetProperty("$active_feature_flags").EnumerateArray(),
+            flag => flag.GetString() == "flag3");
+    }
+
+    static JsonElement GetOnlyBatchItem(FakeHttpMessageHandler.RequestHandler batchHandler)
+    {
+        using var document = JsonDocument.Parse(batchHandler.GetReceivedRequestBody(indented: false));
+        return document.RootElement.GetProperty("batch").EnumerateArray().Single().Clone();
     }
 }
 
@@ -1526,6 +1659,61 @@ public class TheCaptureExceptionMethod
         Assert.Equal("[]", frame.GetProperty("pre_context").ToString());
         Assert.Equal("", frame.GetProperty("context_line").GetString());
         Assert.Equal("[]", frame.GetProperty("post_context").ToString());
+    }
+}
+
+public class TheNoOpPostHogClient
+{
+    [Fact]
+    public async Task RefactoredApiMethodsReturnNoOpResults()
+    {
+        var client = NoOpPostHogClient.Instance;
+
+        var aliasResult = await client.AliasAsync("previous-id", "new-id", CancellationToken.None);
+        var identifyResult = await client.IdentifyAsync("distinct-id", null, null, CancellationToken.None);
+        var groupResult = await client.GroupIdentifyAsync("organization", "id:5", null, CancellationToken.None);
+        var groupWithDistinctIdResult = await client.GroupIdentifyAsync("distinct-id", "organization", "id:5", null, CancellationToken.None);
+
+        Assert.Equal(0, aliasResult.Status);
+        Assert.Equal(0, identifyResult.Status);
+        Assert.Equal(0, groupResult.Status);
+        Assert.Equal(0, groupWithDistinctIdResult.Status);
+    }
+
+    [Fact]
+    public void RefactoredCaptureMethodsReturnFalseWithoutThrowing()
+    {
+        var client = NoOpPostHogClient.Instance;
+
+        var capturedWithBooleanFlags = client.Capture(
+            "distinct-id",
+            "event-name",
+            properties: null,
+            groups: null,
+            sendFeatureFlags: true);
+        var capturedWithSnapshot = client.Capture(
+            "distinct-id",
+            "event-name",
+            properties: null,
+            groups: null,
+            flags: null);
+        var capturedExceptionWithBooleanFlags = client.CaptureException(
+            null!,
+            "distinct-id",
+            properties: null,
+            groups: null,
+            sendFeatureFlags: true);
+        var capturedExceptionWithSnapshot = client.CaptureException(
+            null!,
+            "distinct-id",
+            properties: null,
+            groups: null,
+            flags: null);
+
+        Assert.False(capturedWithBooleanFlags);
+        Assert.False(capturedWithSnapshot);
+        Assert.False(capturedExceptionWithBooleanFlags);
+        Assert.False(capturedExceptionWithSnapshot);
     }
 }
 

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -1415,67 +1415,30 @@ public class TheCaptureExceptionMethod
     public async Task CaptureExceptionWithInvalidFilePathInStackFrame()
     {
         var (_, requestHandler, client) = CreateClient();
+        var compiledThrower = await CreateDivideByZeroExceptionWithTempSourceFileAsync();
+        File.Delete(compiledThrower.SourcePath);
 
-        var fakePath = @"fake_file.cs";
-        var code =
-            """
-            using System;
-            public static class Thrower
-            {
-                public static void Boom()
-                {
-                    int zero = 0;
-                    var _ = 1 / zero;
-                }
-            }
-            """;
+        client.CaptureException(compiledThrower.Exception, "some-distinct-id");
+        await client.FlushAsync();
 
-        // Parse with the fake source path so PDB embeds it
-        var parse = CSharpParseOptions.Default;
-        var tree = CSharpSyntaxTree.ParseText(SourceText.From(code, Encoding.UTF8), parse, path: fakePath);
-        var trustedPlatformAssemblies = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!).Split(Path.PathSeparator);
+        var (_, batchItem, props) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: true));
+        var divideByZeroException = GetExceptionOfType(props, "System.DivideByZeroException");
+        var frames = GetStackFrames(divideByZeroException);
+        var sourceFrame = frames.FirstOrDefault(f =>
+            f.TryGetProperty("abs_path", out var absPath) &&
+            string.Equals(absPath.GetString(), compiledThrower.SourcePath, StringComparison.Ordinal));
 
-        var refs = trustedPlatformAssemblies
-            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-            .GroupBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase)
-            .Select(g => MetadataReference.CreateFromFile(g.First()));
+        Assert.Equal("$exception", batchItem.GetProperty("event").GetString());
 
-        var comp = CSharpCompilation.Create(
-            "ThrowerAsm",
-            [tree],
-            refs,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Debug));
-
-        using var pe = new MemoryStream();
-        using var pdb = new MemoryStream();
-        var emit = comp.Emit(pe, pdb, options: new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb));
-        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
-
-        pe.Position = 0;
-        pdb.Position = 0;
-
-        var assemblyLoadContext = new AssemblyLoadContext("ThrowerCtx", isCollectible: true);
-        var assembly = assemblyLoadContext.LoadFromStream(pe, pdb);
-        var boom = assembly.GetType("Thrower")!.GetMethod("Boom", BindingFlags.Public | BindingFlags.Static)!;
-
-        try
+        // Some runtime/build combinations do not include source file paths in stack frames.
+        // When source info is absent, this scenario cannot be reproduced.
+        if (sourceFrame.ValueKind is JsonValueKind.Undefined)
         {
-            boom.Invoke(null, null);
+            return;
         }
-        catch (TargetInvocationException tie) when (tie.InnerException is DivideByZeroException ex)
-        {
-            client.CaptureException(ex, "some-distinct-id");
-            await client.FlushAsync();
 
-            var (_, batchItem, props) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: true));
-
-            var divideByZeroException = GetExceptionOfType(props, "System.DivideByZeroException");
-            var frames = GetStackFrames(divideByZeroException);
-
-            Assert.Equal("$exception", batchItem.GetProperty("event").GetString());
-            Assert.Equal(fakePath, frames[0].GetProperty("filename").GetString());
-            AssertContextEmpty(frames[0]);
-        }
+        Assert.Equal(Path.GetFileName(compiledThrower.SourcePath), sourceFrame.GetProperty("filename").GetString());
+        AssertContextEmpty(sourceFrame);
     }
 
     [Fact]


### PR DESCRIPTION
## :bulb: Motivation and Context

Refactor duplicate code paths found by the dry4dotnet PoC (github.com/marandaneto/dry4dotnet) without changing the public API or behavior.

This reduces repeated implementation/test patterns in group identify helpers, no-op client methods, capture helpers, sample setup, fake HTTP response helpers, and several duplicate-heavy tests.


## :green_heart: How did you test it?

- `dotnet build PostHog.sln --no-restore`
- `dotnet test PostHog.sln --no-build --no-restore`
- `dotnet test tests/UnitTests/UnitTests.csproj --framework net8.0 --no-restore --filter "FullyQualifiedName~SemanticVersionTests"`
- `dotnet test tests/UnitTests/UnitTests.csproj --framework net8.0 --no-restore --filter "FullyQualifiedName~TheIdentifyGroupAsyncMethod|FullyQualifiedName~TheCapturePageViewMethod|FullyQualifiedName~TheNoOpPostHogClient"`
- `dotnet test tests/UnitTests/UnitTests.csproj --framework net8.0 --no-build --no-restore --filter "FullyQualifiedName~SemanticVersionTests|FullyQualifiedName~LocalEvaluatorTests|FullyQualifiedName~FeatureFlagErrorTracking"`
- Re-ran dry4dotnet PoC and reduced candidates from 284 to 126.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check README.md#publishing-releases -->



