### PR TITLE
fix: standardize event buffer defaults

### DIFF
--- a/.changeset/standardize-event-buffer-defaults.md
+++ b/.changeset/standardize-event-buffer-defaults.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Standardize event buffering defaults at a 10,000-event queue, 100-event flush threshold, 100-event maximum batch size, and 5-second flush interval.

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -174,22 +174,22 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
     public int MaxBatchSize { get; set; } = 100;
 
     /// <summary>
-    /// The max number of messages to store in the queue before we start dropping messages. (Default: 1000)
+    /// The max number of messages to store in the queue before we start dropping messages. (Default: 10000)
     /// </summary>
     /// <remarks>
     /// This property prevents runaway growth of the queue in the case of network outage or a burst of messages.
     /// </remarks>
-    public int MaxQueueSize { get; set; } = 1000;
+    public int MaxQueueSize { get; set; } = 10_000;
 
     /// <summary>
-    /// The number of events to queue before sending to PostHog (Default: 20)
+    /// The number of events to queue before sending to PostHog (Default: 100)
     /// </summary>
-    public int FlushAt { get; set; } = 20;
+    public int FlushAt { get; set; } = 100;
 
     /// <summary>
-    /// The interval between periodic flushes. (Default: 30s)
+    /// The interval between periodic flushes. (Default: 5s)
     /// </summary>
-    public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// The maximum number of retries for failed requests. (Default: 3)

--- a/tests/UnitTests/Config/RegistrationTests.cs
+++ b/tests/UnitTests/Config/RegistrationTests.cs
@@ -82,10 +82,21 @@ public class TheAddPostHogMethod
             ["Family"] = "Starks"
         }, options.SuperProperties);
         // Check the defaults
-        Assert.Equal(1000, options.MaxQueueSize);
-        Assert.Equal(TimeSpan.FromSeconds(30), options.FlushInterval);
+        Assert.Equal(10_000, options.MaxQueueSize);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.FlushInterval);
         Assert.Equal(TimeSpan.FromMinutes(10), options.FeatureFlagSentCacheSlidingExpiration);
         Assert.Equal(50_000, options.FeatureFlagSentCacheSizeLimit);
+    }
+
+    [Fact]
+    public void UsesStandardEventBufferDefaults()
+    {
+        var options = new PostHogOptions();
+
+        Assert.Equal(10_000, options.MaxQueueSize);
+        Assert.Equal(100, options.FlushAt);
+        Assert.Equal(100, options.MaxBatchSize);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.FlushInterval);
     }
 
     [Fact]
@@ -240,7 +251,7 @@ public class TheAddPostHogMethod
             ["House"] = "Tully"
         }, options.SuperProperties);
         // Check the defaults
-        Assert.Equal(TimeSpan.FromSeconds(30), options.FlushInterval);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.FlushInterval);
         Assert.Equal(TimeSpan.FromMinutes(10), options.FeatureFlagSentCacheSlidingExpiration);
         Assert.Equal(50_000, options.FeatureFlagSentCacheSizeLimit);
     }


### PR DESCRIPTION
## :bulb: Motivation and Context

The .NET SDK currently buffers 1,000 events, flushes after 20 events or 30 seconds, and caps batch requests at 100 events. Increase the queue to 10,000 events and standardize the flush threshold, maximum batch size, and flush interval at 100 events, 100 events, and 5 seconds respectively. These defaults align with the Python, Ruby, and Rails server-side SDKs, as summarized in the [server-side SDK event buffer defaults comparison](https://gist.github.com/dustinbyrne/53aae4565ccae67586b9d8d9a1017033).

Related changes: [Node.js SDK](https://github.com/PostHog/posthog-js/pull/4164), [Java server SDK](https://github.com/PostHog/posthog-android/pull/626), and [PHP SDK](https://github.com/PostHog/posthog-php/pull/204).

## :green_heart: How did you test it?

- `dotnet restore --locked-mode`
- `bin/fmt --check`
- `dotnet build --configuration Release --no-restore --nologo`
- `dotnet test tests/UnitTests/UnitTests.csproj --configuration Release --no-build --nologo --framework net8.0` (945 passed, 2 skipped)
- `dotnet test tests/UnitTests.AspNetCore/UnitTests.AspNetCore.csproj --configuration Release --no-build --nologo --framework net8.0` (49 passed)
- `dotnet test tests/PostHog.AI.Tests/PostHog.AI.Tests.csproj --configuration Release --no-build --nologo --framework net8.0` (19 passed)

The legacy `netcoreapp3.1` test target could not run locally because this arm64 machine does not have the required x64 .NET host; CI will cover that target.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check README.md#publishing-releases -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent as part of a human-directed server-side SDK standardization. Updated `PostHogOptions`, its XML documentation, configuration/default assertions, and a patch changeset for the core `PostHog` package. The existing 100-event maximum batch size already matched the target and remains unchanged.
