### PR TITLE
test: Add public API baseline probe

### DIFF
--- a/src/PostHog/Examples.cs
+++ b/src/PostHog/Examples.cs
@@ -9,6 +9,11 @@ namespace PostHog;
 /// </summary>
 public static class Examples
 {
+    /// <summary>
+    /// Test-only public API marker used to verify baseline checks.
+    /// </summary>
+    public const string PublicApiBaselineProbe = "public-api-baseline-probe";
+
     internal static readonly PostHogClient PostHog = new(new PostHogOptions
     {
         ProjectToken = "<ph_project_token>",


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds a tiny test-only public API surface so the PublicAPI baseline check added in #230 can be observed failing when the baseline is not updated.

## :green_heart: How did you test it?

- Ran `dotnet build --configuration Release --nologo` and confirmed it fails with `RS0016` because `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` were intentionally not updated.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check README.md#publishing-releases -->
