### PR TITLE
feat(flags): minimize $feature_flag_called events for non-experiment flags

### DIFF
--- a/.changeset/minimal-flag-called-events.md
+++ b/.changeset/minimal-flag-called-events.md
@@ -1,0 +1,5 @@
+---
+"PostHog": minor
+---
+
+Send minimal `$feature_flag_called` events when the server enables it (`minimalFlagCalledEvents` in the `/flags` v2 response or `minimal_flag_called_events` in the local evaluation payload) and the evaluated flag is not linked to an experiment. Minimal events keep a strict allowlist of flag evaluation properties and strip everything else, including the `$feature/<key>` enumeration and super properties. Experiment-linked flags and responses that do not carry the field continue to send the full event.

--- a/src/PostHog/Api/FlagsApiResult.cs
+++ b/src/PostHog/Api/FlagsApiResult.cs
@@ -44,6 +44,12 @@ internal record FlagsApiResult
     /// The timestamp when the feature flags were evaluated (milliseconds since Unix epoch).
     /// </summary>
     public long? EvaluatedAt { get; init; }
+
+    /// <summary>
+    /// Whether the server gated this project into sending minimal <c>$feature_flag_called</c> events.
+    /// <c>null</c> when the server does not report the field (older deployments and legacy response formats).
+    /// </summary>
+    public bool? MinimalFlagCalledEvents { get; init; }
 }
 
 /// <summary>
@@ -78,6 +84,12 @@ public record FlagsResult
     /// The list of feature flags that are limited by quota.
     /// </summary>
     public IReadOnlyList<string> QuotaLimited { get; init; } = [];
+
+    /// <summary>
+    /// Whether the server gated this project into sending minimal <c>$feature_flag_called</c> events.
+    /// <c>false</c> when the response does not carry the field.
+    /// </summary>
+    public bool MinimalFlagCalledEvents { get; init; }
 }
 
 /// <summary>
@@ -129,7 +141,8 @@ internal static class FlagsApiResultExtensions
             ErrorsWhileComputingFlags = results.ErrorsWhileComputingFlags,
             RequestId = results.RequestId,
             EvaluatedAt = results.EvaluatedAt,
-            QuotaLimited = results.QuotaLimited ?? []
+            QuotaLimited = results.QuotaLimited ?? [],
+            MinimalFlagCalledEvents = results.MinimalFlagCalledEvents == true
         };
     }
 }

--- a/src/PostHog/Api/LocalEvaluationApiResult.cs
+++ b/src/PostHog/Api/LocalEvaluationApiResult.cs
@@ -27,6 +27,13 @@ internal record LocalEvaluationApiResult
     public IReadOnlyDictionary<string, FilterSet>? Cohorts { get; init; }
 
     /// <summary>
+    /// Whether the server gated this project into sending minimal <c>$feature_flag_called</c> events.
+    /// <c>null</c> when the server does not report the field (older deployments).
+    /// </summary>
+    [JsonPropertyName("minimal_flag_called_events")]
+    public bool? MinimalFlagCalledEvents { get; init; }
+
+    /// <summary>
     /// Compares this instance to another <see cref="LocalEvaluationApiResult"/> for equality.
     /// </summary>
     /// <remarks>
@@ -48,14 +55,15 @@ internal record LocalEvaluationApiResult
 
         return Flags.ListsAreEqual(other.Flags)
                && GroupTypeMapping.DictionariesAreEqual(other.GroupTypeMapping)
-               && Cohorts.DictionariesAreEqual(other.Cohorts);
+               && Cohorts.DictionariesAreEqual(other.Cohorts)
+               && MinimalFlagCalledEvents == other.MinimalFlagCalledEvents;
     }
 
     /// <summary>
     /// Serves as the default hash function.
     /// </summary>
     /// <returns>A hash code for the current object.</returns>
-    public override int GetHashCode() => HashCode.Combine(Flags, GroupTypeMapping, Cohorts);
+    public override int GetHashCode() => HashCode.Combine(Flags, GroupTypeMapping, Cohorts, MinimalFlagCalledEvents);
 }
 
 /// <summary>

--- a/src/PostHog/Features/EvaluatedFlagRecord.cs
+++ b/src/PostHog/Features/EvaluatedFlagRecord.cs
@@ -35,4 +35,11 @@ internal sealed record EvaluatedFlagRecord
     /// on the emitted <c>$feature_flag_called</c> event.
     /// </summary>
     public bool LocallyEvaluated { get; init; }
