### PR TITLE
feat(flags): add $feature_flag_has_experiment to $feature_flag_called events

### DIFF
--- a/.changeset/tall-cows-attend.md
+++ b/.changeset/tall-cows-attend.md
@@ -1,0 +1,5 @@
+---
+"PostHog": minor
+---
+
+Add a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, sourced from the server-reported `has_experiment` field on flag responses. Defaults to `false` when the server does not report the field.

--- a/.changeset/tall-cows-attend.md
+++ b/.changeset/tall-cows-attend.md
@@ -2,4 +2,4 @@
 "PostHog": minor
 ---
 
-Add a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, sourced from the server-reported `has_experiment` field on flag responses. Defaults to `false` when the server does not report the field.
+Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events when the server reports whether the flag is linked to an experiment. The property is omitted when the server does not report it (older deployments and legacy response formats).

--- a/src/PostHog/Api/FeatureFlagWithMetadata.cs
+++ b/src/PostHog/Api/FeatureFlagWithMetadata.cs
@@ -86,9 +86,9 @@ internal record FeatureFlagMetadata
     public string? Description { get; init; }
 
     /// <summary>
-    /// Whether the feature flag is linked to an experiment. Defaults to <c>false</c> when the
-    /// server does not report the field (older deployments).
+    /// Whether the feature flag is linked to an experiment. <c>null</c> when the server does not
+    /// report the field (older deployments).
     /// </summary>
     [JsonPropertyName("has_experiment")]
-    public bool HasExperiment { get; init; }
+    public bool? HasExperiment { get; init; }
 }

--- a/src/PostHog/Api/FeatureFlagWithMetadata.cs
+++ b/src/PostHog/Api/FeatureFlagWithMetadata.cs
@@ -84,4 +84,11 @@ internal record FeatureFlagMetadata
     /// A description of the feature flag.
     /// </summary>
     public string? Description { get; init; }
+
+    /// <summary>
+    /// Whether the feature flag is linked to an experiment. Defaults to <c>false</c> when the
+    /// server does not report the field (older deployments).
+    /// </summary>
+    [JsonPropertyName("has_experiment")]
+    public bool HasExperiment { get; init; }
 }

--- a/src/PostHog/Api/LocalEvaluationApiResult.cs
+++ b/src/PostHog/Api/LocalEvaluationApiResult.cs
@@ -109,11 +109,11 @@ internal record LocalFeatureFlag
     public bool EnsureExperienceContinuity { get; init; }
 
     /// <summary>
-    /// Whether the feature flag is linked to an experiment. Defaults to <c>false</c> when the
-    /// server does not report the field (older deployments).
+    /// Whether the feature flag is linked to an experiment. <c>null</c> when the server does not
+    /// report the field (older deployments).
     /// </summary>
     [JsonPropertyName("has_experiment")]
-    public bool HasExperiment { get; init; }
+    public bool? HasExperiment { get; init; }
 }
 
 /// <summary>

--- a/src/PostHog/Api/LocalEvaluationApiResult.cs
+++ b/src/PostHog/Api/LocalEvaluationApiResult.cs
@@ -107,6 +107,13 @@ internal record LocalFeatureFlag
     /// </summary>
     [JsonPropertyName("ensure_experience_continuity")]
     public bool EnsureExperienceContinuity { get; init; }
+
+    /// <summary>
+    /// Whether the feature flag is linked to an experiment. Defaults to <c>false</c> when the
+    /// server does not report the field (older deployments).
+    /// </summary>
+    [JsonPropertyName("has_experiment")]
+    public bool HasExperiment { get; init; }
 }
 
 /// <summary>

--- a/src/PostHog/Features/FeatureFlag.cs
+++ b/src/PostHog/Features/FeatureFlag.cs
@@ -33,9 +33,9 @@ public record FeatureFlag
 
     /// <summary>
     /// Whether this feature flag is linked to an experiment, as reported by the server.
-    /// Defaults to <c>false</c> when the server does not report it (older deployments).
+    /// <c>null</c> when the server does not report it (older deployments).
     /// </summary>
-    public bool HasExperiment { get; init; }
+    public bool? HasExperiment { get; init; }
 
     /// <summary>
     /// Creates a <see cref="FeatureFlag"/> instance from the <c>/flags</c> endpoint response. Since payloads are
@@ -73,7 +73,7 @@ public record FeatureFlag
             IsEnabled = value.IsString ? value.StringValue is not null : value.Value,
             VariantKey = value.StringValue,
             Payload = payload is null ? null : JsonDocument.Parse(payload),
