### PR TITLE
chore: run required checks on docs-only PRs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,40 +22,12 @@ env:
 permissions:
   checks: write
   contents: read
-  pull-requests: read
 
 jobs:
   detect-markdown-only:
-    name: Detect markdown-only changes
-    runs-on: ubuntu-latest
-    outputs:
-      markdown_only: ${{ steps.detect.outputs.markdown_only }}
-    steps:
-      - name: Detect markdown-only PR
-        id: detect
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            echo "markdown_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename' > "$RUNNER_TEMP/changed-files.txt"
-
-          if [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then
-            markdown_only=false
-          elif grep -qvE '\.md$' "$RUNNER_TEMP/changed-files.txt"; then
-            markdown_only=false
-          else
-            markdown_only=true
-          fi
-
-          echo "markdown_only=$markdown_only" >> "$GITHUB_OUTPUT"
-          echo "markdown_only=$markdown_only"
+    uses: PostHog/.github/.github/workflows/detect-markdown-only.yml@ec25337d9fae0100622cbfea1bd5bd88284ac10b
+    permissions:
+      pull-requests: read
 
   build:
     needs: detect-markdown-only

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,9 +34,9 @@ jobs:
     name: Build and package
     runs-on: ubuntu-latest
     steps:
-      - name: Skip expensive CI for markdown-only PR
+      - name: Complete markdown-only PR check
         if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
+        run: echo "Only Markdown files changed; no additional work is required for this check."
       - name: Checkout main branch
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -75,9 +75,9 @@ jobs:
           - name: PostHog.AspNetCore
             project: src/PostHog.AspNetCore/PostHog.AspNetCore.csproj
     steps:
-      - name: Skip expensive CI for markdown-only PR
+      - name: Complete markdown-only PR check
         if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
+        run: echo "Only Markdown files changed; no additional work is required for this check."
       - name: Checkout main branch
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -104,9 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     # Run tests independently so build, test, and format feedback can complete in parallel.
     steps:
-      - name: Skip expensive CI for markdown-only PR
+      - name: Complete markdown-only PR check
         if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
+        run: echo "Only Markdown files changed; no additional work is required for this check."
       - name: Checkout main branch
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -149,9 +149,9 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Skip expensive CI for markdown-only PR
+      - name: Complete markdown-only PR check
         if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
+        run: echo "Only Markdown files changed; no additional work is required for this check."
       - name: Checkout main branch
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,21 +22,61 @@ env:
 permissions:
   checks: write
   contents: read
+  pull-requests: read
 
 jobs:
+  detect-markdown-only:
+    name: Detect markdown-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      markdown_only: ${{ steps.detect.outputs.markdown_only }}
+    steps:
+      - name: Detect markdown-only PR
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "markdown_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename' > "$RUNNER_TEMP/changed-files.txt"
+
+          if [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then
+            markdown_only=false
+          elif grep -qvE '\.md$' "$RUNNER_TEMP/changed-files.txt"; then
+            markdown_only=false
+          else
+            markdown_only=true
+          fi
+
+          echo "markdown_only=$markdown_only" >> "$GITHUB_OUTPUT"
+          echo "markdown_only=$markdown_only"
+
   build:
+    needs: detect-markdown-only
     name: Build and package
     runs-on: ubuntu-latest
     steps:
+      - name: Skip expensive CI for markdown-only PR
+        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
+        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
       - name: Checkout main branch
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET Core
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Restore NuGet Packages
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: dotnet restore --locked-mode
         shell: bash
 
@@ -44,10 +84,12 @@ jobs:
       # If a public API change is intentional, run `dotnet build --configuration Release`
       # locally and commit the relevant PublicAPI.Shipped.txt/PublicAPI.Unshipped.txt updates.
       - name: Build
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: dotnet build --configuration Release --no-restore --nologo
         shell: bash
 
   package:
+    needs: detect-markdown-only
     name: Package (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
@@ -61,45 +103,60 @@ jobs:
           - name: PostHog.AspNetCore
             project: src/PostHog.AspNetCore/PostHog.AspNetCore.csproj
     steps:
+      - name: Skip expensive CI for markdown-only PR
+        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
+        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
       - name: Checkout main branch
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET Core
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Restore NuGet Packages
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: dotnet restore --locked-mode
         shell: bash
 
       - name: Pack ${{ matrix.name }}
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: dotnet pack "${{ matrix.project }}" --configuration Release --no-restore --nologo --output "${{ env.PackageDirectory }}" /p:GeneratePackageOnBuild=false
         shell: bash
 
   test:
+    needs: detect-markdown-only
     name: Test
     runs-on: ubuntu-latest
     # Run tests independently so build, test, and format feedback can complete in parallel.
     steps:
+      - name: Skip expensive CI for markdown-only PR
+        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
+        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
       - name: Checkout main branch
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET Core
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Restore NuGet Packages
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: dotnet restore --locked-mode
         shell: bash
 
       - name: Run Tests
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: dotnet test --logger "trx;LogFileName=test-results.trx" --configuration Release --no-restore --nologo
         shell: bash
 
       - name: Collect Test Results
-        if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ needs.detect-markdown-only.outputs.markdown_only != 'true' && (github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) }}
         uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7 # v1
         with:
           name: "xUnit Tests"
@@ -107,7 +164,7 @@ jobs:
           reporter: 'dotnet-trx'
 
       - name: Upload Test Snapshots
-        if: failure()
+        if: ${{ needs.detect-markdown-only.outputs.markdown_only != 'true' && (failure()) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: verify-test-results
@@ -116,25 +173,34 @@ jobs:
             **/*.received.*
 
   format:
+    needs: detect-markdown-only
     name: Format
     runs-on: ubuntu-latest
     steps:
+      - name: Skip expensive CI for markdown-only PR
+        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
+        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
       - name: Checkout main branch
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Restore NuGet Packages
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: dotnet restore --locked-mode
         shell: bash
 
       - name: Set up dotnet-format problem matcher
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/problemMatchers/dotnet-format.json"
         shell: bash
 
       - name: Format!
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: bin/fmt --check
         shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "**/*.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem

Required checks can remain permanently pending on docs-only PRs when the workflow that reports the required check is skipped by a PR path filter.

## Changes

- Keep required-check workflows running for PRs so required status contexts are always reported.
- Reuse the shared markdown-only detector from `PostHog/.github` pinned to `ec25337d9fae0100622cbfea1bd5bd88284ac10b`.
- Scope `pull-requests: read` to only the detector job.
- For PRs where every changed file ends in `.md`, each required job runs a neutral completion step and bypasses the build/test/lint work.
- For any PR with non-`.md` changes, the normal CI steps still run.

## How did you test this code?

- Reviewed the workflow diff.
- Ran `git diff --check`.
- Parsed the edited workflow YAML locally.
- Verified the copied detector implementation was removed and the shared workflow reference is pinned to the merged `.github` commit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to apply this workflow change after markdown-only AI policy PRs exposed required checks that did not report. One subagent inspected each affected repo before implementation so the required job names and workflow structure stayed repo-specific. The common detector was then factored into `PostHog/.github` and referenced from this repo after that shared workflow merged.
