### PR TITLE
fix: Retry flags requests on 502 and 504

### DIFF
--- a/.changeset/gentle-flags-retry.md
+++ b/.changeset/gentle-flags-retry.md
@@ -1,0 +1,6 @@
+---
+'PostHog': patch
+'PostHog.AspNetCore': patch
+---
+
+Retry remote feature flag requests after transient 502 and 504 responses.

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -174,7 +174,8 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
     public int MaxRetries { get; set; } = 3;
 
     /// <summary>
-    /// The maximum number of retries for feature flag requests after transient network errors. (Default: 1)
+    /// The maximum number of retries for feature flag requests after transient network errors
+    /// or HTTP 502/504 responses. (Default: 1)
     /// Set to 0 to disable feature flag request retries.
     /// </summary>
     public int FeatureFlagRequestMaxRetries { get; set; } = 1;

--- a/src/PostHog/Library/HttpClientExtensions.cs
+++ b/src/PostHog/Library/HttpClientExtensions.cs
@@ -46,8 +46,8 @@ internal static class HttpClientExtensions
     }
 
     /// <summary>
-    /// Sends a POST request with retry logic only for network/transport failures and timeouts.
-    /// Non-successful HTTP responses are not retried.
+    /// Sends a POST request with retry logic only for network/transport failures, timeouts,
+    /// and HTTP 502/504 responses.
     /// </summary>
     public static async Task<TBody?> PostJsonWithNetworkRetryAsync<TBody>(
         this HttpClient httpClient,
@@ -141,7 +141,13 @@ internal static class HttpClientExtensions
             // be caught by the retry logic above.
             using (response)
             {
-                if (isHalfOpenProbe || response.IsSuccessStatusCode)
+                var isRetryableFlagsStatusCode = ShouldRetryFlagsStatusCode(response.StatusCode);
+                if (isRetryableFlagsStatusCode && await ShouldRetryAfterTransientFailure())
+                {
+                    continue;
+                }
+
+                if ((isHalfOpenProbe && !isRetryableFlagsStatusCode) || response.IsSuccessStatusCode)
                 {
                     circuitBreaker.Close();
                 }
@@ -155,6 +161,9 @@ internal static class HttpClientExtensions
             }
         }
     }
+
+    static bool ShouldRetryFlagsStatusCode(HttpStatusCode statusCode)
+        => statusCode is HttpStatusCode.BadGateway or HttpStatusCode.GatewayTimeout;
 
     static bool IsRetryableFlagsHttpRequestException(HttpRequestException exception)
     {

--- a/tests/UnitTests/Library/HttpClientExtensionsTests.cs
+++ b/tests/UnitTests/Library/HttpClientExtensionsTests.cs
@@ -1210,6 +1210,39 @@ public class ThePostJsonWithNetworkRetryAsyncMethod
     }
 
     [Theory]
+    [InlineData(HttpStatusCode.BadGateway)] // 502
+    [InlineData(HttpStatusCode.GatewayTimeout)] // 504
+    public async Task ThrowsAfterFeatureFlagRequestMaxRetriesWhenGatewayHttpStatusCodesKeepFailing(
+        HttpStatusCode statusCode)
+    {
+        var handler = new FakeRetryHttpMessageHandler();
+        handler.AddResponse(statusCode, new { type = "error", detail = "server error" });
+        handler.AddResponse(statusCode, new { type = "error", detail = "server error" });
+        handler.AddResponse(statusCode, new { type = "error", detail = "server error" });
+        using var httpClient = CreateHttpClient(handler);
+        var options = CreateOptions(maxRetries: 2);
+        var timeProvider = new FakeTimeProvider();
+
+        var task = httpClient.PostJsonWithNetworkRetryAsync<FlagsApiResult>(
+            FlagsUrl,
+            new { api_key = "test", distinct_id = "user-1" },
+            timeProvider,
+            options,
+            new FeatureFlagRequestCircuitBreaker(),
+            CancellationToken.None);
+
+        for (var i = 1; i <= 3 && !task.IsCompleted; i++)
+        {
+            await handler.WaitForRequestCountAsync(i);
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var exception = await Assert.ThrowsAsync<ApiException>(() => task);
+        Assert.Equal(statusCode, exception.Status);
+        Assert.Equal(3, handler.RequestCount);
+    }
+
+    [Theory]
     [InlineData(HttpStatusCode.RequestTimeout)] // 408
     [InlineData(HttpStatusCode.TooManyRequests)] // 429
     [InlineData(HttpStatusCode.InternalServerError)] // 500

--- a/tests/UnitTests/Library/HttpClientExtensionsTests.cs
+++ b/tests/UnitTests/Library/HttpClientExtensionsTests.cs
@@ -1154,13 +1154,67 @@ public class ThePostJsonWithNetworkRetryAsyncMethod
     }
 
     [Theory]
