### PR TITLE
fix(feature-management): enumerate flags without PersonalApiKey

### DIFF
--- a/src/PostHog.AspNetCore/FeatureManagement/FeatureEnumerationFallback.cs
+++ b/src/PostHog.AspNetCore/FeatureManagement/FeatureEnumerationFallback.cs
@@ -1,0 +1,38 @@
+namespace PostHog.FeatureManagement;
+
+/// <summary>
+/// Shared fallback used by <see cref="PostHogFeatureDefinitionProvider"/> and
+/// <see cref="PostHogVariantFeatureManager"/> to enumerate flag keys when no
+/// <see cref="Config.PostHogOptions.PersonalApiKey"/> is configured (no local evaluation source).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Polls <c>/flags</c> with a stable sentinel <c>distinct_id</c> and returns the keys from the
+/// response. Per-flag values for the sentinel are discarded — only the set of keys is consumed.
+/// </para>
+/// <para>
+/// The sentinel id is intentionally stable: a random id would spawn a phantom person on every poll
+/// and defeat the in-memory <c>/flags</c> cache. See PostHog/posthog-dotnet#64 for the rationale.
+/// </para>
+/// </remarks>
+internal static class FeatureEnumerationFallback
+{
+    /// <summary>
+    /// Stable sentinel <c>distinct_id</c> used by the enumeration fallback. Stays constant so the
+    /// SDK's in-memory <c>/flags</c> cache (keyed by distinct_id) reuses the response and PostHog
+    /// doesn't create a new phantom person per poll.
+    /// </summary>
+    internal const string SentinelDistinctId = "$feature_enumeration_sentinel";
+
+    public static async Task<IReadOnlyCollection<string>> GetFeatureKeysAsync(
+        IPostHogClient posthog,
+        CancellationToken cancellationToken)
+    {
+        var flags = await posthog.GetAllFeatureFlagsAsync(
+            distinctId: SentinelDistinctId,
+            options: null,
+            cancellationToken);
+        // Order is not guaranteed by /flags; callers (Microsoft Feature Management) don't rely on it.
+        return flags.Keys.ToList();
+    }
+}

--- a/src/PostHog.AspNetCore/FeatureManagement/PostHogFeatureDefinitionProvider.cs
+++ b/src/PostHog.AspNetCore/FeatureManagement/PostHogFeatureDefinitionProvider.cs
@@ -31,16 +31,25 @@ public class PostHogFeatureDefinitionProvider(IPostHogClient posthog) : IFeature
         {
             foreach (var flag in localEvaluator.LocalEvaluationApiResult.Flags)
             {
-                yield return CreateFeatureDefinition(flag);
+                yield return CreateFeatureDefinition(flag.Key);
             }
+            yield break;
+        }
+
+        // Fallback: no PersonalApiKey means no local-evaluation flag list. Poll /flags with a stable
+        // sentinel distinct_id and use the returned keys as the enumeration source. We only care about
+        // keys; the values for the sentinel are discarded. See PostHog/posthog-dotnet#64.
+        foreach (var key in await FeatureEnumerationFallback.GetFeatureKeysAsync(posthog, CancellationToken.None))
+        {
+            yield return CreateFeatureDefinition(key);
         }
     }
 
-    static FeatureDefinition CreateFeatureDefinition(LocalFeatureFlag flag)
+    static FeatureDefinition CreateFeatureDefinition(string key)
     {
         return new FeatureDefinition
         {
-            Name = flag.Key,
+            Name = key,
             EnabledFor = [new FeatureFilterConfiguration { Name = "PostHog" }],
             RequirementType = RequirementType.Any
         };

--- a/src/PostHog.AspNetCore/FeatureManagement/PostHogVariantFeatureManager.cs
+++ b/src/PostHog.AspNetCore/FeatureManagement/PostHogVariantFeatureManager.cs
@@ -23,13 +23,20 @@ public class PostHogVariantFeatureManager(
         [EnumeratorCancellation] CancellationToken cancellationToken = new())
     {
         var localEvaluator = await posthog.GetLocalEvaluatorAsync(cancellationToken);
-        if (localEvaluator is null)
+        if (localEvaluator is not null)
         {
+            foreach (var flag in localEvaluator.LocalEvaluationApiResult.Flags)
+            {
+                yield return flag.Key;
+            }
             yield break;
         }
-        foreach (var flag in localEvaluator.LocalEvaluationApiResult.Flags)
+
+        // Fallback: no PersonalApiKey means no local-evaluation flag list. Poll /flags with a stable
+        // sentinel distinct_id and yield the returned keys. See PostHog/posthog-dotnet#64.
+        foreach (var key in await FeatureEnumerationFallback.GetFeatureKeysAsync(posthog, cancellationToken))
         {
-            yield return flag.Key;
+            yield return key;
         }
     }
 

--- a/tests/UnitTests.AspNetCore/FeatureManagement/PostHogFeatureDefinitionProviderTests.cs
+++ b/tests/UnitTests.AspNetCore/FeatureManagement/PostHogFeatureDefinitionProviderTests.cs
@@ -67,6 +67,41 @@ public class TheGetAllFeatureDefinitionsAsyncMethod
     }
 }
 
