### PR TITLE
fix: stop duplicating distinct_id in flags person properties

### DIFF
--- a/.changeset/quiet-wolves-fix.md
+++ b/.changeset/quiet-wolves-fix.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Stop duplicating `distinct_id` inside `/flags` person properties.

--- a/.changeset/quiet-wolves-fix.md
+++ b/.changeset/quiet-wolves-fix.md
@@ -1,5 +1,6 @@
 ---
 "PostHog": patch
+"PostHog.AspNetCore": patch
 ---
 
 Stop duplicating `distinct_id` inside `/flags` person properties.

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"

--- a/sdk_compliance_adapter/CONTRIBUTING.md
+++ b/sdk_compliance_adapter/CONTRIBUTING.md
@@ -35,7 +35,7 @@ docker run -d --name sdk-adapter --network test-network -p 8080:8080 posthog-dot
 docker run --rm \
   --name test-harness \
   --network test-network \
-  ghcr.io/posthog/sdk-test-harness:0.9.0 \
+  ghcr.io/posthog/sdk-test-harness:0.10.0 \
   run --adapter-url http://sdk-adapter:8080 --mock-url http://test-harness:8081
 
 # Cleanup

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   # Test harness
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
     networks:
       - test-network

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -131,13 +131,7 @@ internal sealed class PostHogApiClient : IDisposable
 
         if (personProperties is { Count: > 0 })
         {
-            var mergedPersonProperties = new Dictionary<string, object?>(personProperties);
-            if (!mergedPersonProperties.ContainsKey("distinct_id"))
-            {
-                mergedPersonProperties["distinct_id"] = distinctUserId;
-            }
-
-            payload["person_properties"] = mergedPersonProperties;
+            payload["person_properties"] = personProperties;
         }
 
         if (flagKeysToEvaluate is { Count: > 0 })

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -2283,7 +2283,7 @@ public class TheGetFeatureFlagAsyncMethod
     public async Task BooleanFeatureFlagPayloadsFromDecide()
     {
         var container = new TestContainer();
-        container.FakeHttpMessageHandler.AddFlagsResponse(
+        var handler = container.FakeHttpMessageHandler.AddFlagsResponse(
             """
             {"featureFlags": {"person-flag": true}, "featureFlagPayloads": {"person-flag": "300"}}
             """
@@ -2295,6 +2295,10 @@ public class TheGetFeatureFlagAsyncMethod
             PersonProperties = new() { ["region"] = "USA" }
         });
         JsonAssert.Equal(300, result?.Payload);
+        using var document = JsonDocument.Parse(handler.GetReceivedRequestBody(indented: false));
+        var personProperties = document.RootElement.GetProperty("person_properties");
+        Assert.Equal("USA", personProperties.GetProperty("region").GetString());
+        Assert.False(personProperties.TryGetProperty("distinct_id", out _));
     }
 
     [Fact] // Ported from PostHog/posthog-python test_multivariate_feature_flag_payloads
@@ -2400,6 +2404,7 @@ public class TheGetFeatureFlagAsyncMethod
         Assert.Equal("fake-project-token", root.GetProperty("api_key").GetString());
         Assert.Equal("some-distinct-id", root.GetProperty("distinct_id").GetString());
         Assert.Empty(root.GetProperty("groups").EnumerateObject());
+        Assert.False(root.TryGetProperty("person_properties", out _));
         Assert.Empty(root.GetProperty("group_properties").EnumerateObject());
         Assert.Equal(disableGeoIp, root.GetProperty("geoip_disable").GetBoolean());
         var flagKey = Assert.Single(root.GetProperty("flag_keys_to_evaluate").EnumerateArray());


### PR DESCRIPTION
## :bulb: Motivation and Context
`/flags` requests already send `distinct_id` at the top level. Automatically copying the same value into `person_properties.distinct_id` sends duplicated identity data and differs from the desired payload shape.

This PR keeps the top-level `distinct_id` and stops automatically injecting it into `person_properties`. Caller-provided person properties are still forwarded.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --filter FullyQualifiedName~FeatureFlagsTests`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This was implemented with pi in dedicated git worktrees. I changed the /flags request construction so SDKs keep the top-level distinct_id while no longer auto-copying it into person_properties; explicit caller-provided person_properties['distinct_id'] values are still preserved where covered.
