### PR TITLE
fix: use correct historical migration field

### DIFF
--- a/.changeset/tidy-ravens-migrate.md
+++ b/.changeset/tidy-ravens-migrate.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Use the correct historical_migration wire field for batch capture payloads.

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -71,7 +71,7 @@ internal sealed class PostHogApiClient : IDisposable
         {
             // PostHog's ingestion API still expects the project token under the wire name `api_key`.
             ["api_key"] = ProjectToken,
-            ["historical_migrations"] = false,
+            ["historical_migration"] = false,
             ["batch"] = events.ToReadOnlyList()
         };
 

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -181,7 +181,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             $$"""
               {
                 "api_key": "fake-project-token",
-                "historical_migrations": false,
+                "historical_migration": false,
                 "batch": [
                   {
                     "uuid": "00000000-0000-0000-0000-000000000000",
@@ -279,7 +279,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             $$"""
               {
                 "api_key": "fake-project-token",
-                "historical_migrations": false,
+                "historical_migration": false,
                 "batch": [
                   {
                     "uuid": "00000000-0000-0000-0000-000000000000",
@@ -488,7 +488,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             $$"""
               {
                 "api_key": "fake-project-token",
-                "historical_migrations": false,
+                "historical_migration": false,
                 "batch": [
                   {
                     "uuid": "00000000-0000-0000-0000-000000000000",
@@ -540,7 +540,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             $$"""
               {
                 "api_key": "fake-project-token",
-                "historical_migrations": false,
+                "historical_migration": false,
                 "batch": [
                   {
                     "uuid": "00000000-0000-0000-0000-000000000000",
@@ -593,7 +593,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             $$"""
               {
                 "api_key": "fake-project-token",
-                "historical_migrations": false,
+                "historical_migration": false,
                 "batch": [
                   {
                     "uuid": "00000000-0000-0000-0000-000000000000",
@@ -719,7 +719,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             $$"""
               {
                 "api_key": "fake-project-token",
-                "historical_migrations": false,
+                "historical_migration": false,
                 "batch": [
                   {
                     "uuid": "00000000-0000-0000-0000-000000000000",
@@ -2451,7 +2451,7 @@ public class TheGetFeatureFlagAsyncMethod
         JsonAssert.EqualIgnoringUuids($$"""
                        {
                          "api_key": "fake-project-token",
-                         "historical_migrations": false,
+                         "historical_migration": false,
                          "batch": [
                            {
                              "uuid": "00000000-0000-0000-0000-000000000000",
@@ -2501,7 +2501,7 @@ public class TheGetFeatureFlagAsyncMethod
         JsonAssert.EqualIgnoringUuids($$"""
                        {
                          "api_key": "fake-project-token",
-                         "historical_migrations": false,
+                         "historical_migration": false,
                          "batch": [
                            {
                              "uuid": "00000000-0000-0000-0000-000000000000",
@@ -2567,7 +2567,7 @@ public class TheGetFeatureFlagAsyncMethod
         JsonAssert.EqualIgnoringUuids($$"""
                        {
                          "api_key": "fake-project-token",
-                         "historical_migrations": false,
+                         "historical_migration": false,
                          "batch": [
                            {
                              "uuid": "00000000-0000-0000-0000-000000000000",
@@ -2675,7 +2675,7 @@ public class TheGetFeatureFlagAsyncMethod
         JsonAssert.EqualIgnoringUuids($$"""
                        {
                          "api_key": "test-api-key",
-                         "historical_migrations": false,
+                         "historical_migration": false,
                          "batch": [
                            {
                              "uuid": "00000000-0000-0000-0000-000000000000",

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -442,7 +442,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -606,7 +606,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -644,7 +644,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -683,7 +683,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -724,7 +724,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -767,7 +767,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -811,7 +811,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -862,7 +862,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -940,7 +940,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -1008,7 +1008,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",
@@ -1071,7 +1071,7 @@ public class TheCaptureMethod
         JsonAssert.EqualIgnoringUuids($$"""
                      {
                        "api_key": "fake-project-token",
-                       "historical_migrations": false,
+                       "historical_migration": false,
                        "batch": [
                          {
                            "uuid": "00000000-0000-0000-0000-000000000000",


### PR DESCRIPTION
## :bulb: Motivation and Context
The batch capture payload used `historical_migrations`, but the PostHog ingestion backend expects the singular `historical_migration` field. Since the SDK currently sends `false`, ingestion behaved the same by default, but the wire format was inconsistent with the backend and other SDKs.

## :green_heart: How did you test it?

```bash
dotnet test --no-restore --filter "FullyQualifiedName~PostHogClientTests|FullyQualifiedName~FeatureFlagsTests"
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The change was made with the pi coding agent after cross-checking the backend ingestion payload shape. The SDK payload key and existing expected JSON assertions were updated to use `historical_migration`, and a patch changeset was added for release notes.