-            HasExperiment = flag?.Metadata is { HasExperiment: true }
+            HasExperiment = flag?.Metadata?.HasExperiment
         };
     }
 

--- a/src/PostHog/Features/FeatureFlag.cs
+++ b/src/PostHog/Features/FeatureFlag.cs
@@ -32,6 +32,12 @@ public record FeatureFlag
     public bool IsEnabled { get; init; } = true;
 
     /// <summary>
+    /// Whether this feature flag is linked to an experiment, as reported by the server.
+    /// Defaults to <c>false</c> when the server does not report it (older deployments).
+    /// </summary>
+    public bool HasExperiment { get; init; }
+
+    /// <summary>
     /// Creates a <see cref="FeatureFlag"/> instance from the <c>/flags</c> endpoint response. Since payloads are
     /// already calculated, we can look them up by the feature key.
     /// </summary>
@@ -44,10 +50,11 @@ public record FeatureFlag
         FlagsApiResult apiResult)
     {
         var payload = NotNull(apiResult).FeatureFlagPayloads?.GetValueOrDefault(key);
+        var flag = apiResult.Flags?.GetValueOrDefault(key);
 
-        var featureFlag = apiResult.Flags is not null && apiResult.Flags.TryGetValue(key, out var flag)
-                                                      && flag.Metadata is { Id: { } id, Version: { } version }
-                                                      && flag.Reason?.Description is { } reason
+        var featureFlag = flag is not null
+                          && flag.Metadata is { Id: { } id, Version: { } version }
+                          && flag.Reason?.Description is { } reason
             ? new FeatureFlagWithMetadata
             {
                 Key = flag.Key,
@@ -65,7 +72,8 @@ public record FeatureFlag
         {
             IsEnabled = value.IsString ? value.StringValue is not null : value.Value,
             VariantKey = value.StringValue,
-            Payload = payload is null ? null : JsonDocument.Parse(payload)
+            Payload = payload is null ? null : JsonDocument.Parse(payload),
+            HasExperiment = flag?.Metadata is { HasExperiment: true }
         };
     }
 
@@ -90,7 +98,8 @@ public record FeatureFlag
             Key = key,
             IsEnabled = value.IsString ? value.StringValue is not null : value.Value,
             VariantKey = value.StringValue,
-            Payload = payloadJsonString is null ? null : JsonDocument.Parse(payloadJsonString)
+            Payload = payloadJsonString is null ? null : JsonDocument.Parse(payloadJsonString),
+            HasExperiment = localFeatureFlag.HasExperiment
         };
     }
 
@@ -104,13 +113,14 @@ public record FeatureFlag
         && Key == other.Key
         && IsEnabled == other.IsEnabled
         && VariantKey == other.VariantKey
+        && HasExperiment == other.HasExperiment
         && JsonEqual(Payload, other.Payload);
 
     /// <summary>
     /// Serves as the default hash function.
     /// </summary>
     /// <returns>A hash code for the current <see cref="FeatureFlag"/>.</returns>
-    public override int GetHashCode() => HashCode.Combine(Key, IsEnabled, VariantKey, Payload);
+    public override int GetHashCode() => HashCode.Combine(Key, IsEnabled, VariantKey, HasExperiment, Payload);
 
     static bool JsonEqual(JsonDocument? source, JsonDocument? comparand) =>
         JsonNode.DeepEquals(ToJsonNode(source), ToJsonNode(comparand));

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -809,6 +809,7 @@ public sealed class PostHogClient : IPostHogClient
             ["$feature_flag"] = featureKey,
             ["$feature_flag_response"] = flag.ToResponseObject(),
             ["locally_evaluated"] = locallyEvaluated,
+            ["$feature_flag_has_experiment"] = flag is { HasExperiment: true },
             [$"$feature/{featureKey}"] = flag.ToResponseObject()
         };
         if (locallyEvaluated)

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -809,9 +809,15 @@ public sealed class PostHogClient : IPostHogClient
             ["$feature_flag"] = featureKey,
             ["$feature_flag_response"] = flag.ToResponseObject(),
             ["locally_evaluated"] = locallyEvaluated,
-            ["$feature_flag_has_experiment"] = flag is { HasExperiment: true },
             [$"$feature/{featureKey}"] = flag.ToResponseObject()
         };
