### PR TITLE
chore: restore release checkout fetch depth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Check for changesets
         id: check
@@ -91,6 +92,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
+          fetch-depth: 0
           token: ${{ steps.releaser.outputs.token }}
 
       - name: Configure Git


### PR DESCRIPTION
## :bulb: Motivation and Context

Rollback the `fetch-depth: 0` removal from PR #232 for the release workflow checkout steps that need full history.

## :green_heart: How did you test it?

Not run; workflow-only rollback.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
