### PR TITLE
feat: add before send callback

### DIFF
--- a/.changeset/bright-owls-filter.md
+++ b/.changeset/bright-owls-filter.md
@@ -1,0 +1,5 @@
+---
+"posthog-dotnet": minor
+---
+
+Add a before send callback for modifying or dropping fully enriched events.

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using PostHog.Api;
 using PostHog.Library;
 
 namespace PostHog;
@@ -100,6 +101,12 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
     /// key sent with the event.
     /// </summary>
     public Dictionary<string, object> SuperProperties { get; init; } = new();
+
+    /// <summary>
+    /// Optional callback invoked after an event is fully enriched and before it is serialized for upload.
+    /// Return the event (mutated or unchanged) to continue, or <c>null</c> to drop it.
+    /// </summary>
+    public Func<CapturedEvent, CapturedEvent?>? BeforeSend { get; set; }
 
     /// <summary>
     /// When <see cref="PersonalApiKey"/> is set, this is the interval to poll for feature flags used in

--- a/src/PostHog/Library/AsyncBatchHandler.cs
+++ b/src/PostHog/Library/AsyncBatchHandler.cs
@@ -15,14 +15,14 @@ namespace PostHog.Library;
 /// <typeparam name="TBatchContext">
 /// The type of the context object to pass to batch items. A new instance is passed for each batch.
 /// </typeparam>
-internal class BatchItem<TItem, TBatchContext>(Func<TBatchContext, Task<TItem>> itemFetcher)
+internal class BatchItem<TItem, TBatchContext>(Func<TBatchContext, Task<TItem?>> itemFetcher)
 {
     /// <summary>
     /// Resolves the item to send in the batch.
     /// </summary>
     /// <param name="context">Context to provide to the resolver.</param>
-    /// <returns>The item to send in the batch.</returns>
-    public Task<TItem> ResolveItem(TBatchContext context) => itemFetcher(context);
+    /// <returns>The item to send in the batch, or <c>null</c> to drop it.</returns>
+    public Task<TItem?> ResolveItem(TBatchContext context) => itemFetcher(context);
 }
 
 /// <summary>
@@ -91,7 +91,7 @@ internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAs
     /// </summary>
     /// <param name="item">The item to enqueue</param>
     /// <returns><c>true</c> if the item was enqueued, otherwise <c>false</c>ß</returns>
-    public bool Enqueue(Task<TItem> item) => Enqueue(new BatchItem<TItem, TBatchContext>(_ => item));
+    public bool Enqueue(Task<TItem> item) => Enqueue(new BatchItem<TItem, TBatchContext>(async _ => await item));
 
     /// <summary>
     /// Enqueues a batch item and returns true if the item was successfully enqueued.
@@ -232,7 +232,8 @@ internal sealed class AsyncBatchHandler<TItem, TBatchContext> : IDisposable, IAs
         {
             var tasks = batch.Select(item => item.ResolveItem(batchContext));
             var resolved = await Task.WhenAll(tasks);
-            await SendBatch(resolved);
+            var itemsToSend = resolved.Where(item => item is not null).Select(item => item!).ToArray();
+            await SendBatch(itemsToSend);
         }
 
         return;

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -331,27 +331,60 @@ public sealed class PostHogClient : IPostHogClient
         _logger.LogWarnCaptureFailed(eventName, capturedEvent.Properties.Count, _asyncBatchHandler.Count);
         return false;
 
-        Task<CapturedEvent> BatchTask(CapturedEventBatchContext context)
+        async Task<CapturedEvent?> BatchTask(CapturedEventBatchContext context)
         {
+            CapturedEvent enrichedEvent;
             if (flags is not null)
             {
-                AddFeatureFlagsToCapturedEvent(capturedEvent, flags);
-                return Task.FromResult(capturedEvent);
+                enrichedEvent = AddFeatureFlagsToCapturedEvent(capturedEvent, flags);
             }
-
-            if (!sendFeatureFlags)
+            else if (!sendFeatureFlags)
             {
-                return Task.FromResult(capturedEvent);
+                enrichedEvent = capturedEvent;
             }
-
-            // Prefer local evaluation when available
-            if (_featureFlagsLoader.IsLoaded)
+            else if (_featureFlagsLoader.IsLoaded)
             {
-                return AddLocalFeatureFlagDataAsync(captureContext.DistinctId, groups, capturedEvent);
+                // Prefer local evaluation when available
+                enrichedEvent = await AddLocalFeatureFlagDataAsync(captureContext.DistinctId, groups, capturedEvent);
+            }
+            else
+            {
+                // Otherwise we fall back to remote /flags call
+                enrichedEvent = await AddFreshFeatureFlagDataAsync(
+                    context.FeatureFlagCache,
+                    captureContext.DistinctId,
+                    groups,
+                    capturedEvent);
             }
 
-            // Otherwise we fall back to remote /flags call
-            return AddFreshFeatureFlagDataAsync(context.FeatureFlagCache, captureContext.DistinctId, groups, capturedEvent);
+            return ApplyBeforeSend(enrichedEvent);
+        }
+    }
+
+    CapturedEvent? ApplyBeforeSend(CapturedEvent capturedEvent)
+    {
+        var beforeSend = _options.Value.BeforeSend;
+        if (beforeSend is null)
+        {
+            return capturedEvent;
+        }
+
+        try
+        {
+            var result = beforeSend(capturedEvent);
+            if (result is null)
+            {
+                _logger.LogDebugBeforeSendDropped(capturedEvent.EventName);
+            }
+
+            return result;
+        }
+#pragma warning disable CA1031 // Customer callbacks can throw any exception; drop just this event.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogErrorBeforeSendException(ex, capturedEvent.EventName);
+            return null;
         }
     }
 