+
+        // Tri-state: only sent when the server explicitly reported has_experiment; omitted when
+        // unknown (older deployments, legacy response formats, or missing flags).
+        if (flag?.HasExperiment is { } hasExperiment)
+        {
+            properties["$feature_flag_has_experiment"] = hasExperiment;
+        }
         if (locallyEvaluated)
         {
             properties["$feature_flag_reason"] = "Evaluated locally";

--- a/src/PostHog/PublicAPI.Unshipped.txt
+++ b/src/PostHog/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.get -> bool
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.init -> void
-PostHog.Features.FeatureFlag.HasExperiment.get -> bool
+PostHog.Features.FeatureFlag.HasExperiment.get -> bool?
 PostHog.Features.FeatureFlag.HasExperiment.init -> void
 PostHog.PostHogOptions.BeforeSend.get -> System.Func<PostHog.Api.CapturedEvent!, PostHog.Api.CapturedEvent?>?
 PostHog.PostHogOptions.BeforeSend.set -> void

--- a/src/PostHog/PublicAPI.Unshipped.txt
+++ b/src/PostHog/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.get -> bool
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.init -> void
+PostHog.Features.FeatureFlag.HasExperiment.get -> bool
+PostHog.Features.FeatureFlag.HasExperiment.init -> void
 PostHog.PostHogOptions.BeforeSend.get -> System.Func<PostHog.Api.CapturedEvent!, PostHog.Api.CapturedEvent?>?
 PostHog.PostHogOptions.BeforeSend.set -> void
 PostHog.PostHogOptions.FeatureFlagRequestMaxRetries.get -> int

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -191,7 +191,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": true,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "$feature_flag_reason": "Evaluated locally",
                       "$feature_flag_definitions_loaded_at": 1705864103000,
@@ -211,7 +210,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": true,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "$feature_flag_reason": "Evaluated locally",
                       "$feature_flag_definitions_loaded_at": 1705864103000,
@@ -231,7 +229,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": false,
                       "locally_evaluated": true,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": false,
                       "$feature_flag_reason": "Evaluated locally",
                       "$feature_flag_definitions_loaded_at": 1705864103000,
@@ -292,7 +289,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": false,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "distinct_id": "a-distinct-id",
                       "$lib": "posthog-dotnet",
@@ -310,7 +306,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": false,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "distinct_id": "another-distinct-id",
                       "$lib": "posthog-dotnet",
@@ -328,7 +323,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": false,
                       "locally_evaluated": false,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": false,
                       "distinct_id": "another-distinct-id",
                       "$lib": "posthog-dotnet",
@@ -504,7 +498,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "complex-flag",
                       "$feature_flag_response": true,
                       "locally_evaluated": true,
-                      "$feature_flag_has_experiment": false,
                       "$feature/complex-flag": true,
                       "$feature_flag_reason": "Evaluated locally",
                       "$feature_flag_definitions_loaded_at": 1705864103000,
@@ -557,7 +550,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": false,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "$feature_flag_request_id": "the-request-id",
                       "$feature_flag_evaluated_at": 1705862903000,
@@ -611,7 +603,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": false,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "$feature_flag_request_id": "the-request-id",
                       "$feature_flag_evaluated_at": 1705862903000,
@@ -738,7 +729,6 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": {{expected}},
                       "locally_evaluated": false,
-                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": {{expected}},
                       "$feature_flag_id": 1,
                       "$feature_flag_version": 23,
@@ -762,10 +752,10 @@ public class TheIsFeatureFlagEnabledAsyncMethod
     [Theory]
     [InlineData("\"has_experiment\": true,", true)]
     [InlineData("\"has_experiment\": false,", false)]
-    [InlineData("", false)] // Older deployments don't report the field.
+    [InlineData("", null)] // Older deployments don't report the field, so the property is omitted.
     public async Task CapturesFeatureFlagCalledEventWithHasExperimentFromFlagsMetadata(
         string hasExperimentJson,
-        bool expected)
+        bool? expected)
     {
         var container = new TestContainer();
         var messageHandler = container.FakeHttpMessageHandler;
@@ -804,16 +794,23 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             .EnumerateArray()
             .Single()
             .GetProperty("properties");
-        Assert.Equal(expected, properties.GetProperty("$feature_flag_has_experiment").GetBoolean());
+        if (expected is { } expectedValue)
+        {
+            Assert.Equal(expectedValue, properties.GetProperty("$feature_flag_has_experiment").GetBoolean());
+        }
+        else
+        {
+            Assert.False(properties.TryGetProperty("$feature_flag_has_experiment", out _));
+        }
     }
 
     [Theory]
     [InlineData("\"has_experiment\": true,", true)]
     [InlineData("\"has_experiment\": false,", false)]