+
+    /// <summary>
+    /// Whether the server gated this project into sending minimal <c>$feature_flag_called</c> events,
+    /// as reported by the source that evaluated this record (the local definitions payload or the
+    /// <c>/flags</c> response).
+    /// </summary>
+    public bool MinimalFlagCalledEvents { get; init; }
 }

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -73,6 +73,12 @@ internal sealed class LocalEvaluator
     public LocalEvaluationApiResult LocalEvaluationApiResult { get; }
 
     /// <summary>
+    /// Whether the server gated this project into sending minimal <c>$feature_flag_called</c> events,
+    /// as reported by the local evaluation payload. <c>false</c> when the payload does not carry the field.
+    /// </summary>
+    public bool MinimalFlagCalledEvents => LocalEvaluationApiResult.MinimalFlagCalledEvents == true;
+
+    /// <summary>
     /// Constructs a <see cref="LocalEvaluator"/> with the specified flags.
     /// </summary>
     /// <param name="flags">The flags returned from the local evaluation endpoint.</param>

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -391,6 +391,11 @@ public sealed class PostHogClient : IPostHogClient
         }
     }
 
+    // Minimal events require both the server-side gate and an explicit has_experiment == false;
+    // any missing signal (gate off, has_experiment unknown) sends the full event.
+    static bool ShouldSendMinimalFeatureFlagCalledEvent(bool gate, bool? hasExperiment)
+        => gate && hasExperiment == false;
+
     // Builds the minimal event from the allowlist rather than removing properties from the full
     // set, so anything merged upstream (super properties, context properties) cannot leak in. The
     // CapturedEvent constructor re-adds distinct_id and defaults $geoip_disable to true when it
@@ -783,13 +788,11 @@ public sealed class PostHogClient : IPostHogClient
                     ? _featureFlagsLoader.FlagDefinitionsLoadedAt
                     : null);
 
-            // Minimal events require both the server-side gate (read from whichever source
-            // evaluated the flag) and an explicit has_experiment == false; any missing signal
-            // sends the full event.
-            var minimalEvent = response?.HasExperiment == false
-                && (flagWasLocallyEvaluated
-                    ? localEvaluator?.MinimalFlagCalledEvents == true
-                    : flagsResult?.MinimalFlagCalledEvents == true);
+            // The gate is read from whichever source evaluated the flag.
+            var minimalFlagCalledEventsGate = flagWasLocallyEvaluated
+                ? localEvaluator?.MinimalFlagCalledEvents == true
+                : flagsResult?.MinimalFlagCalledEvents == true;
+            var minimalEvent = ShouldSendMinimalFeatureFlagCalledEvent(minimalFlagCalledEventsGate, response?.HasExperiment);
 
             TryCaptureDedupedFeatureFlagCalledEvent(
                 resolvedDistinctId,
@@ -1008,10 +1011,10 @@ public sealed class PostHogClient : IPostHogClient
                 locallyEvaluated: record?.LocallyEvaluated ?? false,
                 flagDefinitionsLoadedAt: record?.LocallyEvaluated == true ? flagDefinitionsLoadedAt : null);
 
