### PR TITLE
chore: add missing changeset for PR 250

### DIFF
--- a/.changeset/silent-flags-enumerate.md
+++ b/.changeset/silent-flags-enumerate.md
@@ -1,0 +1,5 @@
+---
+'PostHog.AspNetCore': patch
+---
+
+Release feature flag enumeration fallback without a Personal API Key.


### PR DESCRIPTION
## :bulb: Motivation and Context
PR #250 was merged without a changeset, so the `PostHog.AspNetCore` fix for feature flag enumeration without a Personal API Key was not queued for release.


## :green_heart: How did you test it?

- `pnpm changeset status --since=main`


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi added a missing changeset for the already-merged fix from #250. The changeset targets `PostHog.AspNetCore` with a patch bump because the original PR fixed existing feature management behavior without a public API change.