-    [InlineData("", false)] // Older deployments don't report the field.
+    [InlineData("", null)] // Older deployments don't report the field, so the property is omitted.
     public async Task CapturesFeatureFlagCalledEventWithHasExperimentFromLocalEvaluation(
         string hasExperimentJson,
-        bool expected)
+        bool? expected)
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");
         var messageHandler = container.FakeHttpMessageHandler;
@@ -850,7 +847,14 @@ public class TheIsFeatureFlagEnabledAsyncMethod
             .EnumerateArray()
             .Single()
             .GetProperty("properties");
-        Assert.Equal(expected, properties.GetProperty("$feature_flag_has_experiment").GetBoolean());
+        if (expected is { } expectedValue)
+        {
+            Assert.Equal(expectedValue, properties.GetProperty("$feature_flag_has_experiment").GetBoolean());
+        }
+        else
+        {
+            Assert.False(properties.TryGetProperty("$feature_flag_has_experiment", out _));
+        }
         Assert.True(properties.GetProperty("locally_evaluated").GetBoolean());
     }
 }
@@ -2610,7 +2614,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": true,
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": true,
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2661,7 +2664,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": true,
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": true,
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2728,7 +2730,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2746,7 +2747,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "another-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2764,7 +2764,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "another-flag-key",
                                "$feature_flag_response": "flag-variant-2",
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/another-flag-key": "flag-variant-2",
                                "distinct_id": "another-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2782,7 +2781,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2840,7 +2838,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2858,7 +2855,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "another-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2876,7 +2872,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "another-flag-key",
                                "$feature_flag_response": "flag-variant-2",
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/another-flag-key": "flag-variant-2",
                                "distinct_id": "another-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2894,7 +2889,6 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
-                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -191,6 +191,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": true,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "$feature_flag_reason": "Evaluated locally",
                       "$feature_flag_definitions_loaded_at": 1705864103000,
@@ -210,6 +211,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": true,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "$feature_flag_reason": "Evaluated locally",
                       "$feature_flag_definitions_loaded_at": 1705864103000,
@@ -229,6 +231,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": false,
                       "locally_evaluated": true,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": false,
                       "$feature_flag_reason": "Evaluated locally",
                       "$feature_flag_definitions_loaded_at": 1705864103000,
@@ -289,6 +292,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": false,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "distinct_id": "a-distinct-id",
                       "$lib": "posthog-dotnet",
@@ -306,6 +310,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": false,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "distinct_id": "another-distinct-id",
                       "$lib": "posthog-dotnet",
@@ -323,6 +328,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": false,
                       "locally_evaluated": false,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": false,
                       "distinct_id": "another-distinct-id",
                       "$lib": "posthog-dotnet",
@@ -498,6 +504,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "complex-flag",
                       "$feature_flag_response": true,
                       "locally_evaluated": true,
+                      "$feature_flag_has_experiment": false,
                       "$feature/complex-flag": true,
                       "$feature_flag_reason": "Evaluated locally",
                       "$feature_flag_definitions_loaded_at": 1705864103000,
@@ -550,6 +557,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": false,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "$feature_flag_request_id": "the-request-id",
                       "$feature_flag_evaluated_at": 1705862903000,
@@ -603,6 +611,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": true,
                       "locally_evaluated": false,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": true,
                       "$feature_flag_request_id": "the-request-id",
                       "$feature_flag_evaluated_at": 1705862903000,
@@ -729,6 +738,7 @@ public class TheIsFeatureFlagEnabledAsyncMethod
                       "$feature_flag": "flag-key",
                       "$feature_flag_response": {{expected}},
                       "locally_evaluated": false,
+                      "$feature_flag_has_experiment": false,
                       "$feature/flag-key": {{expected}},
                       "$feature_flag_id": 1,
                       "$feature_flag_version": 23,