-            // Minimal events require both the server-side gate (carried on the record from the
-            // source that evaluated it) and an explicit has_experiment == false; any missing
-            // signal sends the full event.
-            var minimalEvent = record is { MinimalFlagCalledEvents: true, Flag.HasExperiment: false };
+            // The gate is carried on the record from the source that evaluated it.
+            var minimalEvent = ShouldSendMinimalFeatureFlagCalledEvent(
+                record?.MinimalFlagCalledEvents == true,
+                record?.Flag.HasExperiment);
 
             _client.TryCaptureDedupedFeatureFlagCalledEvent(
                 distinctId,

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -25,6 +25,30 @@ public sealed class PostHogClient : IPostHogClient
     static readonly ApiResult NoOpApiResult = new(0);
     static readonly IReadOnlyDictionary<string, FeatureFlag> EmptyFeatureFlags = new Dictionary<string, FeatureFlag>(0);
 
+    // Strict allowlist for minimal $feature_flag_called events, shared across PostHog SDKs.
+    // Everything else — including super properties, context properties, the $feature/<key>
+    // enumeration, and system context — is stripped.
+    static readonly string[] MinimalFeatureFlagCalledEventProperties =
+    [
+        "$feature_flag",
+        "$feature_flag_response",
+        "$feature_flag_has_experiment",
+        "$feature_flag_id",
+        "$feature_flag_version",
+        "$feature_flag_reason",
+        "$feature_flag_request_id",
+        "$feature_flag_evaluated_at",
+        "$feature_flag_error",
+        "locally_evaluated",
+        "$groups",
+        PostHogProperties.ProcessPersonProfile,
+        PostHogProperties.SessionId,
+        PostHogProperties.Lib,
+        PostHogProperties.LibVersion,
+        PostHogProperties.GeoIpDisable,
+        PostHogProperties.IsServer,
+    ];
+
     readonly TimeProvider _timeProvider;
     readonly IOptions<PostHogOptions> _options;
     readonly ITaskScheduler _taskScheduler;
@@ -278,7 +302,8 @@ public sealed class PostHogClient : IPostHogClient
         GroupCollection? groups,
         bool sendFeatureFlags,
         FeatureFlagEvaluations? flags,
-        DateTimeOffset? timestamp)
+        DateTimeOffset? timestamp,
+        bool minimalFeatureFlagCalledEvent = false)
     {
         if (CheckDisabledAndLog(nameof(Capture)))
         {
@@ -321,6 +346,11 @@ public sealed class PostHogClient : IPostHogClient
             capturedEvent.Properties[PostHogProperties.IsServer] = true;
         }
 
+        if (minimalFeatureFlagCalledEvent)
+        {
+            capturedEvent = ToMinimalFeatureFlagCalledEvent(capturedEvent);
+        }
+
         var batchItem = new BatchItem<CapturedEvent, CapturedEventBatchContext>(BatchTask);
 
         if (_asyncBatchHandler.Enqueue(batchItem))
@@ -359,6 +389,28 @@ public sealed class PostHogClient : IPostHogClient
 
             return enrichedEvent;
         }
+    }
+
+    // Builds the minimal event from the allowlist rather than removing properties from the full
+    // set, so anything merged upstream (super properties, context properties) cannot leak in. The
+    // CapturedEvent constructor re-adds distinct_id and defaults $geoip_disable to true when it
+    // was not explicitly set.
+    static CapturedEvent ToMinimalFeatureFlagCalledEvent(CapturedEvent capturedEvent)
+    {
+        var properties = new Dictionary<string, object>(MinimalFeatureFlagCalledEventProperties.Length);
+        foreach (var key in MinimalFeatureFlagCalledEventProperties)
+        {
+            if (capturedEvent.Properties.TryGetValue(key, out var value))
+            {
+                properties[key] = value;
+            }
+        }
+
+        return new CapturedEvent(
+            capturedEvent.EventName,
+            capturedEvent.DistinctId,
+            properties,
+            capturedEvent.Timestamp);
     }
 
     async Task CaptureBatchAsync(IEnumerable<CapturedEvent> batch)
@@ -731,12 +783,21 @@ public sealed class PostHogClient : IPostHogClient
                     ? _featureFlagsLoader.FlagDefinitionsLoadedAt
                     : null);
 
+            // Minimal events require both the server-side gate (read from whichever source
+            // evaluated the flag) and an explicit has_experiment == false; any missing signal
+            // sends the full event.
+            var minimalEvent = response?.HasExperiment == false
+                && (flagWasLocallyEvaluated
+                    ? localEvaluator?.MinimalFlagCalledEvents == true
+                    : flagsResult?.MinimalFlagCalledEvents == true);
+
             TryCaptureDedupedFeatureFlagCalledEvent(
                 resolvedDistinctId,
                 featureKey,
                 cacheKeyValue: (string)response,
                 properties,
                 options.Groups,
+                minimalEvent,
                 cancellationToken);
         }
 
@@ -857,6 +918,7 @@ public sealed class PostHogClient : IPostHogClient
         string cacheKeyValue,
         Dictionary<string, object> properties,
         GroupCollection? groups,
+        bool minimalEvent,
         CancellationToken cancellationToken)
     {
         var groupsCacheKey = CanonicalGroupsCacheKey(groups);
@@ -879,7 +941,8 @@ public sealed class PostHogClient : IPostHogClient
                     groups: groups,
                     sendFeatureFlags: false,
                     flags: null,
-                    timestamp: null);
+                    timestamp: null,
+                    minimalFeatureFlagCalledEvent: minimalEvent);
                 return true;
             });
 
