### PR TITLE
ci: Configure SDK compliance harness options

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,11 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@fix/sdk-harness-options-20260630
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
       test-harness-version: "0.8.0"
+      suite: "capture"
+      sdk-type: "server"
+      continue-on-error: true

--- a/sdk_compliance_adapter/Program.cs
+++ b/sdk_compliance_adapter/Program.cs
@@ -24,7 +24,8 @@ var state = new AdapterState();
 app.MapGet("/health", () => new HealthResponse(
     SdkName: "posthog-dotnet",
     SdkVersion: VersionConstants.Version,
-    AdapterVersion: "1.0.0"
+    AdapterVersion: "1.0.0",
+    Capabilities: ["capture_v0", "encoding_gzip"]
 ));
 
 app.MapPost("/init", async (InitRequest request) =>
@@ -246,7 +247,8 @@ app.Run();
 record HealthResponse(
     [property: JsonPropertyName("sdk_name")] string SdkName,
     [property: JsonPropertyName("sdk_version")] string SdkVersion,
-    [property: JsonPropertyName("adapter_version")] string AdapterVersion
+    [property: JsonPropertyName("adapter_version")] string AdapterVersion,
+    [property: JsonPropertyName("capabilities")] string[] Capabilities
 );
 
 record InitRequest(

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   # Test harness
   test-harness:
     image: ghcr.io/posthog/sdk-test-harness:0.8.0
-    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
+    command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--suite", "capture"]
     networks:
       - test-network
     depends_on:


### PR DESCRIPTION
## Problem

SDK compliance workflows need explicit harness suite/sdk-type selection and configurable blocking behavior so CI only runs the intended contract checks.

## Changes

- Point SDK compliance to the harness branch with new workflow inputs.
- Run the capture v0 suite as a server SDK and keep failures non-blocking for now.
- Advertise `capture_v0` and `encoding_gzip` capabilities from the compliance adapter.
- Align local compose with the same suite/sdk type.

## Testing

- Parsed workflow YAML.
- Ran `dotnet build sdk_compliance_adapter/SdkComplianceAdapter.csproj --no-restore`.
- Ran `docker compose config` for the adapter compose file.
- Ran `git diff --check`.

## Release / changeset

No SDK package changeset: this only changes CI/compliance adapter setup, not the published SDK.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using dedicated git worktrees. The change was requested to align SDK compliance harness setup across SDK repositories while keeping non-ready SDKs non-blocking.