@@ -747,6 +757,101 @@ public class TheIsFeatureFlagEnabledAsyncMethod
               }
               """
             , received);
+    }
+
+    [Theory]
+    [InlineData("\"has_experiment\": true,", true)]
+    [InlineData("\"has_experiment\": false,", false)]
+    [InlineData("", false)] // Older deployments don't report the field.
+    public async Task CapturesFeatureFlagCalledEventWithHasExperimentFromFlagsMetadata(
+        string hasExperimentJson,
+        bool expected)
+    {
+        var container = new TestContainer();
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddFlagsResponse(
+            $$"""
+              {
+                  "flags": {
+                      "flag-key": {
+                          "key": "flag-key",
+                          "enabled": true,
+                          "variant": null,
+                          "reason": {
+                            "code": "condition_match",
+                            "description": "Matched conditions set 1",
+                            "condition_index": 0
+                          },
+                          "metadata": {
+                            "id": 1,
+                            "version": 2,
+                            {{hasExperimentJson}}
+                            "description": "A flag"
+                          }
+                      }
+                  }
+              }
+              """
+        );
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "a-distinct-id"));
+
+        await client.FlushAsync();
+        using var document = JsonDocument.Parse(captureRequestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement.GetProperty("batch")
+            .EnumerateArray()
+            .Single()
+            .GetProperty("properties");
+        Assert.Equal(expected, properties.GetProperty("$feature_flag_has_experiment").GetBoolean());
+    }
+
+    [Theory]
+    [InlineData("\"has_experiment\": true,", true)]
+    [InlineData("\"has_experiment\": false,", false)]
+    [InlineData("", false)] // Older deployments don't report the field.
+    public async Task CapturesFeatureFlagCalledEventWithHasExperimentFromLocalEvaluation(
+        string hasExperimentJson,
+        bool expected)
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddLocalEvaluationResponse(
+            $$"""
+              {
+                "flags": [
+                  {
+                      "id": 1,
+                      "key": "flag-key",
+                      "active": true,
+                      {{hasExperimentJson}}
+                      "filters": {
+                          "groups": [
+                              {
+                                  "properties": [],
+                                  "rollout_percentage": 100
+                              }
+                          ]
+                      }
+                  }
+                ]
+              }
+              """
+        );
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "a-distinct-id"));
+
+        await client.FlushAsync();
+        using var document = JsonDocument.Parse(captureRequestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement.GetProperty("batch")
+            .EnumerateArray()
+            .Single()
+            .GetProperty("properties");
+        Assert.Equal(expected, properties.GetProperty("$feature_flag_has_experiment").GetBoolean());
+        Assert.True(properties.GetProperty("locally_evaluated").GetBoolean());
     }
 }
 
@@ -2505,6 +2610,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": true,
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": true,
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2555,6 +2661,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": true,
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": true,
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2621,6 +2728,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2638,6 +2746,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "another-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2655,6 +2764,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "another-flag-key",
                                "$feature_flag_response": "flag-variant-2",
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/another-flag-key": "flag-variant-2",
                                "distinct_id": "another-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2672,6 +2782,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2729,6 +2840,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2746,6 +2858,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "another-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2763,6 +2876,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "another-flag-key",
                                "$feature_flag_response": "flag-variant-2",
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/another-flag-key": "flag-variant-2",
                                "distinct_id": "another-distinct-id",
                                "$lib": "posthog-dotnet",
@@ -2780,6 +2894,7 @@ public class TheGetFeatureFlagAsyncMethod
                                "$feature_flag": "flag-key",
                                "$feature_flag_response": "flag-variant-1",
                                "locally_evaluated": false,
+                               "$feature_flag_has_experiment": false,
                                "$feature/flag-key": "flag-variant-1",
                                "distinct_id": "a-distinct-id",
                                "$lib": "posthog-dotnet",


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of a cross-SDK effort to shrink `$feature_flag_called` events. This first phase adds a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, reflecting the server's `has_experiment` signal: `metadata.has_experiment` in the `/flags?v=2` response and `has_experiment` on `/api/feature_flag/local_evaluation` flag definitions. When the server does not report the field (older deployments, bootstrapped flags), the property is omitted, so it is tri-state: `true`, `false`, or absent (unknown).

This lets ingestion distinguish experiment-linked flag events (which need the full property set for exposure analysis) from the rest, and lets us measure the split before a later phase strips the expensive properties (`$feature/<key>`, `$feature_flag_payload`, per-event system metadata) from non-experiment flag events. This PR intentionally minimizes nothing: no properties are removed, no config options are added, and dedupe behavior is unchanged.

## Changes

- `FeatureFlagMetadata.HasExperiment` (`has_experiment`) on the `/flags` DTO and the same property on `LocalFeatureFlag` for `/local_evaluation`; both factories thread it onto the shared `FeatureFlag` record (included in record equality).
- Both send paths funnel through `BuildFeatureFlagCalledProperties`, which now always sets `$feature_flag_has_experiment`; synthetic missing/error flags report `false`. Legacy v3 responses and missing metadata safely default to `false`.
- `PublicAPI.Unshipped.txt` updated (RS0016); minor changeset.

## :green_heart: How did you test it?

`dotnet build PostHog.sln`: 0 errors, 0 warnings. `dotnet test`: 1,012 passed (UnitTests 944 + AspNetCore 49 + PostHog.AI 19), 0 failures. Two new theories cover true / false / absent from flags metadata and local evaluation, and 20 exact-JSON expectations were updated. `bin/fmt` clean.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

