### PR TITLE
feat: add SecretKey config, deprecate PersonalApiKey

### DIFF
--- a/.changeset/secret-key-config.md
+++ b/.changeset/secret-key-config.md
@@ -1,0 +1,5 @@
+---
+'PostHog': minor
+---
+
+Add `PostHogOptions.SecretKey` for local feature flag evaluation and remote config. It accepts either a Personal API Key (`phx_...`) or a Project Secret API Key (`phs_...`). The existing `PersonalApiKey` option is now a deprecated alias; when both are set, `SecretKey` takes precedence.

--- a/samples/HogTied.Web/Pages/Index.cshtml
+++ b/samples/HogTied.Web/Pages/Index.cshtml
@@ -47,17 +47,17 @@
                 </strong>
             </div>
 
-            if (Model.PersonalApiKeyIsSet) {
+            if (Model.SecretKeyIsSet) {
                 <div class="alert alert-info mt-3" role="alert">
                     <strong>
-                        The Personal API Key is set. If it's valid, we'll be using local evaluation.
+                        The Secret Key is set. If it's valid, we'll be using local evaluation.
                     </strong>
                 </div>
             }
             else {
                 <div class="alert alert-info mt-3" role="alert">
                     <strong>
-                        The Personal API Key is NOT set. We'll be using remote evaluation.
+                        The Secret Key is NOT set. We'll be using remote evaluation.
                     </strong>
                 </div>
             }

--- a/samples/HogTied.Web/Pages/Index.cshtml.cs
+++ b/samples/HogTied.Web/Pages/Index.cshtml.cs
@@ -66,7 +66,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
     public async Task OnGetAsync()
     {
         ProjectTokenIsSet = options.Value.ProjectToken is not (null or []);
-        PersonalApiKeyIsSet = options.Value.PersonalApiKey is not (null or []);
+        PersonalApiKeyIsSet = options.Value.SecretKey is not (null or []);
 
         // Check if the user is authenticated and get their user id.
         UserId = User.Identity?.IsAuthenticated == true

--- a/samples/HogTied.Web/Pages/Index.cshtml.cs
+++ b/samples/HogTied.Web/Pages/Index.cshtml.cs
@@ -24,7 +24,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
 
     public bool ProjectTokenIsSet { get; private set; }
 
-    public bool PersonalApiKeyIsSet { get; private set; }
+    public bool SecretKeyIsSet { get; private set; }
 
     public bool? NonExistentFlag { get; private set; }
 
@@ -66,7 +66,7 @@ public class IndexModel(IOptions<PostHogOptions> options, IPostHogClient posthog
     public async Task OnGetAsync()
     {
         ProjectTokenIsSet = options.Value.ProjectToken is not (null or []);
-        PersonalApiKeyIsSet = options.Value.SecretKey is not (null or []);
+        SecretKeyIsSet = options.Value.SecretKey is not (null or []);
 
         // Check if the user is authenticated and get their user id.
         UserId = User.Identity?.IsAuthenticated == true

--- a/samples/PostHog.Example.Console/.env.example
+++ b/samples/PostHog.Example.Console/.env.example
@@ -4,9 +4,10 @@
 # Your project token (found on the /project/settings page in PostHog)
 POSTHOG_PROJECT_TOKEN=phc_your_project_token_here
 
-# Your personal API key (for local evaluation and other advanced features)
+# Your secret key (for local evaluation and other advanced features)
+# Accepts either a Personal API Key (phx_...) or a Project Secret API Key (phs_...)
 # Found on https://us.posthog.com/settings/user-api-keys
-POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
+POSTHOG_SECRET_KEY=phx_your_secret_key_here
 
 # PostHog host URL (default is US cloud)
 # Use https://eu.i.posthog.com for EU cloud

--- a/samples/PostHog.Example.Console/Program.cs
+++ b/samples/PostHog.Example.Console/Program.cs
@@ -28,7 +28,7 @@ DotEnv.Load(options: new DotEnvOptions(envFilePaths: envPaths, ignoreExceptions:
 // Get configuration from environment variables
 var projectToken = Environment.GetEnvironmentVariable("POSTHOG_PROJECT_TOKEN")
                    ?? Environment.GetEnvironmentVariable("POSTHOG_PROJECT_API_KEY");
-var personalApiKey = Environment.GetEnvironmentVariable("POSTHOG_PERSONAL_API_KEY");
+var secretKey = Environment.GetEnvironmentVariable("POSTHOG_SECRET_KEY");
 var endpoint = Environment.GetEnvironmentVariable("POSTHOG_HOST") ?? "https://us.i.posthog.com";
 
 // Check credentials
@@ -58,7 +58,7 @@ if (endpointUri.Scheme != "https" && !endpointUri.IsLoopback)
 
 Console.WriteLine("✅ PostHog credentials loaded successfully!");
 Console.WriteLine($"   Project Token: ✅ Configured");
-Console.WriteLine($"   Personal API Key: {(string.IsNullOrEmpty(personalApiKey) ? "❌ Not set (local evaluation disabled)" : "✅ Configured")}");
+Console.WriteLine($"   Secret Key: {(string.IsNullOrEmpty(secretKey) ? "❌ Not set (local evaluation disabled)" : "✅ Configured")}");
 Console.WriteLine($"   Endpoint: {endpoint}");
 Console.WriteLine();
 
@@ -66,7 +66,7 @@ Console.WriteLine();
 var options = new PostHogOptions
 {
     ProjectToken = projectToken,
-    SecretKey = personalApiKey,
+    SecretKey = secretKey,
     HostUrl = new Uri(endpoint),
     FlushAt = 1, // Flush immediately for demo purposes
     FlushInterval = TimeSpan.FromSeconds(1)
@@ -87,7 +87,7 @@ await using var posthog = new PostHogClient(options, loggerFactory: loggerFactor
 // Display menu
 while (true)
 {
-    ShowMenu(hasPersonalApiKey: !string.IsNullOrEmpty(personalApiKey));
+    ShowMenu(hasSecretKey: !string.IsNullOrEmpty(secretKey));
     var choice = Prompt("\nEnter your choice (1-6): ");
 
     switch (choice)
@@ -102,10 +102,10 @@ while (true)
             await RunFeatureFlagExamples(posthog);
             break;
         case "4":
-            await RunLocalEvaluationExample(posthog, hasPersonalApiKey: !string.IsNullOrEmpty(personalApiKey));
+            await RunLocalEvaluationExample(posthog, hasSecretKey: !string.IsNullOrEmpty(secretKey));
             break;
         case "5":
-            await RunAllExamples(posthog, hasPersonalApiKey: !string.IsNullOrEmpty(personalApiKey));
+            await RunAllExamples(posthog, hasSecretKey: !string.IsNullOrEmpty(secretKey));
             break;
         case "6":
             Console.WriteLine("👋 Goodbye!");
@@ -131,14 +131,14 @@ while (true)
     Console.WriteLine();
 }
 
-static void ShowMenu(bool hasPersonalApiKey)
+static void ShowMenu(bool hasSecretKey)
 {
     Console.WriteLine("🦔 PostHog .NET SDK Demo - Choose an example to run:");
     Console.WriteLine();
     Console.WriteLine("1. Capture events");
     Console.WriteLine("2. Identify users");
     Console.WriteLine("3. Feature flags (remote evaluation)");
-    Console.WriteLine($"4. Local evaluation with ETag polling{(hasPersonalApiKey ? "" : " (requires Personal API Key)")}");
+    Console.WriteLine($"4. Local evaluation with ETag polling{(hasSecretKey ? "" : " (requires Secret Key)")}");
     Console.WriteLine("5. Run all examples");
     Console.WriteLine("6. Exit");
 }
@@ -283,17 +283,17 @@ static async Task RunFeatureFlagExamples(PostHogClient posthog)
     }
 }
 
-static async Task RunLocalEvaluationExample(PostHogClient posthog, bool hasPersonalApiKey)
+static async Task RunLocalEvaluationExample(PostHogClient posthog, bool hasSecretKey)
 {
     Console.WriteLine("\n" + new string('=', 60));
     Console.WriteLine("LOCAL EVALUATION WITH ETAG POLLING");
     Console.WriteLine(new string('=', 60));
 
-    if (!hasPersonalApiKey)
+    if (!hasSecretKey)
     {
-        Console.WriteLine("\n⚠️  This example requires a Personal API Key to be set.");
-        Console.WriteLine("   Set POSTHOG_PERSONAL_API_KEY in your .env file.");
-        Console.WriteLine("   Personal API keys can be created at:");
+        Console.WriteLine("\n⚠️  This example requires a Secret Key to be set.");
+        Console.WriteLine("   Set POSTHOG_SECRET_KEY in your .env file.");
+        Console.WriteLine("   Secret keys can be created at:");
         Console.WriteLine("   https://us.posthog.com/settings/user-api-keys");
         return;
     }
@@ -368,12 +368,12 @@ static async Task RunLocalEvaluationExample(PostHogClient posthog, bool hasPerso
     Console.WriteLine("   ✓ Polling stopped");
 }
 
-static async Task RunAllExamples(PostHogClient posthog, bool hasPersonalApiKey)
+static async Task RunAllExamples(PostHogClient posthog, bool hasSecretKey)
 {
     Console.WriteLine("\n🔄 Running all examples…");
 
     await RunCaptureExamples(posthog);
     await RunIdentifyExamples(posthog);
     await RunFeatureFlagExamples(posthog);
-    await RunLocalEvaluationExample(posthog, hasPersonalApiKey);
+    await RunLocalEvaluationExample(posthog, hasSecretKey);
 }

--- a/samples/PostHog.Example.Console/Program.cs
+++ b/samples/PostHog.Example.Console/Program.cs
@@ -66,7 +66,7 @@ Console.WriteLine();
 var options = new PostHogOptions
 {
     ProjectToken = projectToken,
-    PersonalApiKey = personalApiKey,
+    SecretKey = personalApiKey,
     HostUrl = new Uri(endpoint),
     FlushAt = 1, // Flush immediately for demo purposes
     FlushInterval = TimeSpan.FromSeconds(1)

--- a/src/PostHog/Api/PostHogApiClient.cs
+++ b/src/PostHog/Api/PostHogApiClient.cs
@@ -209,9 +209,9 @@ internal sealed class PostHogApiClient : IDisposable
     async Task<T?> GetAuthenticatedResponseAsync<T>(string relativeUrl, CancellationToken cancellationToken)
     {
         var options = _options.Value ?? throw new InvalidOperationException(nameof(_options));
-        var personalApiKey = options.PersonalApiKey
+        var personalApiKey = options.SecretKey
                              ?? throw new InvalidOperationException(
-                                 "This API requires that a Personal API Key is set.");
+                                 "This API requires that a SecretKey (Personal API Key or Project Secret API Key) is set.");
 
         var endpointUrl = new Uri(HostUrl, relativeUrl);
 
@@ -234,9 +234,9 @@ internal sealed class PostHogApiClient : IDisposable
         where T : LocalEvaluationApiResult
     {
         var options = _options.Value ?? throw new InvalidOperationException(nameof(_options));
-        var personalApiKey = options.PersonalApiKey
+        var personalApiKey = options.SecretKey
                              ?? throw new InvalidOperationException(
-                                 "This API requires that a Personal API Key is set.");
+                                 "This API requires that a SecretKey (Personal API Key or Project Secret API Key) is set.");
 
         var endpointUrl = new Uri(HostUrl, relativeUrl);
 

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -10,6 +10,8 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
 {
     string? _projectToken;
     string? _projectApiKey;
+    string? _secretKey;
+    string? _personalApiKey;
 
     /// <summary>
     /// The PostHog project token that identifies which project this client works with.
@@ -31,7 +33,8 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
     {
         _projectToken = _projectToken.NullIfEmpty();
         _projectApiKey = _projectApiKey.NullIfEmpty();
-        PersonalApiKey = PersonalApiKey.NullIfEmpty();
+        _secretKey = _secretKey.NullIfEmpty();
+        _personalApiKey = _personalApiKey.NullIfEmpty();
         HostUrl = HostUrl.NormalizeHostUrl();
     }
 
@@ -46,17 +49,34 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
     }
 
     /// <summary>
-    /// Optional personal API key for local feature flag evaluation.
+    /// Optional secret key used for local feature flag evaluation and remote config. Accepts either a Personal
+    /// API Key (<c>phx_...</c>) or a Project Secret API Key (<c>phs_...</c>).
     /// </summary>
     /// <remarks>
-    /// You can find this https://us.posthog.com/project/{YOUR_PROJECT_ID}/settings/user-api-keys
+    /// You can find these at https://us.posthog.com/project/{YOUR_PROJECT_ID}/settings/user-api-keys
     /// When developing an ASP.NET Core project locally, we recommend setting this in your user secrets.
     /// <c>
-    /// dotnet user-secrets --project your/project/path.csproj set PostHog:PersonalApiKey YOUR_PERSONAL_API_KEY
+    /// dotnet user-secrets --project your/project/path.csproj set PostHog:SecretKey YOUR_SECRET_KEY
     /// </c>
     /// In other cases, use an appropriate secrets manager, configuration provider, or environment variable.
+    /// When both <see cref="SecretKey"/> and the deprecated <see cref="PersonalApiKey"/> are set,
+    /// <see cref="SecretKey"/> takes precedence.
     /// </remarks>
-    public string? PersonalApiKey { get; set; }
+    public string? SecretKey
+    {
+        get => _secretKey ?? _personalApiKey;
+        set => _secretKey = value;
+    }
+
+    /// <summary>
+    /// Obsolete alias for <see cref="SecretKey"/>.
+    /// </summary>
+    [Obsolete("Use SecretKey instead. SecretKey accepts a Personal API Key or a Project Secret API Key.")]
+    public string? PersonalApiKey
+    {
+        get => _secretKey ?? _personalApiKey;
+        set => _personalApiKey = value;
+    }
 
     /// <summary>
     /// Evaluation contexts for feature flags.
@@ -102,7 +122,7 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
     public Dictionary<string, object> SuperProperties { get; init; } = new();
 
     /// <summary>
-    /// When <see cref="PersonalApiKey"/> is set, this is the interval to poll for feature flags used in
+    /// When <see cref="SecretKey"/> is set, this is the interval to poll for feature flags used in
     /// local evaluation. Default is 30 seconds.
     /// </summary>
     public TimeSpan FeatureFlagPollInterval { get; set; } = TimeSpan.FromSeconds(30);

--- a/src/PostHog/Examples.cs
+++ b/src/PostHog/Examples.cs
@@ -13,7 +13,7 @@ public static class Examples
     {
         ProjectToken = "<ph_project_token>",
         HostUrl = new Uri("<ph_client_api_host>"),
-        PersonalApiKey = Environment.GetEnvironmentVariable("PostHog__PersonalApiKey"),
+        SecretKey = Environment.GetEnvironmentVariable("PostHog__SecretKey"),
     });
 
     /// <summary>

--- a/src/PostHog/Features/FeatureFlagOptions.cs
+++ b/src/PostHog/Features/FeatureFlagOptions.cs
@@ -25,14 +25,14 @@ public class AllFeatureFlagsOptions
     /// Whether to only evaluate the flag locally. Defaults to <c>false</c>.
     /// </summary>
     /// <remarks>
-    /// Local evaluation requires that <see cref="PostHogOptions.PersonalApiKey"/> is set.
+    /// Local evaluation requires that <see cref="PostHogOptions.SecretKey"/> is set.
     /// </remarks>
     public bool OnlyEvaluateLocally { get; init; }
 
     /// <summary>
     /// The set of person properties used to evaluate feature flags. Required for both local and remote evaluation
     /// when feature flags have conditions based on person properties.
-    /// For local evaluation (when <see cref="PostHogOptions.PersonalApiKey"/> is present and
+    /// For local evaluation (when <see cref="PostHogOptions.SecretKey"/> is present and
     /// <see cref="OnlyEvaluateLocally"/> is <c>true</c>), these properties are used directly.
     /// For remote evaluation, these properties are sent to PostHog's servers and can override stored person properties.
     /// </summary>

--- a/src/PostHog/Features/LocalFeatureFlagsLoader.cs
+++ b/src/PostHog/Features/LocalFeatureFlagsLoader.cs
@@ -52,9 +52,9 @@ internal sealed class LocalFeatureFlagsLoader(
     /// <exception cref="ApiException">Thrown when the API returns a <c>quota_limited</c> error.</exception>
     public async ValueTask<LocalEvaluator?> GetFeatureFlagsForLocalEvaluationAsync(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(options.Value.PersonalApiKey))
+        if (string.IsNullOrWhiteSpace(options.Value.SecretKey))
         {
-            // Local evaluation is not enabled since it requires a personal api key.
+            // Local evaluation is not enabled since it requires a secret key.
             return null;
         }
         if (_localEvaluator is { } localEvaluator)
@@ -72,7 +72,7 @@ internal sealed class LocalFeatureFlagsLoader(
     /// <returns>The local evaluator with the feature flags.</returns>
     public async ValueTask<LocalEvaluator?> RefreshAsync(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(options.Value.PersonalApiKey))
+        if (string.IsNullOrWhiteSpace(options.Value.SecretKey))
         {
             return null;
         }

--- a/src/PostHog/Features/RemoteConfigExtensions.cs
+++ b/src/PostHog/Features/RemoteConfigExtensions.cs
@@ -12,8 +12,8 @@ public static class RemoteConfigExtensions
     /// Retrieves a remote config payload.
     /// </summary>
     /// <remarks>
-    /// Requires <see cref="PostHogOptions.PersonalApiKey"/>. Returns <c>null</c> when the client is disabled,
-    /// the personal API key is missing, the payload is missing, or the request fails.
+    /// Requires <see cref="PostHogOptions.SecretKey"/>. Returns <c>null</c> when the client is disabled,
+    /// the secret key is missing, the payload is missing, or the request fails.
     /// </remarks>
     /// <param name="client">The <see cref="IPostHogClient"/> to extend.</param>
     /// <param name="key">The remote config key.</param>

--- a/src/PostHog/IPostHogClient.cs
+++ b/src/PostHog/IPostHogClient.cs
@@ -210,8 +210,8 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// Retrieves a remote config payload.
     /// </summary>
     /// <remarks>
-    /// Requires <see cref="PostHogOptions.PersonalApiKey"/>. Returns <c>null</c> when the client is disabled,
-    /// the personal API key is missing, the payload is missing, or the request fails.
+    /// Requires <see cref="PostHogOptions.SecretKey"/>. Returns <c>null</c> when the client is disabled,
+    /// the secret key is missing, the payload is missing, or the request fails.
     /// </remarks>
     /// <param name="key">The remote config key.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -1414,7 +1414,7 @@ internal static partial class PostHogClientLoggerExtensions
     [LoggerMessage(
         EventId = 21,
         Level = LogLevel.Warning,
-        Message = "PostHog personal_api_key is not configured; {MethodName} is a no-op.")]
+        Message = "PostHog secret_key is not configured; {MethodName} is a no-op.")]
     public static partial void LogWarningPersonalApiKeyMissing(this ILogger<PostHogClient> logger, string methodName);
 
     [LoggerMessage(

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -132,7 +132,7 @@ public sealed class PostHogClient : IPostHogClient
 
     bool CheckPersonalApiKeyMissingAndLog(string methodName)
     {
-        if (_options.Value.PersonalApiKey is not null)
+        if (_options.Value.SecretKey is not null)
         {
             return false;
         }
@@ -934,7 +934,7 @@ public sealed class PostHogClient : IPostHogClient
 
         // 1. Local pass.
         var fallbackToRemote = true;
-        if (_options.Value.PersonalApiKey is not null)
+        if (_options.Value.SecretKey is not null)
         {
             try
             {
@@ -1063,7 +1063,7 @@ public sealed class PostHogClient : IPostHogClient
             return EmptyFeatureFlags;
         }
 
-        if (_options.Value.PersonalApiKey is not null)
+        if (_options.Value.SecretKey is not null)
         {
             // Attempt to load local feature flags.
             try

--- a/src/PostHog/PostHogSdk.cs
+++ b/src/PostHog/PostHogSdk.cs
@@ -243,8 +243,8 @@ public static class PostHogSdk
     /// Retrieves a remote config payload using the default client.
     /// </summary>
     /// <remarks>
-    /// Requires <see cref="PostHogOptions.PersonalApiKey"/>. Returns <c>null</c> when the client is disabled,
-    /// the personal API key is missing, the payload is missing, or the request fails.
+    /// Requires <see cref="PostHogOptions.SecretKey"/>. Returns <c>null</c> when the client is disabled,
+    /// the secret key is missing, the payload is missing, or the request fails.
     /// </remarks>
     /// <param name="key">The remote config key.</param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>

--- a/src/PostHog/PublicAPI.Unshipped.txt
+++ b/src/PostHog/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 PostHog.PostHogOptions.FeatureFlagRequestMaxRetries.get -> int
 PostHog.PostHogOptions.FeatureFlagRequestMaxRetries.set -> void
+PostHog.PostHogOptions.SecretKey.get -> string?
+PostHog.PostHogOptions.SecretKey.set -> void

--- a/tests/TestLibrary/TestContainer.cs
+++ b/tests/TestLibrary/TestContainer.cs
@@ -42,7 +42,7 @@ public sealed class TestContainer : IServiceProvider
         services.Configure<PostHogOptions>(options =>
         {
             options.ProjectToken = "fake-project-token";
-            options.PersonalApiKey = personalApiKey;
+            options.SecretKey = personalApiKey;
         });
     })
     {

--- a/tests/UnitTests.AspNetCore/FeatureManagement/PostHogFeatureDefinitionProviderTests.cs
+++ b/tests/UnitTests.AspNetCore/FeatureManagement/PostHogFeatureDefinitionProviderTests.cs
@@ -16,7 +16,7 @@ public class TheGetAllFeatureDefinitionsAsyncMethod
         {
             var builder = new PostHogConfigurationBuilder(sp);
             builder.UseFeatureManagement<FakePostHogFeatureFlagContextProvider>();
-            builder.PostConfigure(o => o.PersonalApiKey = "fake-personal-api-key");
+            builder.PostConfigure(o => o.SecretKey = "fake-personal-api-key");
         });
         container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
             """
@@ -76,7 +76,7 @@ public class TheGetFeatureDefinitionAsyncMethod
         {
             var builder = new PostHogConfigurationBuilder(sp);
             builder.UseFeatureManagement<FakePostHogFeatureFlagContextProvider>();
-            builder.PostConfigure(o => o.PersonalApiKey = "fake-personal-api-key");
+            builder.PostConfigure(o => o.SecretKey = "fake-personal-api-key");
         });
         container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
             """

--- a/tests/UnitTests.AspNetCore/FeatureManagement/PostHogVariantFeatureManagerTests.cs
+++ b/tests/UnitTests.AspNetCore/FeatureManagement/PostHogVariantFeatureManagerTests.cs
@@ -16,7 +16,7 @@ public class TheGetFeatureNamesAsyncMethod
         {
             var builder = new PostHogConfigurationBuilder(sp);
             builder.UseFeatureManagement<FakePostHogFeatureFlagContextProvider>();
-            builder.PostConfigure(o => o.PersonalApiKey = "fake-personal-api-key");
+            builder.PostConfigure(o => o.SecretKey = "fake-personal-api-key");
         });
         container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
             """
@@ -72,7 +72,7 @@ public class TheIsEnabledAsyncMethod
         {
             var builder = new PostHogConfigurationBuilder(sp);
             builder.UseFeatureManagement<FakePostHogFeatureFlagContextProvider>();
-            builder.PostConfigure(o => o.PersonalApiKey = "fake-personal-api-key");
+            builder.PostConfigure(o => o.SecretKey = "fake-personal-api-key");
         });
         container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
             """
@@ -130,7 +130,7 @@ public class TheGetVariantAsyncMethod
         {
             var builder = new PostHogConfigurationBuilder(sp);
             builder.UseFeatureManagement<FakePostHogFeatureFlagContextProvider>();
-            builder.PostConfigure(o => o.PersonalApiKey = "fake-personal-api-key");
+            builder.PostConfigure(o => o.SecretKey = "fake-personal-api-key");
         });
         var contextProvider = container.GetRequiredService<IPostHogFeatureFlagContextProvider>() as FakePostHogFeatureFlagContextProvider;
         Assert.NotNull(contextProvider);

--- a/tests/UnitTests.AspNetCore/RegistrationTests.cs
+++ b/tests/UnitTests.AspNetCore/RegistrationTests.cs
@@ -35,7 +35,7 @@ public class TheAddPostHogMethod
         var provider = services.BuildServiceProvider();
         Assert.NotNull(provider.GetRequiredService<IPostHogClient>());
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
-        Assert.Equal("fake-secret", options.PersonalApiKey);
+        Assert.Equal("fake-secret", options.SecretKey);
         Assert.Equal("fake-not-so-secret", options.ProjectToken);
         Assert.Equal(new Uri("https://test-host.com"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
@@ -98,7 +98,7 @@ public class TheAddPostHogMethod
         var provider = services.BuildServiceProvider();
         Assert.NotNull(provider.GetRequiredService<IPostHogClient>());
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
-        Assert.Equal("fake-secret", options.PersonalApiKey);
+        Assert.Equal("fake-secret", options.SecretKey);
         Assert.Equal("fake-not-so-secret", options.ProjectToken);
         Assert.Equal(new Uri("https://local-test-host.com"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(20), options.FeatureFlagPollInterval);

--- a/tests/UnitTests.AspNetCore/RegistrationTests.cs
+++ b/tests/UnitTests.AspNetCore/RegistrationTests.cs
@@ -41,6 +41,30 @@ public class TheAddPostHogMethod
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
     }
 
+    [Fact]
+    public void ReadsSecretKeyFromPostHogConfigurationSection()
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Host.UseDefaultServiceProvider((_, options) =>
+        {
+            options.ValidateScopes = true;
+            options.ValidateOnBuild = true;
+        });
+        var services = builder.Services;
+        var configuration = builder.Configuration;
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["PostHog:SecretKey"] = "fake-secret",
+            ["PostHog:ProjectToken"] = "fake-not-so-secret",
+        });
+
+        builder.AddPostHog();
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
+        Assert.Equal("fake-secret", options.SecretKey);
+        Assert.Equal("fake-not-so-secret", options.ProjectToken);
+    }
 
     [Fact]
     public void ReadsLegacyProjectApiKeyFromPostHogConfigurationSection()

--- a/tests/UnitTests/Config/RegistrationTests.cs
+++ b/tests/UnitTests/Config/RegistrationTests.cs
@@ -70,7 +70,7 @@ public class TheAddPostHogMethod
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
 
         Assert.Equal("fake-public-project-token", options.ProjectToken);
-        Assert.Equal("fake-secret-personal-api-key", options.PersonalApiKey);
+        Assert.Equal("fake-secret-personal-api-key", options.SecretKey);
         Assert.Equal(new Uri("https://test-host/"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
         Assert.Equal(10, options.FlushAt);
@@ -136,6 +136,28 @@ public class TheAddPostHogMethod
     }
 
     [Fact]
+    public void SecretKeyResolvesFromSecretKeyThenPersonalApiKey()
+    {
+        var options = new PostHogOptions { SecretKey = "phx_secret" };
+
+        Assert.Equal("phx_secret", options.SecretKey);
+
+#pragma warning disable CS0618
+        options = new PostHogOptions { PersonalApiKey = "phx_personal" };
+
+        Assert.Equal("phx_personal", options.SecretKey);
+
+        options = new PostHogOptions
+        {
+            SecretKey = "phx_secret",
+            PersonalApiKey = "phx_personal"
+        };
+#pragma warning restore CS0618
+
+        Assert.Equal("phx_secret", options.SecretKey);
+    }
+
+    [Fact]
     public void AllowsOverridingConfiguration()
     {
         var services = new ServiceCollection();
@@ -176,7 +198,7 @@ public class TheAddPostHogMethod
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
 
         Assert.Equal("fake-public-project-token", options.ProjectToken);
-        Assert.Equal("fake-secret-personal-api-key", options.PersonalApiKey);
+        Assert.Equal("fake-secret-personal-api-key", options.SecretKey);
         Assert.Equal(new Uri("https://test-host/"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
         Assert.Equal(42, options.FlushAt);

--- a/tests/UnitTests/Config/RegistrationTests.cs
+++ b/tests/UnitTests/Config/RegistrationTests.cs
@@ -89,6 +89,35 @@ public class TheAddPostHogMethod
     }
 
     [Fact]
+    public void CanReadSecretKeyConfiguration()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PostHogTest:SecretKey"] = "fake-secret-key",
+                ["PostHogTest:ProjectToken"] = "fake-public-project-token",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddPostHog(options =>
+        {
+            options.UseConfigurationSection(configuration.GetSection("PostHogTest"));
+        });
+
+        var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
+
+        Assert.Equal("fake-secret-key", options.SecretKey);
+        Assert.Equal("fake-public-project-token", options.ProjectToken);
+    }
+
+    [Fact]
     public void CanReadLegacyProjectApiKeyConfiguration()
     {
         var services = new ServiceCollection();

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -3433,7 +3433,7 @@ public class TheGetAllFeatureFlagsAsyncMethod
             services.Configure<PostHogOptions>(options =>
             {
                 options.ProjectToken = "fake-project-token";
-                options.PersonalApiKey = "fake-personal-api-key";
+                options.SecretKey = "fake-personal-api-key";
                 options.FeatureFlagPollInterval = TimeSpan.FromSeconds(30);
             });
         });

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -1727,7 +1727,7 @@ public class TheDisabledClient
             services.Configure<PostHogOptions>(options =>
             {
                 options.ProjectToken = projectToken;
-                options.PersonalApiKey = "fake-personal-api-key";
+                options.SecretKey = "fake-personal-api-key";
             });
         });
         var captureHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
@@ -1843,7 +1843,7 @@ public class TheDisabledClient
             services.Configure<PostHogOptions>(options =>
             {
                 options.ProjectToken = null;
-                options.PersonalApiKey = "fake-personal-api-key";
+                options.SecretKey = "fake-personal-api-key";
 #pragma warning disable CS0618
                 options.ProjectApiKey = projectApiKey;
 #pragma warning restore CS0618

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -2026,7 +2026,7 @@ public class ThePersonalApiKeyProtectedMethods
         var warningLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Warning);
         var matches = warningLogs.Count(log =>
             log.EventId.Id == 21
-            && log.Message == $"PostHog personal_api_key is not configured; {methodName} is a no-op.");
+            && log.Message == $"PostHog secret_key is not configured; {methodName} is a no-op.");
         Assert.Equal(1, matches);
     }
 }
@@ -2061,7 +2061,7 @@ public class TheLoadFeatureFlagsAsyncMethod
 
         var warningLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Warning);
         Assert.Contains(warningLogs, log =>
-            log.Message?.Contains("personal_api_key is not configured", StringComparison.Ordinal) == true
+            log.Message?.Contains("secret_key is not configured", StringComparison.Ordinal) == true
             && log.Message.Contains(nameof(PostHogClient.LoadFeatureFlagsAsync), StringComparison.Ordinal));
     }
 
@@ -2075,7 +2075,7 @@ public class TheLoadFeatureFlagsAsyncMethod
 
         var warningLogs = container.FakeLoggerProvider.GetAllEvents(minimumLevel: LogLevel.Warning);
         Assert.Contains(warningLogs, log =>
-            log.Message?.Contains("personal_api_key is not configured", StringComparison.Ordinal) == true
+            log.Message?.Contains("secret_key is not configured", StringComparison.Ordinal) == true
             && log.Message.Contains(nameof(PostHogClient.LoadFeatureFlagsAsync), StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
## Problem

The credential used for local feature flag evaluation and remote config accepts **either** a Personal API Key (`phx_...`) **or** a Project Secret API Key (`phs_...`). The option that carries it is named `PersonalApiKey`, which is confusing — it implies only a personal key is valid.

## Change

Add a new canonical `PostHogOptions.SecretKey` property and keep `PersonalApiKey` as a **deprecated alias**. Non-breaking.

- `SecretKey` accepts a Personal API Key or a Project Secret API Key.
- `PersonalApiKey` is marked `[Obsolete("Use SecretKey instead...")]` (warning, not error).
- Both are backed by separate fields; the effective value resolves to `SecretKey` when non-empty, otherwise `PersonalApiKey`. When both are set, `SecretKey` wins. This mirrors the existing `ProjectToken`/`ProjectApiKey` alias pattern in this file, so all internal consumers read the canonical property and never touch the obsolete member (no obsolete-warning noise under `TreatWarningsAsErrors`).
- XML docs, user-secrets example, exception messages, and `<see cref>` references updated to `SecretKey`.
- Added a changeset (`PostHog`, minor).

## Context

Coordinated rename across the backend SDKs (Slack discussion). Tracks the rename item in PostHog/posthog-js#4046. Mirrors the draft in posthog-python (#727). This PR covers only the rename item.
