### PR TITLE
fix: generate SDK UUIDs as v7

### DIFF
--- a/.changeset/warm-tigers-flow.md
+++ b/.changeset/warm-tigers-flow.md
@@ -1,0 +1,6 @@
+---
+'PostHog': patch
+'PostHog.AI': patch
+---
+
+Generate SDK-created event, personless, and AI trace IDs as UUID v7.

--- a/src/PostHog.AI/PostHogOpenAIHandler.cs
+++ b/src/PostHog.AI/PostHogOpenAIHandler.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
+using PostHog.Library;
 
 namespace PostHog.AI;
 
@@ -424,7 +425,7 @@ public class PostHogOpenAIHandler : DelegatingHandler
                 eventProperties[PostHogAIFieldNames.Model] = model ?? "unknown";
 
             // Context integration
-            var traceId = context?.TraceId ?? Guid.NewGuid().ToString();
+            var traceId = context?.TraceId ?? UuidV7.NewString();
             eventProperties[PostHogAIFieldNames.TraceId] = traceId;
 
             var distinctId = context?.DistinctId ?? traceId;

--- a/src/PostHog/Api/CapturedEvent.cs
+++ b/src/PostHog/Api/CapturedEvent.cs
@@ -22,7 +22,7 @@ public class CapturedEvent
         Dictionary<string, object>? properties,
         DateTimeOffset timestamp)
     {
-        Uuid = Guid.NewGuid().ToString();
+        Uuid = UuidV7.NewString();
         EventName = eventName;
         DistinctId = distinctId;
         Timestamp = timestamp;

--- a/src/PostHog/Config/AssemblyInfo.cs
+++ b/src/PostHog/Config/AssemblyInfo.cs
@@ -4,3 +4,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnitTests.AspNetCore")]
 [assembly: InternalsVisibleTo("TestLibrary")]
 [assembly: InternalsVisibleTo("PostHog.AspNetCore")]
+[assembly: InternalsVisibleTo("PostHog.AI")]

--- a/src/PostHog/Library/UuidV7.cs
+++ b/src/PostHog/Library/UuidV7.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Security.Cryptography;
 
 namespace PostHog.Library;
@@ -8,16 +9,20 @@ internal static class UuidV7
     static readonly RandomNumberGenerator Random = RandomNumberGenerator.Create();
     static readonly char[] Hex = "0123456789abcdef".ToCharArray();
     static readonly byte[] LastRandom = new byte[10];
+    static readonly Func<Guid>? PlatformCreateVersion7 = CreatePlatformCreateVersion7();
 
     static long LastTimestamp = -1;
 
     public static string NewString()
+        => PlatformCreateVersion7?.Invoke().ToString() ?? NewFallbackString();
+
+    internal static string NewFallbackString(Func<long>? timestampProvider = null)
     {
         var bytes = new byte[16];
 
         lock (Sync)
         {
-            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var timestamp = timestampProvider?.Invoke() ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             if (timestamp <= LastTimestamp)
             {
                 timestamp = LastTimestamp;
@@ -43,6 +48,20 @@ internal static class UuidV7
         bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
 
         return Format(bytes);
+    }
+
+    static Func<Guid>? CreatePlatformCreateVersion7()
+    {
+        var method = typeof(Guid).GetMethod(
+            "CreateVersion7",
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        return method?.ReturnType == typeof(Guid)
+            ? (Func<Guid>)Delegate.CreateDelegate(typeof(Func<Guid>), method)
+            : null;
     }
 
     static void IncrementRandom()

--- a/src/PostHog/Library/UuidV7.cs
+++ b/src/PostHog/Library/UuidV7.cs
@@ -1,0 +1,79 @@
+using System.Security.Cryptography;
+
+namespace PostHog.Library;
+
+internal static class UuidV7
+{
+    static readonly object Sync = new();
+    static readonly RandomNumberGenerator Random = RandomNumberGenerator.Create();
+    static readonly char[] Hex = "0123456789abcdef".ToCharArray();
+    static readonly byte[] LastRandom = new byte[10];
+
+    static long LastTimestamp = -1;
+
+    public static string NewString()
+    {
+        var bytes = new byte[16];
+
+        lock (Sync)
+        {
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            if (timestamp <= LastTimestamp)
+            {
+                timestamp = LastTimestamp;
+                IncrementRandom();
+            }
+            else
+            {
+                LastTimestamp = timestamp;
+                Random.GetBytes(LastRandom);
+            }
+
+            bytes[0] = (byte)(timestamp >> 40);
+            bytes[1] = (byte)(timestamp >> 32);
+            bytes[2] = (byte)(timestamp >> 24);
+            bytes[3] = (byte)(timestamp >> 16);
+            bytes[4] = (byte)(timestamp >> 8);
+            bytes[5] = (byte)timestamp;
+
+            Buffer.BlockCopy(LastRandom, 0, bytes, 6, LastRandom.Length);
+        }
+
+        bytes[6] = (byte)((bytes[6] & 0x0F) | 0x70);
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
+
+        return Format(bytes);
+    }
+
+    static void IncrementRandom()
+    {
+        for (var i = LastRandom.Length - 1; i >= 0; i--)
+        {
+            LastRandom[i]++;
+            if (LastRandom[i] != 0)
+            {
+                return;
+            }
+        }
+    }
+
+    static string Format(byte[] bytes)
+    {
+        var chars = new char[36];
+        var charIndex = 0;
+
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            if (i is 4 or 6 or 8 or 10)
+            {
+                chars[charIndex++] = '-';
+            }
+
+            var b = bytes[i];
+            chars[charIndex++] = Hex[b >> 4];
+            chars[charIndex++] = Hex[b & 0x0F];
+        }
+
+        return new string(chars);
+    }
+}

--- a/src/PostHog/PostHogContext.cs
+++ b/src/PostHog/PostHogContext.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using PostHog.Api;
+using PostHog.Library;
 
 namespace PostHog;
 
@@ -138,7 +139,7 @@ internal static class PostHogContextHelper
             return new PostHogCaptureIdentity(contextDistinctId!, IsPersonless: false);
         }
 
-        return new PostHogCaptureIdentity(Guid.NewGuid().ToString(), IsPersonless: true);
+        return new PostHogCaptureIdentity(UuidV7.NewString(), IsPersonless: true);
     }
 
     static Dictionary<string, object>? ApplyContextProperties(

--- a/tests/PostHog.AI.Tests/PostHogOpenAIHandlerTests.cs
+++ b/tests/PostHog.AI.Tests/PostHogOpenAIHandlerTests.cs
@@ -309,6 +309,14 @@ public sealed class PostHogOpenAIHandlerTests : IDisposable
             || (string)provider != "openai"
         )
             return false;
+        if (
+            !props.TryGetValue(PostHogAIFieldNames.TraceId, out var traceId)
+            || traceId is not string traceIdString
+            || traceIdString.Length != 36
+            || !Guid.TryParse(traceIdString, out _)
+            || traceIdString[14] != '7'
+        )
+            return false;
         return true;
     }
 