@@ -1278,6 +1311,18 @@ public sealed class PostHogClient : IPostHogClient
 
 internal static partial class PostHogClientLoggerExtensions
 {
+    [LoggerMessage(
+        EventId = 22,
+        Level = LogLevel.Debug,
+        Message = "Event {EventName} was dropped by the before send callback")]
+    public static partial void LogDebugBeforeSendDropped(this ILogger<PostHogClient> logger, string eventName);
+
+    [LoggerMessage(
+        EventId = 23,
+        Level = LogLevel.Error,
+        Message = "Error in before send callback for event {EventName}; dropping event")]
+    public static partial void LogErrorBeforeSendException(this ILogger<PostHogClient> logger, Exception exception, string eventName);
+
     [LoggerMessage(
         EventId = 1,
         Level = LogLevel.Information,

--- a/src/PostHog/PublicAPI.Unshipped.txt
+++ b/src/PostHog/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.get -> bool
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.init -> void
+PostHog.PostHogOptions.BeforeSend.get -> System.Func<PostHog.Api.CapturedEvent!, PostHog.Api.CapturedEvent?>?
+PostHog.PostHogOptions.BeforeSend.set -> void
 PostHog.PostHogOptions.FeatureFlagRequestMaxRetries.get -> int
 PostHog.PostHogOptions.FeatureFlagRequestMaxRetries.set -> void

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -415,6 +415,60 @@ public class TheCapturePageViewMethod
 
 public class TheCaptureMethod
 {
+    [Fact]
+    public async Task BeforeSendCanModifyFullyEnrichedEventBeforeUpload()
+    {
+        var sawFullyEnrichedEvent = false;
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SuperProperties["source"] = "super";
+            options.BeforeSend = capturedEvent =>
+            {
+                sawFullyEnrichedEvent = capturedEvent.Properties.ContainsKey("$lib")
+                    && capturedEvent.Properties.ContainsKey("$lib_version")
+                    && capturedEvent.Properties.ContainsKey("$is_server")
+                    && capturedEvent.Properties.TryGetValue("source", out var source)
+                    && (string)source == "super";
+                capturedEvent.Properties.Remove("secret");
+                capturedEvent.Properties["before_send"] = true;
+                return capturedEvent;
+            };
+        }));
+        var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        client.Capture(
+            "test-user",
+            "before-send-event",
+            new Dictionary<string, object> { ["secret"] = "remove-me" });
+        await client.FlushAsync();
+
+        using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement
+            .GetProperty("batch")[0]
+            .GetProperty("properties");
+
+        Assert.True(sawFullyEnrichedEvent);
+        Assert.True(properties.GetProperty("before_send").GetBoolean());
+        Assert.False(properties.TryGetProperty("secret", out _));
+    }
+
+    [Fact]
+    public async Task BeforeSendCanDropEventBeforeUpload()
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.BeforeSend = _ => null;
+        }));
+        var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(client.Capture("test-user", "drop-me"));
+        await client.FlushAsync();
+
+        Assert.Empty(requestHandler.ReceivedRequests);
+    }
+
     [Theory]
     [InlineData(true, false)]
     [InlineData(false, true)]


### PR DESCRIPTION
## :bulb: Motivation and Context

Customers need a configuration hook to inspect, modify, or drop events before upload, matching the before-send behavior available in other PostHog SDKs.

This adds `PostHogOptions.BeforeSend`, invoked after event enrichment (SDK properties, super properties, `$is_server`, groups, and feature flags) and before batch serialization. Returning `null` drops the event.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --filter 'FullyQualifiedName~PostHogClientTests.TheCaptureMethod'`
- `dotnet build src/PostHog/PostHog.csproj`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent. The hook runs after the event is fully enriched by moving before-send processing into the batch resolution path, so feature flag enrichment is visible to the callback before serialization. A dropped event is filtered out of the outgoing batch.
