### PR TITLE
fix: preserve capture geoip override

### DIFF
--- a/.changeset/calm-bees-smile.md
+++ b/.changeset/calm-bees-smile.md
@@ -1,0 +1,5 @@
+---
+'PostHog': patch
+---
+
+Preserve per-capture GeoIP override properties when super properties are configured.

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -292,6 +292,10 @@ public sealed class PostHogClient : IPostHogClient
         }
 
         var captureContext = PostHogContextHelper.ResolveCaptureContext(distinctId, properties);
+        object? geoIpDisableOverride = null;
+        var hasGeoIpDisableOverride = captureContext.Properties?.TryGetValue(
+            PostHogProperties.GeoIpDisable,
+            out geoIpDisableOverride) == true;
 
         var capturedEvent = new CapturedEvent(
             eventName,
@@ -305,6 +309,11 @@ public sealed class PostHogClient : IPostHogClient
         }
 
         capturedEvent.Properties.Merge(_options.Value.SuperProperties);
+
+        if (hasGeoIpDisableOverride)
+        {
+            capturedEvent.Properties[PostHogProperties.GeoIpDisable] = geoIpDisableOverride!;
+        }
 
         // Stamp $is_server last so a super property can't override the SDK's server/client classification.
         if (_options.Value.IsServer)

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -415,12 +415,14 @@ public class TheCapturePageViewMethod
 
 public class TheCaptureMethod
 {
-    [Fact]
-    public async Task CapturePropertiesOverrideConfiguredGeoIpDisable()
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task CapturePropertiesOverrideConfiguredGeoIpDisable(bool superValue, bool perCaptureValue)
     {
         var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
         {
-            options.SuperProperties["$geoip_disable"] = true;
+            options.SuperProperties["$geoip_disable"] = superValue;
         }));
         var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
@@ -430,7 +432,7 @@ public class TheCaptureMethod
             "geoip-event",
             new Dictionary<string, object>
             {
-                ["$geoip_disable"] = false,
+                ["$geoip_disable"] = perCaptureValue,
                 ["$ip"] = "203.0.113.42"
             });
         await client.FlushAsync();
@@ -440,7 +442,7 @@ public class TheCaptureMethod
             .GetProperty("batch")[0]
             .GetProperty("properties");
 
-        Assert.False(properties.GetProperty("$geoip_disable").GetBoolean());
+        Assert.Equal(perCaptureValue, properties.GetProperty("$geoip_disable").GetBoolean());
         Assert.Equal("203.0.113.42", properties.GetProperty("$ip").GetString());
     }
 

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -416,6 +416,35 @@ public class TheCapturePageViewMethod
 public class TheCaptureMethod
 {
     [Fact]
+    public async Task CapturePropertiesOverrideConfiguredGeoIpDisable()
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SuperProperties["$geoip_disable"] = true;
+        }));
+        var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        client.Capture(
+            "test-user",
+            "geoip-event",
+            new Dictionary<string, object>
+            {
+                ["$geoip_disable"] = false,
+                ["$ip"] = "203.0.113.42"
+            });
+        await client.FlushAsync();
+
+        using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement
+            .GetProperty("batch")[0]
+            .GetProperty("properties");
+
+        Assert.False(properties.GetProperty("$geoip_disable").GetBoolean());
+        Assert.Equal("203.0.113.42", properties.GetProperty("$ip").GetString());
+    }
+
+    [Fact]
     public async Task SendsEnrichedCapturedEventsWhenSendFeatureFlagsTrueButDoesNotMakeSameDecideCallTwice()
     {
         var container = new TestContainer();


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes https://github.com/PostHog/posthog-dotnet/issues/95.

`$geoip_disable` can be configured globally through super properties, but callers also need to opt individual capture calls back into GeoIP enrichment by passing `$geoip_disable: false` alongside `$ip`. The existing capture path merged super properties after constructing the event, so the global value overwrote the per-capture override.

## :green_heart: How did you test it?

```bash
dotnet test tests/UnitTests/UnitTests.csproj
dotnet test tests/UnitTests/UnitTests.csproj --filter "FullyQualifiedName~PostHogClientTests.TheCaptureMethod.CapturePropertiesOverrideConfiguredGeoIpDisable"
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi. The issue was reproduced with a regression test and fixed by preserving the per-capture override following super property merging. Reviewer feedback was addressed by parameterizing the regression test to cover both override directions. Added a patch changeset for the `PostHog` package.