--- a/tests/UnitTests/Api/CapturedEventTests.cs
+++ b/tests/UnitTests/Api/CapturedEventTests.cs
@@ -23,6 +23,7 @@ public class TheConstructor
 
         Assert.True(Guid.TryParse(capturedEvent.Uuid, out var guid), "UUID should be valid GUID format");
         Assert.NotEqual(Guid.Empty, guid);
+        Assert.Equal('7', capturedEvent.Uuid[14]);
     }
 
     [Fact]

--- a/tests/UnitTests/Library/UuidV7Tests.cs
+++ b/tests/UnitTests/Library/UuidV7Tests.cs
@@ -1,0 +1,21 @@
+using PostHog.Library;
+
+namespace UuidV7Tests;
+
+public class TheNewFallbackStringMethod
+{
+    [Fact]
+    public void GeneratesMonotonicUuidStringsWithinSameMillisecond()
+    {
+        const long sameMillisecond = 1_735_689_600_000;
+
+        var first = UuidV7.NewFallbackString(() => sameMillisecond);
+        var second = UuidV7.NewFallbackString(() => sameMillisecond);
+
+        Assert.True(Guid.TryParse(first, out _));
+        Assert.True(Guid.TryParse(second, out _));
+        Assert.Equal('7', first[14]);
+        Assert.Equal('7', second[14]);
+        Assert.True(string.CompareOrdinal(first, second) < 0);
+    }
+}

--- a/tests/UnitTests/PostHogContextTests.cs
+++ b/tests/UnitTests/PostHogContextTests.cs
@@ -154,6 +154,7 @@ public class ThePostHogContext
         var context = PostHogContextHelper.ResolveCaptureContext(distinctId: null, properties: properties);
 
         Assert.True(Guid.TryParse(context.DistinctId, out _));
+        Assert.Equal('7', context.DistinctId[14]);
         Assert.True(context.IsPersonless);
         Assert.NotNull(context.Properties);
         Assert.Equal(expectedValue, (bool)context.Properties["$process_person_profile"]);


### PR DESCRIPTION
## :bulb: Motivation and Context

SDK-generated IDs should be UUID v7 so event UUIDs, personless distinct IDs, and default AI trace IDs are time-ordered instead of random UUID v4 values.

This adds an internal UUID v7 helper that uses `Guid.CreateVersion7()` when the runtime provides it, with a fallback generator for older runtimes/target frameworks. The helper is used for runtime SDK-generated IDs in `PostHog` and `PostHog.AI`.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --filter "FullyQualifiedName~CapturedEventTests|FullyQualifiedName~PostHogContextTests"`
- `dotnet test tests/PostHog.AI.Tests/PostHog.AI.Tests.csproj --filter "FullyQualifiedName~PostHogOpenAIHandlerTests.SendAsyncCapturesEventOnSuccess"`
- `dotnet build src/PostHog/PostHog.csproj --no-restore`
- `dotnet build src/PostHog.AI/PostHog.AI.csproj --no-restore`
- `dotnet test PostHog.sln`
- `dotnet test`
- `dotnet format --verify-no-changes`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by the `worker` agent using repository-local inspection and .NET CLI validation. Follow-up review feedback added runtime use of `Guid.CreateVersion7()` when available plus deterministic fallback monotonicity coverage.
