### PR TITLE
chore: add package CI job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,38 @@ jobs:
         run: dotnet build --configuration Release --no-restore --nologo
         shell: bash
 
+  package:
+    name: Package (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: PostHog
+            project: src/PostHog/PostHog.csproj
+          - name: PostHog.AI
+            project: src/PostHog.AI/PostHog.AI.csproj
+          - name: PostHog.AspNetCore
+            project: src/PostHog.AspNetCore/PostHog.AspNetCore.csproj
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore NuGet Packages
+        run: dotnet restore --locked-mode
+        shell: bash
+
+      - name: Pack ${{ matrix.name }}
+        run: dotnet pack "${{ matrix.project }}" --configuration Release --no-restore --nologo --output "${{ env.PackageDirectory }}"
+        shell: bash
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,8 +65,6 @@ jobs:
     steps:
       - name: Checkout main branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
 
       - name: Pack ${{ matrix.name }}
-        run: dotnet pack "${{ matrix.project }}" --configuration Release --no-restore --nologo --output "${{ env.PackageDirectory }}"
+        run: dotnet pack "${{ matrix.project }}" --configuration Release --no-restore --nologo --output "${{ env.PackageDirectory }}" /p:GeneratePackageOnBuild=false
         shell: bash
 
   test:


### PR DESCRIPTION
## :bulb: Motivation and Context
Package creation was not validated as part of CI, so packaging regressions could be missed until release time.

This adds a dedicated matrix CI job that restores dependencies and runs `dotnet pack` for the PostHog packages. The pack command disables `GeneratePackageOnBuild` during explicit packing so each package can build and pack successfully from a clean checkout.

## :green_heart: How did you test it?
Ran locally:

```bash
rm -rf build && dotnet restore --locked-mode && dotnet pack "src/PostHog/PostHog.csproj" --configuration Release --no-restore --nologo --output "$PWD/build/packages/Release" /p:GeneratePackageOnBuild=false && dotnet pack "src/PostHog.AI/PostHog.AI.csproj" --configuration Release --no-restore --nologo --output "$PWD/build/packages/Release" /p:GeneratePackageOnBuild=false && dotnet pack "src/PostHog.AspNetCore/PostHog.AspNetCore.csproj" --configuration Release --no-restore --nologo --output "$PWD/build/packages/Release" /p:GeneratePackageOnBuild=false
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check README.md#publishing-releases -->
