### PR TITLE
chore: rollback unpublished release metadata

### DIFF
--- a/.changeset/dry-owls-refactor.md
+++ b/.changeset/dry-owls-refactor.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Refactor duplicate internal SDK code paths without changing public API behavior.

--- a/.changeset/feature-flag-early-exit.md
+++ b/.changeset/feature-flag-early-exit.md
@@ -1,0 +1,5 @@
+---
+"PostHog": minor
+---
+
+Support the `early_exit` filter option in local feature flag evaluation, mirroring the server-side evaluation engine. When a flag's `filters.early_exit` is `true` and a condition group's property filters match (or the group has none) but the rollout percentage excludes the user, evaluation stops and the flag returns a definitive disabled result instead of falling through to later condition groups. A pure property-filter mismatch always falls through, even when `early_exit` is enabled. When the field is absent or `false`, existing behavior is preserved.

--- a/.changeset/few-flags-dance.md
+++ b/.changeset/few-flags-dance.md
@@ -1,0 +1,6 @@
+---
+"PostHog": minor
+"PostHog.AspNetCore": minor
+---
+
+Add feature flag evaluation contexts via `PostHogOptions.EvaluationContexts`. `/flags` requests now send `evaluation_contexts` when configured.

--- a/.changeset/gentle-ducks-share.md
+++ b/.changeset/gentle-ducks-share.md
@@ -1,0 +1,7 @@
+---
+"PostHog": patch
+"PostHog.AspNetCore": patch
+"PostHog.AI": patch
+---
+
+Document public APIs and make `GroupCollection.TryAdd(Group)` store entries by group type instead of group key, matching the collection's one-group-per-type behavior.

