### PR TITLE
fix: fall back when payload compression fails

### DIFF
--- a/.changeset/cold-buckets-gzip.md
+++ b/.changeset/cold-buckets-gzip.md
@@ -1,0 +1,5 @@
+---
+'posthog-dotnet': patch
+---
+
+Fall back to uncompressed batch uploads when local gzip compression fails.

--- a/.changeset/cold-buckets-gzip.md
+++ b/.changeset/cold-buckets-gzip.md
@@ -1,5 +1,6 @@
 ---
-'posthog-dotnet': patch
+'PostHog': patch
+'PostHog.AspNetCore': patch
 ---
 
 Fall back to uncompressed batch uploads when local gzip compression fails.

--- a/src/PostHog/Library/HttpClientExtensions.cs
+++ b/src/PostHog/Library/HttpClientExtensions.cs
@@ -13,7 +13,7 @@ namespace PostHog.Library;
 /// </summary>
 internal static class HttpClientExtensions
 {
-    internal static Func<byte[], ByteArrayContent> CreateCompressedJsonContent = CreateGzipJsonContent;
+    internal static Func<object, CancellationToken, Task<ByteArrayContent>> CreateCompressedJsonContentAsync = CreateGzipJsonContentAsync;
     /// <summary>
     /// Sends a POST request to the specified Uri containing the value serialized as JSON in the request body.
     /// Returns the response body deserialized as <typeparamref name="TBody"/>.
@@ -276,8 +276,7 @@ internal static class HttpClientExtensions
         object content,
         CancellationToken cancellationToken)
     {
-        var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(content, JsonSerializerHelper.Options);
-        var compressedContent = TryCreateCompressedJsonContent(jsonBytes);
+        var compressedContent = await TryCreateCompressedJsonContentAsync(content, cancellationToken);
         if (compressedContent is null)
         {
             return await httpClient.PostAsJsonAsync(
@@ -293,11 +292,13 @@ internal static class HttpClientExtensions
         }
     }
 
-    static ByteArrayContent? TryCreateCompressedJsonContent(byte[] jsonBytes)
+    static async Task<ByteArrayContent?> TryCreateCompressedJsonContentAsync(
+        object content,
+        CancellationToken cancellationToken)
     {
         try
         {
-            return CreateCompressedJsonContent(jsonBytes);
+            return await CreateCompressedJsonContentAsync(content, cancellationToken);
         }
         catch (Exception ex) when (ex is IOException or InvalidDataException or NotSupportedException or ObjectDisposedException)
         {
@@ -306,12 +307,15 @@ internal static class HttpClientExtensions
         }
     }
 
-    static ByteArrayContent CreateGzipJsonContent(byte[] jsonBytes)
+    static async Task<ByteArrayContent> CreateGzipJsonContentAsync(
+        object content,
+        CancellationToken cancellationToken)
     {
+        // Stream JSON directly into gzip to avoid intermediate allocation and honor cancellation during serialization.
         using var memoryStream = new MemoryStream(4096);
         using (var gzipStream = new GZipStream(memoryStream, CompressionLevel.Fastest, leaveOpen: true))
         {
-            gzipStream.Write(jsonBytes, 0, jsonBytes.Length);
+            await JsonSerializer.SerializeAsync(gzipStream, content, JsonSerializerHelper.Options, cancellationToken);
         }
 
         // Use TryGetBuffer to avoid ToArray() copy when possible

--- a/src/PostHog/Library/HttpClientExtensions.cs
+++ b/src/PostHog/Library/HttpClientExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Json;
@@ -12,6 +13,7 @@ namespace PostHog.Library;
 /// </summary>
 internal static class HttpClientExtensions
 {
+    internal static Func<byte[], ByteArrayContent> CreateCompressedJsonContent = CreateGzipJsonContent;
     /// <summary>
     /// Sends a POST request to the specified Uri containing the value serialized as JSON in the request body.
     /// Returns the response body deserialized as <typeparamref name="TBody"/>.
@@ -274,7 +276,8 @@ internal static class HttpClientExtensions
         object content,
         CancellationToken cancellationToken)
     {
-        var compressedContent = await TryCreateCompressedJsonContentAsync(content, cancellationToken);
+        var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(content, JsonSerializerHelper.Options);
+        var compressedContent = TryCreateCompressedJsonContent(jsonBytes);
         if (compressedContent is null)
         {
             return await httpClient.PostAsJsonAsync(
@@ -290,36 +293,35 @@ internal static class HttpClientExtensions
         }
     }
 
-    static async Task<ByteArrayContent?> TryCreateCompressedJsonContentAsync(
-        object content,
-        CancellationToken cancellationToken)
+    static ByteArrayContent? TryCreateCompressedJsonContent(byte[] jsonBytes)
     {
         try
         {
-            // Stream JSON directly into gzip to avoid intermediate allocation
-            using var memoryStream = new MemoryStream(4096);
-            using (var gzipStream = new GZipStream(memoryStream, CompressionLevel.Fastest, leaveOpen: true))
-            {
-                await JsonSerializer.SerializeAsync(gzipStream, content, JsonSerializerHelper.Options, cancellationToken);
-            }
-
-            // Use TryGetBuffer to avoid ToArray() copy when possible
-            var compressedContent = memoryStream.TryGetBuffer(out var buffer)
-                ? new ByteArrayContent(buffer.Array!, buffer.Offset, buffer.Count)
-                : new ByteArrayContent(memoryStream.ToArray());
-
-            compressedContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            compressedContent.Headers.ContentEncoding.Add("gzip");
-            return compressedContent;
+            return CreateCompressedJsonContent(jsonBytes);
         }
-        catch (IOException)
+        catch (Exception ex) when (ex is IOException or InvalidDataException or NotSupportedException or ObjectDisposedException)
         {
+            Debug.WriteLine($"Failed to gzip request body, sending uncompressed: {ex}");
             return null;
         }
-        catch (InvalidDataException)
+    }
+
+    static ByteArrayContent CreateGzipJsonContent(byte[] jsonBytes)
+    {
+        using var memoryStream = new MemoryStream(4096);
+        using (var gzipStream = new GZipStream(memoryStream, CompressionLevel.Fastest, leaveOpen: true))
         {
-            return null;
+            gzipStream.Write(jsonBytes, 0, jsonBytes.Length);
         }
+
+        // Use TryGetBuffer to avoid ToArray() copy when possible
+        var compressedContent = memoryStream.TryGetBuffer(out var buffer)
+            ? new ByteArrayContent(buffer.Array!, buffer.Offset, buffer.Count)
+            : new ByteArrayContent(memoryStream.ToArray());
+
+        compressedContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+        compressedContent.Headers.ContentEncoding.Add("gzip");
+        return compressedContent;
     }
 
     public static async Task EnsureSuccessfulApiCall(

--- a/src/PostHog/Library/HttpClientExtensions.cs
+++ b/src/PostHog/Library/HttpClientExtensions.cs
@@ -69,7 +69,7 @@ internal static class HttpClientExtensions
             try
             {
                 response = enableCompression
-                    ? await PostCompressedJsonAsync(httpClient, requestUri, content, cancellationToken)
+                    ? await PostCompressedJsonWithFallbackAsync(httpClient, requestUri, content, cancellationToken)
                     : await httpClient.PostAsJsonAsync(
                         requestUri,
                         content,
@@ -268,30 +268,57 @@ internal static class HttpClientExtensions
 #endif
     }
 
-    static async Task<HttpResponseMessage> PostCompressedJsonAsync(
+    static async Task<HttpResponseMessage> PostCompressedJsonWithFallbackAsync(
         HttpClient httpClient,
         Uri requestUri,
         object content,
         CancellationToken cancellationToken)
     {
-        // Stream JSON directly into gzip to avoid intermediate allocation
-        using var memoryStream = new MemoryStream(4096);
-        using (var gzipStream = new GZipStream(memoryStream, CompressionLevel.Fastest, leaveOpen: true))
+        var compressedContent = await TryCreateCompressedJsonContentAsync(content, cancellationToken);
+        if (compressedContent is null)
         {
-            await JsonSerializer.SerializeAsync(gzipStream, content, JsonSerializerHelper.Options, cancellationToken);
+            return await httpClient.PostAsJsonAsync(
+                requestUri,
+                content,
+                JsonSerializerHelper.Options,
+                cancellationToken);
         }
-
-        // Use TryGetBuffer to avoid ToArray() copy when possible
-        var compressedContent = memoryStream.TryGetBuffer(out var buffer)
-            ? new ByteArrayContent(buffer.Array!, buffer.Offset, buffer.Count)
-            : new ByteArrayContent(memoryStream.ToArray());
 
         using (compressedContent)
         {
+            return await httpClient.PostAsync(requestUri, compressedContent, cancellationToken);
+        }
+    }
+
+    static async Task<ByteArrayContent?> TryCreateCompressedJsonContentAsync(
+        object content,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Stream JSON directly into gzip to avoid intermediate allocation
+            using var memoryStream = new MemoryStream(4096);
+            using (var gzipStream = new GZipStream(memoryStream, CompressionLevel.Fastest, leaveOpen: true))
+            {
+                await JsonSerializer.SerializeAsync(gzipStream, content, JsonSerializerHelper.Options, cancellationToken);
+            }
+
+            // Use TryGetBuffer to avoid ToArray() copy when possible
+            var compressedContent = memoryStream.TryGetBuffer(out var buffer)
+                ? new ByteArrayContent(buffer.Array!, buffer.Offset, buffer.Count)
+                : new ByteArrayContent(memoryStream.ToArray());
+
             compressedContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
             compressedContent.Headers.ContentEncoding.Add("gzip");
-
-            return await httpClient.PostAsync(requestUri, compressedContent, cancellationToken);
+            return compressedContent;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (InvalidDataException)
+        {
+            return null;
         }
     }
 

--- a/tests/UnitTests/Library/HttpClientExtensionsTests.cs
+++ b/tests/UnitTests/Library/HttpClientExtensionsTests.cs
@@ -605,8 +605,17 @@ public class ThePostCompressedJsonAsyncMethod
         Assert.Contains("api_key", decompressedJson, StringComparison.Ordinal);
     }
 
-    [Fact]
-    public async Task FallsBackToUncompressedRequestWhenCompressionFails()
+    public static IEnumerable<object[]> CompressionFailureExceptions()
+    {
+        yield return [new IOException("gzip failed")];
+        yield return [new InvalidDataException("gzip failed")];
+        yield return [new NotSupportedException("gzip failed")];
+        yield return [new ObjectDisposedException("gzip")];
+    }
+
+    [Theory]
+    [MemberData(nameof(CompressionFailureExceptions))]
+    public async Task FallsBackToUncompressedRequestWhenCompressionFails(Exception compressionException)
     {
         string? capturedBody = null;
         IEnumerable<string>? capturedContentEncoding = null;
@@ -632,8 +641,8 @@ public class ThePostCompressedJsonAsyncMethod
         };
         var timeProvider = new FakeTimeProvider();
         var payload = new { api_key = "test", batch = new[] { new { @event = "test-event" } } };
-        var originalCompressor = HttpClientExtensions.CreateCompressedJsonContent;
-        HttpClientExtensions.CreateCompressedJsonContent = _ => throw new IOException("gzip failed");
+        var originalCompressor = HttpClientExtensions.CreateCompressedJsonContentAsync;
+        HttpClientExtensions.CreateCompressedJsonContentAsync = (_, _) => Task.FromException<ByteArrayContent>(compressionException);
 
         try
         {
@@ -646,7 +655,7 @@ public class ThePostCompressedJsonAsyncMethod
         }
         finally
         {
-            HttpClientExtensions.CreateCompressedJsonContent = originalCompressor;
+            HttpClientExtensions.CreateCompressedJsonContentAsync = originalCompressor;
         }
 
         Assert.Empty(capturedContentEncoding ?? Enumerable.Empty<string>());

--- a/tests/UnitTests/Library/HttpClientExtensionsTests.cs
+++ b/tests/UnitTests/Library/HttpClientExtensionsTests.cs
@@ -606,6 +606,56 @@ public class ThePostCompressedJsonAsyncMethod
     }
 
     [Fact]
+    public async Task FallsBackToUncompressedRequestWhenCompressionFails()
+    {
+        string? capturedBody = null;
+        IEnumerable<string>? capturedContentEncoding = null;
+
+        var handler = new LambdaHttpMessageHandler(async request =>
+        {
+            capturedContentEncoding = request.Content?.Headers.ContentEncoding;
+            if (request.Content != null)
+            {
+                capturedBody = await request.Content.ReadAsStringAsync();
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"status\": 1}")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler);
+        var options = new PostHogOptions
+        {
+            ProjectToken = "test-api-key",
+            EnableCompression = true
+        };
+        var timeProvider = new FakeTimeProvider();
+        var payload = new { api_key = "test", batch = new[] { new { @event = "test-event" } } };
+        var originalCompressor = HttpClientExtensions.CreateCompressedJsonContent;
+        HttpClientExtensions.CreateCompressedJsonContent = _ => throw new IOException("gzip failed");
+
+        try
+        {
+            await httpClient.PostJsonWithRetryAsync<ApiResult>(
+                BatchUrl,
+                payload,
+                timeProvider,
+                options,
+                CancellationToken.None);
+        }
+        finally
+        {
+            HttpClientExtensions.CreateCompressedJsonContent = originalCompressor;
+        }
+
+        Assert.Empty(capturedContentEncoding ?? Enumerable.Empty<string>());
+        Assert.NotNull(capturedBody);
+        Assert.Contains("test-event", capturedBody, StringComparison.Ordinal);
+        Assert.Contains("api_key", capturedBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task DoesNotCompressWhenCompressionDisabled()
     {
         IEnumerable<string>? capturedContentEncoding = null;


### PR DESCRIPTION
## :bulb: Motivation and Context

If local gzip compression fails while preparing a batch upload, the SDK should still send the original payload uncompressed instead of failing before the request is sent.

This updates the compressed batch path to build gzip content first and fall back to the normal JSON request path when gzip content creation fails.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --filter HttpClientExtensionsTests`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented as part of a cross-SDK consistency pass for client-side compression failure fallback. Kept the change surgical and limited to the gzip request-construction path.
