### PR TITLE
chore: add AI contribution policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,3 +19,29 @@
 - [ ] Ran `pnpm changeset` to generate a changeset file
 
 <!-- For more details check README.md#publishing-releases -->
+
+## 🤖 Agent context
+
+<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
+
+<!-- Autonomy — keep one of the two options on the line below:
+     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
+     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->
+
+**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous
+
+<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
+     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
+     - decisions made along the way (what was tried, rejected, chosen, and why)
+     - anything else that helps reviewers
+     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
+     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
+-->
+<!-- Rules for agent-authored PRs:
+     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
+     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
+     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
+     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
+     - Do NOT claim manual testing you haven't done.
+     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
+-->

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -38,7 +38,7 @@ This is generally never helpful.
 
 ## Why we're not anti-AI
 
-We think the best contributions in 2026 often involve AI.
+We think the best contributions today often involve AI.
 A contributor who uses an LLM to help them understand unfamiliar code, draft a first pass, or catch edge cases they'd miss is probably _more_ productive than someone doing everything by hand.
 The key difference is that they're driving the AI, not the other way around.
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,45 @@
+# AI contributions policy
+
+PostHog is built with plenty of AI assistance.
+This policy exists because of a growing volume of low-quality, AI-generated contributions that waste maintainer time.
+
+## The standard
+
+**You own what you submit.**
+Understand your code, test it, and be ready to explain why it's correct and how it interacts with the rest of the system (without re-prompting an LLM).
+This is no different from what we'd expect of any contribution; AI makes it easier to skip the work – please don't skip the work.
+
+**Prove it works.**
+Before submitting, please verify the change actually works end-to-end — don't rely on "it compiles" or "tests pass" alone.
+
+Add tests for new behavior, smoke test the change in an example project where applicable, and describe your test strategy in the PR description: what you tested, how you tested it, and what edge cases you considered.
+
+For changes with user-visible UI, include a short demo (screenshot, screen recording, or GIF) of the feature working in the PR description. Ideally you demo more than just the happy path.
+
+PRs that clearly weren't run or tested will be closed under this policy.
+
+**Disclose AI usage.**
+Our [PR template](.github/pull_request_template.md) includes an Agent context section — please use it (most agents will pick it up automatically).
+If an agent co-authored or authored your PR, say so and leave context about the tools and session.
+This helps reviewers calibrate.
+
+**Prefer PRs over AI-generated issues.**
+If AI helped you find a bug, fix it and open a pull request — don't paste the AI's output into an issue.
+Unreviewed, AI-generated bug reports and security disclosures will be closed without response.
+
+**Don't submit unsolicited AI-generated PR reviews.**
+If you didn't write the code and aren't a maintainer, don't point an LLM at someone else's PR and leave its output as a review comment.
+This is generally never helpful.
+
+## What happens when contributions don't meet this bar
+
+- **First time:** We'll close the PR/issue with a link to this policy and a brief explanation.
+- **Two or more closures:** We'll block the account.
+
+## Why we're not anti-AI
+
+We think the best contributions in 2026 often involve AI.
+A contributor who uses an LLM to help them understand unfamiliar code, draft a first pass, or catch edge cases they'd miss is probably _more_ productive than someone doing everything by hand.
+The key difference is that they're driving the AI, not the other way around.
+
+If you're new to open-source contributing and want to learn, we're genuinely happy to help — open an issue, ask questions, submit small PRs.


### PR DESCRIPTION
## Problem

PostHog's main repo has an AI contributions policy and PR-template agent context section. The SDK and agent-extension repos should set the same expectations so AI-assisted contributions are easier to review consistently.

## Changes

- Add `AI_POLICY.md` at the repository root.
- Add an `Agent context` section to the PR template.
- Adapt the proof-of-work guidance for SDK and agent-extension projects by using repo-neutral testing guidance and calling out example-project smoke tests where applicable.

## How did you test this code?

- Verified the markdown changes locally.
- Ran `git diff --check`.
- Verified the PR template contains exactly one `## 🤖 Agent context` section.

## Checklist

- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Documentation-only change

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to apply the same policy/template update across the SDK and agent-extension repositories. The change was prepared in isolated git worktrees to avoid disturbing existing local branches, then reviewed for duplicate Agent context sections and markdown whitespace issues.
