### PR TITLE
ci: set release environment for publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,7 @@ jobs:
     needs: [version-bump, notify-approval-needed]
     runs-on: ubuntu-latest
     if: always() && needs.version-bump.outputs.committed == 'true'
+    environment: Release
     permissions:
       contents: write
       actions: write


### PR DESCRIPTION
## :bulb: Motivation and Context
The release workflow failed while publishing `PostHog@2.8.0` because NuGet trusted publishing rejected the OIDC token:

> Environment mismatch for policy 'posthog-dotnet': expected 'Release', actual ''

The publish job requested `id-token: write` but did not declare the `Release` GitHub environment, so the token did not include the environment claim required by the NuGet policy.

## :green_heart: How did you test it?

- Parsed `.github/workflows/release.yml` successfully with PyYAML.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An agent investigated the failed GitHub Actions run, identified the missing release environment on the publish job, and made the smallest workflow change needed for NuGet trusted publishing to receive the expected environment claim.
