### PR TITLE
Revert: "ci: set release environment for publish job"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,6 @@ jobs:
     needs: [version-bump, notify-approval-needed]
     runs-on: ubuntu-latest
     if: always() && needs.version-bump.outputs.committed == 'true'
-    environment: Release
     permissions:
       contents: write
       actions: write


### PR DESCRIPTION
Reverts PostHog/posthog-dotnet#241

removed the requirement from nuget so we dont have to approve twice
i'll refactor this soon so we dont have to approve multiple times and still behind the environment protection