@@ -945,12 +1008,18 @@ public sealed class PostHogClient : IPostHogClient
                 locallyEvaluated: record?.LocallyEvaluated ?? false,
                 flagDefinitionsLoadedAt: record?.LocallyEvaluated == true ? flagDefinitionsLoadedAt : null);
 
+            // Minimal events require both the server-side gate (carried on the record from the
+            // source that evaluated it) and an explicit has_experiment == false; any missing
+            // signal sends the full event.
+            var minimalEvent = record is { MinimalFlagCalledEvents: true, Flag.HasExperiment: false };
+
             _client.TryCaptureDedupedFeatureFlagCalledEvent(
                 distinctId,
                 featureKey,
                 cacheKeyValue,
                 properties,
                 groups,
+                minimalEvent,
                 CancellationToken.None);
         }
 
@@ -1013,7 +1082,11 @@ public sealed class PostHogClient : IPostHogClient
 
                     foreach (var (key, flag) in locallyEvaluated)
                     {
-                        records[key] = ToRecord(key, flag, locallyEvaluated: true);
+                        records[key] = ToRecord(
+                            key,
+                            flag,
+                            locallyEvaluated: true,
+                            minimalFlagCalledEvents: localEvaluator.MinimalFlagCalledEvents);
                     }
 
                     if (locallyEvaluated.Count > 0)
@@ -1069,7 +1142,11 @@ public sealed class PostHogClient : IPostHogClient
                     // which discards local results entirely on remote fallback.
                     if (!records.ContainsKey(key))
                     {
-                        records[key] = ToRecord(key, flag, locallyEvaluated: false);
+                        records[key] = ToRecord(
+                            key,
+                            flag,
+                            locallyEvaluated: false,
+                            minimalFlagCalledEvents: flagsResult.MinimalFlagCalledEvents);
                     }
                 }
             }
@@ -1092,7 +1169,7 @@ public sealed class PostHogClient : IPostHogClient
             options?.Groups,
             errors);
 
-        static EvaluatedFlagRecord ToRecord(string key, FeatureFlag flag, bool locallyEvaluated)
+        static EvaluatedFlagRecord ToRecord(string key, FeatureFlag flag, bool locallyEvaluated, bool minimalFlagCalledEvents)
             => new()
             {
                 Key = key,
@@ -1100,6 +1177,7 @@ public sealed class PostHogClient : IPostHogClient
                 Enabled = flag.IsEnabled,
                 CacheKeyValue = (string)flag,
                 LocallyEvaluated = locallyEvaluated,
+                MinimalFlagCalledEvents = minimalFlagCalledEvents,
             };
     }
 

--- a/src/PostHog/PublicAPI.Unshipped.txt
+++ b/src/PostHog/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.get -> bool
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.init -> void
+PostHog.Api.FlagsResult.MinimalFlagCalledEvents.get -> bool
+PostHog.Api.FlagsResult.MinimalFlagCalledEvents.init -> void
 PostHog.Features.FeatureFlag.HasExperiment.get -> bool?
 PostHog.Features.FeatureFlag.HasExperiment.init -> void
 PostHog.PostHogOptions.BeforeSend.get -> System.Func<PostHog.Api.CapturedEvent!, PostHog.Api.CapturedEvent?>?

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -242,6 +242,38 @@ public class TheEvaluateFlagsAsyncMethod
     }
 
     [Fact]
+    public async Task SendsFullFeatureFlagCalledEventPerRecordWhenHasExperimentIsUnknownEvenWhenGated()
+    {
+        var container = new TestContainer();
+        // Gate is on, but the flag's metadata omits has_experiment entirely: an unknown signal
+        // must still fall back to the full event on the snapshot path.
+        container.FakeHttpMessageHandler.AddFlagsResponse(
+            """
+            {"minimalFlagCalledEvents": true,
+             "flags": {
+                "flag-key": {
+                    "key": "flag-key",
+                    "enabled": true,
+                    "reason": {"description": "matched condition set 1"},
+                    "metadata": {"id": 1, "version": 1}
+                }
+            }}
+            """);
+        var batchHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        var snapshot = await client.EvaluateFlagsAsync("user-1", options: null, CancellationToken.None);
+        snapshot.IsEnabled("flag-key");
+
+        await client.FlushAsync();
+        using var doc = JsonDocument.Parse(batchHandler.GetReceivedRequestBody(indented: false));
+        var properties = doc.RootElement.GetProperty("batch").EnumerateArray().Single().GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("$feature/flag-key", out _));
+        Assert.False(properties.TryGetProperty("$feature_flag_has_experiment", out _));
+    }
+
+    [Fact]
     public async Task UnknownKeyAccessAppendsFlagMissingErrorOnFeatureFlagCalled()
     {
         var container = new TestContainer();

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -178,6 +178,70 @@ public class TheEvaluateFlagsAsyncMethod
     }
 
     [Fact]