+public class TheGetAllFeatureDefinitionsAsyncMethodFallback
+{
+    [Fact]
+    public async Task ReturnsFlagsFromFlagsEndpointWhenNoPersonalApiKey()
+    {
+        var container = new TestContainer(sp =>
+        {
+            var builder = new PostHogConfigurationBuilder(sp);
+            builder.UseFeatureManagement<FakePostHogFeatureFlagContextProvider>();
+            // No PersonalApiKey configured.
+        });
+        container.FakeHttpMessageHandler.AddFlagsResponse(
+            requestPredicate: body =>
+                body.TryGetValue("distinct_id", out var id)
+                && id is System.Text.Json.JsonElement el
+                && el.GetString() == FeatureEnumerationFallback.SentinelDistinctId,
+            responseBody: """
+            {
+              "featureFlags": {
+                "beta-feature": true,
+                "alpha-feature": false
+              }
+            }
+            """
+        );
+        var provider = container.Activate<PostHogFeatureDefinitionProvider>();
+
+        var features = await provider.GetAllFeatureDefinitionsAsync().ToListAsync();
+
+        Assert.Equal(
+            new[] { "beta-feature", "alpha-feature" },
+            features.Select(f => f.Name).OrderByDescending(n => n));
+    }
+}
+
 public class TheGetFeatureDefinitionAsyncMethod
 {
     [Fact]

--- a/tests/UnitTests.AspNetCore/FeatureManagement/PostHogVariantFeatureManagerTests.cs
+++ b/tests/UnitTests.AspNetCore/FeatureManagement/PostHogVariantFeatureManagerTests.cs
@@ -63,6 +63,41 @@ public class TheGetFeatureNamesAsyncMethod
     }
 }
 
+public class TheGetFeatureNamesAsyncMethodFallback
+{
+    [Fact]
+    public async Task ReturnsFlagsFromFlagsEndpointWhenNoPersonalApiKey()
+    {
+        var container = new TestContainer(sp =>
+        {
+            var builder = new PostHogConfigurationBuilder(sp);
+            builder.UseFeatureManagement<FakePostHogFeatureFlagContextProvider>();
+            // No PersonalApiKey configured.
+        });
+        container.FakeHttpMessageHandler.AddFlagsResponse(
+            requestPredicate: body =>
+                body.TryGetValue("distinct_id", out var id)
+                && id is System.Text.Json.JsonElement el
+                && el.GetString() == FeatureEnumerationFallback.SentinelDistinctId,
+            responseBody: """
+            {
+              "featureFlags": {
+                "beta-feature": true,
+                "alpha-feature": false
+              }
+            }
+            """
+        );
+        var featureManager = container.Activate<PostHogVariantFeatureManager>();
+
+        var featureNames = await featureManager.GetFeatureNamesAsync().ToListAsync();
+
+        Assert.Equal(
+            new[] { "beta-feature", "alpha-feature" },
+            featureNames.OrderByDescending(n => n));
+    }
+}
+
 public class TheIsEnabledAsyncMethod
 {
     [Fact]


### PR DESCRIPTION
Fixes #64

## Summary
- Keeps local evaluation as the source when a PersonalApiKey is available.
- Falls back to `/flags` with a stable sentinel distinct id for feature enumeration without a PersonalApiKey.
- Adds unit coverage for both `PostHogFeatureDefinitionProvider` and `PostHogVariantFeatureManager`.

## Verification
- [x] `dotnet test tests/UnitTests.AspNetCore --filter FullyQualifiedName~Fallback -m:1`
- [x] `dotnet test tests/UnitTests.AspNetCore -m:1`
- [x] `git diff --check main...HEAD`

## Risk
Medium. This affects feature flag enumeration only; no public API changes are added.