+    [InlineData(HttpStatusCode.BadGateway)] // 502
+    [InlineData(HttpStatusCode.GatewayTimeout)] // 504
+    public async Task RetriesOnGatewayHttpStatusCodeThenSucceeds(HttpStatusCode statusCode)
+    {
+        var handler = new FakeRetryHttpMessageHandler();
+        handler.AddResponse(statusCode, new { type = "error", detail = "server error" });
+        handler.AddResponse(HttpStatusCode.OK, new { featureFlags = new { retry_flag = true } });
+        using var httpClient = CreateHttpClient(handler);
+        var options = CreateOptions();
+        var timeProvider = new FakeTimeProvider();
+
+        var task = httpClient.PostJsonWithNetworkRetryAsync<FlagsApiResult>(
+            FlagsUrl,
+            new { api_key = "test", distinct_id = "user-1" },
+            timeProvider,
+            options,
+            new FeatureFlagRequestCircuitBreaker(),
+            CancellationToken.None);
+
+        await handler.WaitForRequestCountAsync(1);
+        Assert.Equal(1, handler.RequestCount);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+        var result = await task;
+
+        Assert.NotNull(result);
+        Assert.NotNull(result!.FeatureFlags);
+        Assert.True(result.FeatureFlags!.TryGetValue("retry_flag", out var retryFlag));
+        Assert.True(retryFlag == true);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadGateway)] // 502
+    [InlineData(HttpStatusCode.GatewayTimeout)] // 504
+    public async Task DoesNotRetryGatewayHttpStatusCodeWhenFeatureFlagRequestMaxRetriesIsZero(HttpStatusCode statusCode)
+    {
+        var handler = new FakeRetryHttpMessageHandler();
+        handler.AddResponse(statusCode, new { type = "error", detail = "server error" });
+        handler.AddResponse(HttpStatusCode.OK, new { featureFlags = new { retry_flag = true } }); // Should never be reached
+        using var httpClient = CreateHttpClient(handler);
+        var options = CreateOptions(maxRetries: 0);
+        var timeProvider = new FakeTimeProvider();
+
+        await Assert.ThrowsAsync<ApiException>(() =>
+            httpClient.PostJsonWithNetworkRetryAsync<FlagsApiResult>(
+                FlagsUrl,
+                new { api_key = "test", distinct_id = "user-1" },
+                timeProvider,
+                options,
+                new FeatureFlagRequestCircuitBreaker(),
+                CancellationToken.None));
+
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Theory]
     [InlineData(HttpStatusCode.RequestTimeout)] // 408
     [InlineData(HttpStatusCode.TooManyRequests)] // 429
     [InlineData(HttpStatusCode.InternalServerError)] // 500
-    [InlineData(HttpStatusCode.BadGateway)] // 502
     [InlineData(HttpStatusCode.ServiceUnavailable)] // 503
-    [InlineData(HttpStatusCode.GatewayTimeout)] // 504
-    public async Task DoesNotRetryOnHttpErrorStatusCodes(HttpStatusCode statusCode)
+    public async Task DoesNotRetryOnOtherHttpErrorStatusCodes(HttpStatusCode statusCode)
     {
         var handler = new FakeRetryHttpMessageHandler();
         handler.AddResponse(statusCode, new { type = "error", detail = "server error" });


### PR DESCRIPTION
## :bulb: Motivation and Context
Remote `/flags` requests already retry transient network failures/timeouts via `FeatureFlagRequestMaxRetries`, but HTTP 502/504 responses were surfaced immediately. The SDK test harness now expects `/flags` to retry a 502 or 504 once by default and return the successful retry result.

This change keeps retry handling scoped to the `/flags` helper and only adds HTTP 502/504 as retryable status responses there. It also includes retry-budget exhaustion coverage and a changeset for the affected packages.

## :green_heart: How did you test it?

```bash
dotnet test tests/UnitTests/UnitTests.csproj --filter "FullyQualifiedName~HttpClientExtensionsTests.ThePostJsonWithNetworkRetryAsyncMethod"
```

Passed:
- `net8.0`: 26 passed, 0 failed, 0 skipped
- `netcoreapp3.1`: 25 passed, 0 failed, 0 skipped

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check README.md#publishing-releases -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by an AI coding agent under human direction. The change was kept to the `/flags` retry path: 502/504 responses now use the existing feature-flag retry budget/backoff and focused unit coverage verifies successful retries, retry-budget exhaustion, and max-retry opt-out behavior.