--- a/.changeset/include-group-context-in-flag-called-dedupe.md
+++ b/.changeset/include-group-context-in-flag-called-dedupe.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Include group context in the `$feature_flag_called` dedupe cache key so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinctId, featureKey, response)` was seen under. The groups are canonicalized order-independently (`OrderBy(GroupType, StringComparer.Ordinal)`) so two equal collections built in different insertion orders still dedupe.

--- a/.changeset/is-server-property.md
+++ b/.changeset/is-server-property.md
@@ -1,0 +1,5 @@
+---
+"PostHog": minor
+---
+
+Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `PostHogOptions.IsServer` to `false` when using the SDK as a client/CLI so the device OS is attributed normally.

--- a/.changeset/noop-api-failures.md
+++ b/.changeset/noop-api-failures.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Return no-op results instead of throwing from public APIs when PostHog API calls fail.

--- a/.changeset/silver-geese-trace.md
+++ b/.changeset/silver-geese-trace.md
@@ -1,0 +1,6 @@
+---
+'PostHog': minor
+'PostHog.AspNetCore': minor
+---
+
+Add request-scoped server request context support for tracing headers and ASP.NET Core metadata.

--- a/.changeset/strict-semver-leading-zeros.md
+++ b/.changeset/strict-semver-leading-zeros.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Reject semver values with leading zeros in local flag evaluation. Per semver 2.0.0 §2, numeric identifiers must not include leading zeros — values like `1.07.3` are not valid semver and should not match targeting conditions. Both override values and flag values are now validated; invalid inputs cause `SemanticVersion.TryParse` to return false so the condition does not match.

--- a/.changeset/tidy-ravens-migrate.md
+++ b/.changeset/tidy-ravens-migrate.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Use the correct historical_migration wire field for batch capture payloads.

--- a/src/PostHog.AI/CHANGELOG.md
+++ b/src/PostHog.AI/CHANGELOG.md
@@ -1,11 +1,5 @@
 # PostHog.AI
 
-## 0.1.3
-
-### Patch Changes
-
-- 2f5bded: Document public APIs and make `GroupCollection.TryAdd(Group)` store entries by group type instead of group key, matching the collection's one-group-per-type behavior.
-
 ## 0.1.2
 
 ### Patch Changes

--- a/src/PostHog.AI/PostHog.AI.csproj
+++ b/src/PostHog.AI/PostHog.AI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>0.1.3</Version>
+    <Version>0.1.2</Version>
     <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>PostHog.AI</PackageId>

--- a/src/PostHog.AI/package.json
+++ b/src/PostHog.AI/package.json
@@ -1,5 +1,5 @@
 {
   "name": "PostHog.AI",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "private": true
 }

--- a/src/PostHog.AspNetCore/CHANGELOG.md
+++ b/src/PostHog.AspNetCore/CHANGELOG.md
@@ -1,16 +1,5 @@
 # PostHog.AspNetCore
 
-## 2.7.0
-
-### Minor Changes
-
-- 9ea2412: Add feature flag evaluation contexts via `PostHogOptions.EvaluationContexts`. `/flags` requests now send `evaluation_contexts` when configured.
-- 479f5ca: Add request-scoped server request context support for tracing headers and ASP.NET Core metadata.
-
-### Patch Changes
-
-- 2f5bded: Document public APIs and make `GroupCollection.TryAdd(Group)` store entries by group type instead of group key, matching the collection's one-group-per-type behavior.
-
 ## 2.6.3
 
 ### Patch Changes

--- a/src/PostHog.AspNetCore/PostHog.AspNetCore.csproj
+++ b/src/PostHog.AspNetCore/PostHog.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>2.7.0</Version>
+        <Version>2.6.3</Version>
         <TargetFramework>net8.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>PostHog.AspNetCore</PackageId>

--- a/src/PostHog.AspNetCore/package.json
+++ b/src/PostHog.AspNetCore/package.json
@@ -1,5 +1,5 @@
 {
   "name": "PostHog.AspNetCore",
-  "version": "2.7.0",
+  "version": "2.6.3",
   "private": true
 }

--- a/src/PostHog/CHANGELOG.md
+++ b/src/PostHog/CHANGELOG.md
@@ -1,23 +1,5 @@
 # PostHog
 
-## 2.8.0
-
-### Minor Changes
-
-- b3150eb: Support the `early_exit` filter option in local feature flag evaluation, mirroring the server-side evaluation engine. When a flag's `filters.early_exit` is `true` and a condition group's property filters match (or the group has none) but the rollout percentage excludes the user, evaluation stops and the flag returns a definitive disabled result instead of falling through to later condition groups. A pure property-filter mismatch always falls through, even when `early_exit` is enabled. When the field is absent or `false`, existing behavior is preserved.
-- 9ea2412: Add feature flag evaluation contexts via `PostHogOptions.EvaluationContexts`. `/flags` requests now send `evaluation_contexts` when configured.
-- bd768fd: Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `PostHogOptions.IsServer` to `false` when using the SDK as a client/CLI so the device OS is attributed normally.
-- 479f5ca: Add request-scoped server request context support for tracing headers and ASP.NET Core metadata.
-
-### Patch Changes
-
-- 2367f9b: Refactor duplicate internal SDK code paths without changing public API behavior.
-- 2f5bded: Document public APIs and make `GroupCollection.TryAdd(Group)` store entries by group type instead of group key, matching the collection's one-group-per-type behavior.
-- f0b7308: Include group context in the `$feature_flag_called` dedupe cache key so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinctId, featureKey, response)` was seen under. The groups are canonicalized order-independently (`OrderBy(GroupType, StringComparer.Ordinal)`) so two equal collections built in different insertion orders still dedupe.
-- 48fcc1c: Return no-op results instead of throwing from public APIs when PostHog API calls fail.
-- 2caf86e: Reject semver values with leading zeros in local flag evaluation. Per semver 2.0.0 §2, numeric identifiers must not include leading zeros — values like `1.07.3` are not valid semver and should not match targeting conditions. Both override values and flag values are now validated; invalid inputs cause `SemanticVersion.TryParse` to return false so the condition does not match.
-- 620bc67: Use the correct historical_migration wire field for batch capture payloads.
-
 ## 2.7.1
 
 ### Patch Changes

--- a/src/PostHog/Generated/VersionConstants.cs
+++ b/src/PostHog/Generated/VersionConstants.cs
@@ -13,5 +13,5 @@ public static class VersionConstants
     /// <summary>
     /// The version of the PostHog package.
     /// </summary>
-    public const string Version = "2.8.0";
+    public const string Version = "2.7.1";
 }

--- a/src/PostHog/PostHog.csproj
+++ b/src/PostHog/PostHog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>2.8.0</Version>
+        <Version>2.7.1</Version>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>PostHog</PackageId>

--- a/src/PostHog/package.json
+++ b/src/PostHog/package.json
@@ -1,5 +1,5 @@
 {
   "name": "PostHog",
-  "version": "2.8.0",
+  "version": "2.7.1",
   "private": true
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

NuGet still shows the latest published package versions as:

- `PostHog` `2.7.1`
- `PostHog.AspNetCore` `2.6.3`
- `PostHog.AI` `0.1.2`

The repository metadata had already advanced to unpublished versions (`2.8.0`, `2.7.0`, and `0.1.3`). This rolls back those version/changelog updates and restores the consumed changeset files so the repository state matches what is actually published.

## :green_heart: How did you test it?

Not run; metadata/changelog-only rollback.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi using git worktrees. The change restores the changeset files consumed by the unpublished release metadata commit and reverts package metadata/changelog versions to the latest versions currently available on NuGet.
