### PR TITLE
chore: remove unnecessary checkout fetch depth

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - name: Checkout main branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
@@ -88,8 +86,6 @@ jobs:
     steps:
       - name: Checkout main branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
@@ -127,8 +123,6 @@ jobs:
     steps:
       - name: Checkout main branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
-          fetch-depth: 0
 
       - name: Check for changesets
         id: check
@@ -92,7 +91,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
-          fetch-depth: 0
           token: ${{ steps.releaser.outputs.token }}
 
       - name: Configure Git

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -55,7 +55,5 @@
         <!-- Existing public API contains multiple optional-parameter overloads; keep PublicAPI baseline checks focused on local API diffs. -->
         <NoWarn>RS0026; $(NoWarn)</NoWarn>
 
-        <!-- Existing public API contains multiple optional-parameter overloads; keep PublicAPI baseline checks focused on local API diffs. -->
-        <NoWarn>RS0026; $(NoWarn)</NoWarn>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## :bulb: Motivation and Context
Remove checkout `fetch-depth: 0` where the workflows do not need full git history, and clean up the duplicated PublicApiAnalyzers warning suppression introduced in #230.

## :green_heart: How did you test it?

- `dotnet build --configuration Release --no-restore --nologo`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
