### PR TITLE
ci: Standardize SDK release failure telemetry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Notify Slack - Approved
         if: needs.notify-approval-needed.outputs.slack_ts != ''
-        uses: posthog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
+        uses: posthog/.github/.github/actions/slack-thread-reply@cb0979b67dcd585828b61ac45927eef4da8f6287 # main
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -184,23 +184,53 @@ jobs:
             echo "commit-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve release failure metadata
+        id: release-failure-metadata
+        if: failure()
+        run: |
+          set -euo pipefail
+          package_name=""
+          package_version=""
+          separator=""
+          for package_json in src/PostHog/package.json src/PostHog.AspNetCore/package.json src/PostHog.AI/package.json; do
+            if [ -f "$package_json" ]; then
+              package_name_part=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("name", ""))' "$package_json")
+              version=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version", ""))' "$package_json")
+              if [ -n "$package_name_part" ] && [ -n "$version" ]; then
+                package_name="${package_name}${separator}${package_name_part}"
+                package_version="${package_version}${separator}${package_name_part}@v${version}"
+                separator=", "
+              fi
+            fi
+          done
+          echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
+
       - name: Send failure event to PostHog
         if: failure()
-        uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+        continue-on-error: true
+        uses: PostHog/posthog-github-action@9a6a19d360820ab4d95ecc4a5a7564062c895f84 # v1.3.0
         with:
           posthog-token: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
-          event: "posthog-dotnet-github-release-workflow-failure"
+          event: "posthog-sdk-github-release-workflow-failure"
           properties: >-
             {
               "commitSha": "${{ github.sha }}",
               "jobStatus": "${{ job.status }}",
               "ref": "${{ github.ref }}",
-              "phase": "version-bump"
+              "repository": "${{ github.repository }}",
+              "sdk": "posthog-dotnet",
+              "jobName": "version-bump",
+              "packageName": "${{ steps.release-failure-metadata.outputs.package_name || 'unknown' }}",
+              "packageVersion": "${{ steps.release-failure-metadata.outputs.package_version || 'unknown' }}",
+              "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "alertText": ":rotating_light: Failed to prepare release for posthog-dotnet :rotating_light:",
+              "alertContext": "The version bump/changelog step failed before packages were published."
             }
 
       - name: Notify Slack - Failed
         if: failure() && needs.notify-approval-needed.outputs.slack_ts != ''
-        uses: posthog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
+        uses: posthog/.github/.github/actions/slack-thread-reply@cb0979b67dcd585828b61ac45927eef4da8f6287 # main
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -351,23 +381,29 @@ jobs:
 
       - name: Send failure event to PostHog
         if: failure()
-        uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+        continue-on-error: true
+        uses: PostHog/posthog-github-action@9a6a19d360820ab4d95ecc4a5a7564062c895f84 # v1.3.0
         with:
           posthog-token: "${{ secrets.POSTHOG_PROJECT_API_KEY }}"
-          event: "posthog-dotnet-github-release-workflow-failure"
+          event: "posthog-sdk-github-release-workflow-failure"
           properties: >-
             {
               "commitSha": "${{ github.sha }}",
               "jobStatus": "${{ job.status }}",
               "ref": "${{ github.ref }}",
-              "phase": "publish",
+              "repository": "${{ github.repository }}",
+              "sdk": "posthog-dotnet",
+              "jobName": "publish",
               "packageName": "${{ matrix.package.name }}",
-              "packageVersion": "${{ steps.detect-version.outputs.version }}"
+              "packageVersion": "${{ steps.detect-version.outputs.version || 'unknown' }}",
+              "actionUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "alertText": ":rotating_light: Failed to release ${{ matrix.package.name }}@${{ steps.detect-version.outputs.version }} :rotating_light:",
+              "alertContext": "The package publish step failed."
             }
 
       - name: Notify Slack - Failed
         if: failure() && needs.notify-approval-needed.outputs.slack_ts != ''
-        uses: posthog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
+        uses: posthog/.github/.github/actions/slack-thread-reply@cb0979b67dcd585828b61ac45927eef4da8f6287 # main
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -409,7 +445,7 @@ jobs:
       - name: Notify Slack - Rejected
         if: steps.check-rejection.outputs.was_rejected == 'true'
         continue-on-error: true
-        uses: posthog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
+        uses: posthog/.github/.github/actions/slack-thread-reply@cb0979b67dcd585828b61ac45927eef4da8f6287 # main
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -424,7 +460,7 @@ jobs:
     if: always() && needs.publish.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
     steps:
       - name: Notify Slack - Released
-        uses: posthog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
+        uses: posthog/.github/.github/actions/slack-thread-reply@cb0979b67dcd585828b61ac45927eef4da8f6287 # main
         with:
           slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
           slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}


### PR DESCRIPTION
## :bulb: Motivation and Context

Release workflow failures are currently reported with repo-specific PostHog event names or have gaps in pre-publish failure coverage. That would require separate Hog function handling per SDK and makes cross-SDK release failure monitoring harder.

## :green_heart: How did you test it?

- Parsed modified workflow YAML successfully.
- Ran `git diff --check`.
- Verified modified PostHog release failure events use `posthog-sdk-github-release-workflow-failure` and include the expected metadata.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran changeset generation for a release changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared with Pi after a human requested consistent SDK release failure telemetry. The change is limited to GitHub Actions release workflow telemetry; no runtime SDK code is changed.

Changes:

- Updated `.github/workflows/release.yml`

- Use the shared `posthog-sdk-github-release-workflow-failure` event for SDK release failure telemetry.\n- Use latest pinned action versions for `PostHog/posthog-github-action` and `PostHog/.github/.github/actions/slack-thread-reply`.n- Include consistent metadata: `repository`, `sdk`, `jobName`, `packageName`, `packageVersion`, `actionUrl`, `alertText`, and `alertContext`.\n- Keep `actionUrl` pointing at `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`.