+    public async Task SendsMinimalFeatureFlagCalledEventsPerRecordWhenGatedAndFlagHasNoExperiment()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        // local-flag resolves locally; needs-remote and exp-flag fall back to the remote /flags
+        // response. Both sources report the minimal gate; exp-flag is experiment-linked so it
+        // still sends the full event.
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {"minimal_flag_called_events": true,
+             "flags": [
+                {"id": 1, "key": "local-flag", "active": true, "has_experiment": false,
+                 "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+                {"id": 2, "key": "needs-remote", "active": true,
+                 "filters": {"groups": [{"properties": [{"key": "country", "type": "person", "value": "US", "operator": "exact"}],
+                                          "rollout_percentage": 100}]}}
+            ]}
+            """);
+        container.FakeHttpMessageHandler.AddFlagsResponse(
+            """
+            {"minimalFlagCalledEvents": true,
+             "flags": {
+                "needs-remote": {
+                    "key": "needs-remote",
+                    "enabled": true,
+                    "reason": {"description": "matched condition set 1"},
+                    "metadata": {"id": 2, "version": 3, "has_experiment": false}
+                },
+                "exp-flag": {
+                    "key": "exp-flag",
+                    "enabled": true,
+                    "reason": {"description": "matched condition set 1"},
+                    "metadata": {"id": 3, "version": 1, "has_experiment": true}
+                }
+            }}
+            """);
+        var batchHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        var snapshot = await client.EvaluateFlagsAsync("user-1", options: null, CancellationToken.None);
+        snapshot.IsEnabled("local-flag");
+        snapshot.IsEnabled("needs-remote");
+        snapshot.IsEnabled("exp-flag");
+
+        await client.FlushAsync();
+        using var doc = JsonDocument.Parse(batchHandler.GetReceivedRequestBody(indented: false));
+        var byFlag = doc.RootElement.GetProperty("batch").EnumerateArray()
+            .ToDictionary(
+                e => e.GetProperty("properties").GetProperty("$feature_flag").GetString() ?? string.Empty,
+                e => e.GetProperty("properties"));
+
+        // Minimal events strip the $feature/<key> enumeration and (for local evaluation) the
+        // definitions-loaded timestamp.
+        Assert.False(byFlag["local-flag"].TryGetProperty("$feature/local-flag", out _));
+        Assert.False(byFlag["local-flag"].TryGetProperty("$feature_flag_definitions_loaded_at", out _));
+        Assert.False(byFlag["local-flag"].GetProperty("$feature_flag_has_experiment").GetBoolean());
+        Assert.False(byFlag["needs-remote"].TryGetProperty("$feature/needs-remote", out _));
+        Assert.False(byFlag["needs-remote"].GetProperty("$feature_flag_has_experiment").GetBoolean());
+
+        // Experiment-linked flags keep the full event.
+        Assert.True(byFlag["exp-flag"].TryGetProperty("$feature/exp-flag", out _));
+        Assert.True(byFlag["exp-flag"].GetProperty("$feature_flag_has_experiment").GetBoolean());
+    }
+
+    [Fact]
     public async Task UnknownKeyAccessAppendsFlagMissingErrorOnFeatureFlagCalled()
     {
         var container = new TestContainer();

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -1066,6 +1066,53 @@ public class TheIsFeatureFlagEnabledAsyncMethod
         Assert.Equal("id:5", properties.GetProperty("$groups").GetProperty("company").GetString());
     }
 
+    [Fact]
+    public async Task MinimalFeatureFlagCalledEventRetainsErrorProperty()
+    {
+        var container = new TestContainer();
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddFlagsResponse(
+            """
+            {
+                "minimalFlagCalledEvents": true,
+                "errorsWhileComputingFlags": true,
+                "flags": {
+                    "flag-key": {
+                        "key": "flag-key",
+                        "enabled": true,
+                        "variant": null,
+                        "reason": {
+                          "code": "condition_match",
+                          "description": "Matched conditions set 1",
+                          "condition_index": 0
+                        },
+                        "metadata": {
+                          "id": 1,
+                          "version": 2,
+                          "has_experiment": false,
+                          "description": "A flag"
+                        }
+                    }
+                }
+            }
+            """
+        );
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "a-distinct-id"));
+
+        await client.FlushAsync();
+        using var document = JsonDocument.Parse(captureRequestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement.GetProperty("batch")
+            .EnumerateArray()
+            .Single()
+            .GetProperty("properties");
+        // The event is minimal, but $feature_flag_error (allowlisted) still survives the strip.
+        Assert.False(properties.TryGetProperty("$feature/flag-key", out _));
+        Assert.Equal("errors_while_computing_flags", properties.GetProperty("$feature_flag_error").GetString());
+    }
+
     [Theory]
     [InlineData("\"minimal_flag_called_events\": true,", "\"has_experiment\": false,", true)] // Gated + no experiment → minimal.
     [InlineData("\"minimal_flag_called_events\": true,", "\"has_experiment\": true,", false)] // Gated + experiment → full.

--- a/tests/UnitTests/Features/FeatureFlagsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagsTests.cs
@@ -857,6 +857,293 @@ public class TheIsFeatureFlagEnabledAsyncMethod
         }
         Assert.True(properties.GetProperty("locally_evaluated").GetBoolean());
     }
+
+    [Theory]
+    [InlineData("\"minimalFlagCalledEvents\": true,", "\"has_experiment\": false,", true)] // Gated + no experiment → minimal.
+    [InlineData("\"minimalFlagCalledEvents\": true,", "\"has_experiment\": true,", false)] // Gated + experiment → full.
+    [InlineData("\"minimalFlagCalledEvents\": true,", "", false)] // Gated + unknown has_experiment → full.
+    [InlineData("\"minimalFlagCalledEvents\": false,", "\"has_experiment\": false,", false)] // Gate off → full.
+    [InlineData("", "\"has_experiment\": false,", false)] // Gate absent → full.
+    public async Task SendsMinimalFeatureFlagCalledEventOnlyWhenGatedByFlagsResponseAndFlagHasNoExperiment(
+        string minimalFlagCalledEventsJson,
+        string hasExperimentJson,
+        bool expectMinimal)
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SuperProperties["source"] = "super";
+        }));
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddFlagsResponse(
+            $$"""
+              {
+                  {{minimalFlagCalledEventsJson}}
+                  "flags": {
+                      "flag-key": {
+                          "key": "flag-key",
+                          "enabled": true,
+                          "variant": null,
+                          "reason": {
+                            "code": "condition_match",
+                            "description": "Matched conditions set 1",
+                            "condition_index": 0
+                          },
+                          "metadata": {
+                            "id": 1,
+                            "version": 2,
+                            {{hasExperimentJson}}
+                            "description": "A flag"
+                          }
+                      }
+                  },
+                  "requestId": "the-request-id",
+                  "evaluatedAt": 1705862903000
+              }
+              """
+        );
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "a-distinct-id"));
+
+        await client.FlushAsync();
+        using var document = JsonDocument.Parse(captureRequestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement.GetProperty("batch")
+            .EnumerateArray()
+            .Single()
+            .GetProperty("properties");
+        if (expectMinimal)
+        {
+            string[] expectedProperties =
+            [
+                "$feature_flag",
+                "$feature_flag_response",
+                "$feature_flag_has_experiment",
+                "$feature_flag_id",
+                "$feature_flag_version",
+                "$feature_flag_reason",
+                "$feature_flag_request_id",
+                "$feature_flag_evaluated_at",
+                "locally_evaluated",
+                "$lib",
+                "$lib_version",
+                "distinct_id",
+                "$geoip_disable",
+                "$is_server"
+            ];
+            Assert.Equal(
+                expectedProperties.OrderBy(name => name, StringComparer.Ordinal),
+                properties.EnumerateObject().Select(p => p.Name).OrderBy(name => name, StringComparer.Ordinal));
+            Assert.False(properties.GetProperty("$feature_flag_has_experiment").GetBoolean());
+            Assert.True(properties.GetProperty("$is_server").GetBoolean());
+        }
+        else
+        {
+            Assert.True(properties.TryGetProperty("$feature/flag-key", out _));
+            Assert.Equal("super", properties.GetProperty("source").GetString());
+        }
+    }
+
+    [Fact]
+    public async Task MinimalFeatureFlagCalledEventPreservesExplicitGeoIpDisable()
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SuperProperties["$geoip_disable"] = false;
+        }));
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddFlagsResponse(
+            """
+            {
+                "minimalFlagCalledEvents": true,
+                "flags": {
+                    "flag-key": {
+                        "key": "flag-key",
+                        "enabled": true,
+                        "variant": null,
+                        "reason": {
+                          "code": "condition_match",
+                          "description": "Matched conditions set 1",
+                          "condition_index": 0
+                        },
+                        "metadata": {
+                          "id": 1,
+                          "version": 2,
+                          "has_experiment": false,
+                          "description": "A flag"
+                        }
+                    }
+                }
+            }
+            """
+        );
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "a-distinct-id"));
+
+        await client.FlushAsync();
+        using var document = JsonDocument.Parse(captureRequestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement.GetProperty("batch")
+            .EnumerateArray()
+            .Single()
+            .GetProperty("properties");
+        // The event is minimal, but the caller's explicit GeoIP choice survives the allowlist.
+        Assert.False(properties.TryGetProperty("$feature/flag-key", out _));
+        Assert.False(properties.GetProperty("$geoip_disable").GetBoolean());
+    }
+
+    [Fact]
+    public async Task MinimalFeatureFlagCalledEventRetainsGroups()
+    {
+        var container = new TestContainer();
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddFlagsResponse(
+            """
+            {
+                "minimalFlagCalledEvents": true,
+                "flags": {
+                    "flag-key": {
+                        "key": "flag-key",
+                        "enabled": true,
+                        "variant": null,
+                        "reason": {
+                          "code": "condition_match",
+                          "description": "Matched conditions set 1",
+                          "condition_index": 0
+                        },
+                        "metadata": {
+                          "id": 1,
+                          "version": 2,
+                          "has_experiment": false,
+                          "description": "A flag"
+                        }
+                    }
+                },
+                "requestId": "the-request-id",
+                "evaluatedAt": 1705862903000
+            }
+            """
+        );
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(await client.IsFeatureEnabledAsync(
+            "flag-key",
+            "a-distinct-id",
+            options: new FeatureFlagOptions
+            {
+                Groups = [new Group { GroupType = "company", GroupKey = "id:5" }]
+            }));
+
+        await client.FlushAsync();
+        using var document = JsonDocument.Parse(captureRequestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement.GetProperty("batch")
+            .EnumerateArray()
+            .Single()
+            .GetProperty("properties");
+        string[] expectedProperties =
+        [
+            "$feature_flag",
+            "$feature_flag_response",
+            "$feature_flag_has_experiment",
+            "$feature_flag_id",
+            "$feature_flag_version",
+            "$feature_flag_reason",
+            "$feature_flag_request_id",
+            "$feature_flag_evaluated_at",
+            "locally_evaluated",
+            "$groups",
+            "$lib",
+            "$lib_version",
+            "distinct_id",
+            "$geoip_disable",
+            "$is_server"
+        ];
+        Assert.Equal(
+            expectedProperties.OrderBy(name => name, StringComparer.Ordinal),
+            properties.EnumerateObject().Select(p => p.Name).OrderBy(name => name, StringComparer.Ordinal));
+        Assert.Equal("id:5", properties.GetProperty("$groups").GetProperty("company").GetString());
+    }
+
+    [Theory]
+    [InlineData("\"minimal_flag_called_events\": true,", "\"has_experiment\": false,", true)] // Gated + no experiment → minimal.
+    [InlineData("\"minimal_flag_called_events\": true,", "\"has_experiment\": true,", false)] // Gated + experiment → full.
+    [InlineData("\"minimal_flag_called_events\": true,", "", false)] // Gated + unknown has_experiment → full.
+    [InlineData("", "\"has_experiment\": false,", false)] // Gate absent → full.
+    public async Task SendsMinimalFeatureFlagCalledEventOnlyWhenGatedByLocalEvaluationAndFlagHasNoExperiment(
+        string minimalFlagCalledEventsJson,
+        string hasExperimentJson,
+        bool expectMinimal)
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SecretKey = "fake-personal-api-key";
+            options.SuperProperties["source"] = "super";
+        }));
+        var messageHandler = container.FakeHttpMessageHandler;
+        messageHandler.AddLocalEvaluationResponse(
+            $$"""
+              {
+                {{minimalFlagCalledEventsJson}}
+                "flags": [
+                  {
+                      "id": 1,
+                      "key": "flag-key",
+                      "active": true,
+                      {{hasExperimentJson}}
+                      "filters": {
+                          "groups": [
+                              {
+                                  "properties": [],
+                                  "rollout_percentage": 100
+                              }
+                          ]
+                      }
+                  }
+                ]
+              }
+              """
+        );
+        var captureRequestHandler = messageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        Assert.True(await client.IsFeatureEnabledAsync("flag-key", "a-distinct-id"));
+
+        await client.FlushAsync();
+        using var document = JsonDocument.Parse(captureRequestHandler.GetReceivedRequestBody(indented: false));
+        var properties = document.RootElement.GetProperty("batch")
+            .EnumerateArray()
+            .Single()
+            .GetProperty("properties");
+        if (expectMinimal)
+        {
+            string[] expectedProperties =
+            [
+                "$feature_flag",
+                "$feature_flag_response",
+                "$feature_flag_has_experiment",
+                "$feature_flag_reason",
+                "locally_evaluated",
+                "$lib",
+                "$lib_version",
+                "distinct_id",
+                "$geoip_disable",
+                "$is_server"
+            ];
+            Assert.Equal(
+                expectedProperties.OrderBy(name => name, StringComparer.Ordinal),
+                properties.EnumerateObject().Select(p => p.Name).OrderBy(name => name, StringComparer.Ordinal));
+            Assert.False(properties.GetProperty("$feature_flag_has_experiment").GetBoolean());
+            Assert.True(properties.GetProperty("locally_evaluated").GetBoolean());
+        }
+        else
+        {
+            Assert.True(properties.TryGetProperty("$feature/flag-key", out _));
+            Assert.True(properties.TryGetProperty("$feature_flag_definitions_loaded_at", out _));
+            Assert.Equal("super", properties.GetProperty("source").GetString());
+        }
+    }
 }
 
 public class TheGetFeatureFlagAsyncMethod


### PR DESCRIPTION
## :bulb: Motivation and Context

`$feature_flag_called` events carry the full enriched properties (context properties, super properties, custom event properties) on every flag call, even for flags not linked to an experiment. This PR trims those events to a strict allowlist iff the server-controlled gate is on (`minimalFlagCalledEvents` in the v2 `/flags` response, or `minimal_flag_called_events` in the local-evaluation payload) and the flag's `HasExperiment` is exactly `false`. Any missing signal (gate absent, `HasExperiment` unknown, legacy response shapes, parse failure) sends the full legacy shape unchanged.

Server-gated because rolling this out unconditionally could break existing insights; announcement/comms come before enablement. The goal is to establish `$feature_flag_called` as a special system event.

Implementation notes:

- The gate is stored on `FlagsResult`, so it persists alongside cached flags via `IFeatureFlagCache`, and on the `LocalEvaluator`, which the poller already swaps whole via `Interlocked.Exchange`; the gate lives with the poll state and needs no extra synchronization.
- Mixed local+remote snapshots from `EvaluateFlagsAsync` carry the gate per record, read from whichever source evaluated that flag.
- The minimal event is built by construction from the allowlist in `CaptureCore`, after all property merging (context properties, `$groups`, super properties, `$is_server`), so nothing merged upstream can leak in.
- A caller's explicit `$geoip_disable` value is preserved on minimal events; when unset, the usual default applies.
- Includes a changeset (minor) and a `PublicAPI.Unshipped.txt` entry for the new `FlagsResult.MinimalFlagCalledEvents` property.

Part of a cross-SDK rollout; reference implementation and fuller context: PostHog/posthog-python#748

## :green_heart: How did you test it?

- `dotnet test -f net8.0`: 957 passed / 2 skipped (UnitTests), 49 passed (UnitTests.AspNetCore), 19 passed (PostHog.AI.Tests), 0 failed. The netcoreapp3.1 target compiles but cannot execute on ARM hosts; CI covers it.
- `bin/fmt --check`: clean.
- New coverage: gate x `has_experiment` matrix as theories for both signal sources (`/flags` v2 and local evaluation), exact-key-set assertions on minimal events, `$groups` retention when evaluating with a group collection, explicit `$geoip_disable` preservation, and per-record gating on a mixed local+remote snapshot.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
