### PR TITLE
fix: avoid false ProjectApiKey deprecation warning

### DIFF
--- a/.changeset/calm-badgers-bind.md
+++ b/.changeset/calm-badgers-bind.md
@@ -1,0 +1,6 @@
+---
+"PostHog": patch
+"PostHog.AspNetCore": patch
+---
+
+Prevent `ProjectToken`-only configuration from logging the deprecated `ProjectApiKey` warning.

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -1,4 +1,4 @@
-# � SECURITY PLACEHOLDER - DO NOT USE THIS WORKFLOW NAME �
+# SECURITY PLACEHOLDER - DO NOT USE THIS WORKFLOW NAME
 #
 # This workflow previously existed and was compromised. This placeholder file
 # exists to allow blocking this workflow name in GitHub's branch protection rules.
@@ -21,5 +21,5 @@ jobs:
     steps:
       - name: This workflow is blocked
         run: |
-          echo "� A workflow with this name was previously compromised and is now blocked."
+          echo "A workflow with this name was previously compromised and is now blocked."
           exit 1

--- a/src/PostHog/Config/PostHogConfigurationBuilderExtensions.cs
+++ b/src/PostHog/Config/PostHogConfigurationBuilderExtensions.cs
@@ -43,8 +43,9 @@ public static class PostHogConfigurationBuilderExtensions
                 var projectKeyState = options.GetProjectKeyState();
                 section.Bind(options);
 
-                // ConfigurationBinder writes alias getter values back when their keys are absent. Restore the raw
-                // values for absent keys so this section changes only the project key values it contains.
+                // ConfigurationBinder writes alias getter values back when their keys are absent. A raw
+                // ProjectApiKey getter would avoid this but break its public alias behavior, so restore raw values
+                // for absent keys instead.
                 options.RestoreProjectKeyState(
                     projectKeyState,
                     restoreProjectToken: section["ProjectToken"] is null,

--- a/src/PostHog/Config/PostHogConfigurationBuilderExtensions.cs
+++ b/src/PostHog/Config/PostHogConfigurationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using static PostHog.Library.Ensure;
 
 namespace PostHog.Config;
@@ -31,12 +32,23 @@ public static class PostHogConfigurationBuilderExtensions
     public static IPostHogConfigurationBuilder UseConfigurationSection(
         this IPostHogConfigurationBuilder builder,
         IConfigurationSection section) =>
-        NotNull(builder).Use(services
-            => services.Configure<PostHogOptions>(section));
-
-#if NETSTANDARD2_0 || NETSTANDARD2_1
-    static IServiceCollection Configure<T>(this IServiceCollection services, IConfigurationSection section)
-        where T : class =>
-        services.Configure<T>(section.Bind);
+        NotNull(builder).Use(services =>
+        {
+#if !(NETSTANDARD2_0 || NETSTANDARD2_1)
+            services.AddSingleton<IOptionsChangeTokenSource<PostHogOptions>>(
+                new ConfigurationChangeTokenSource<PostHogOptions>(section));
 #endif
+            services.Configure<PostHogOptions>(options =>
+            {
+                var projectKeyState = options.GetProjectKeyState();
+                section.Bind(options);
+
+                // ConfigurationBinder writes alias getter values back when their keys are absent. Restore the raw
+                // values for absent keys so this section changes only the project key values it contains.
+                options.RestoreProjectKeyState(
+                    projectKeyState,
+                    restoreProjectToken: section["ProjectToken"] is null,
+                    restoreProjectApiKey: section["ProjectApiKey"] is null);
+            });
+        });
 }

--- a/src/PostHog/Config/PostHogOptions.cs
+++ b/src/PostHog/Config/PostHogOptions.cs
@@ -30,6 +30,24 @@ public sealed class PostHogOptions : IOptions<PostHogOptions>
 
     internal bool HasLegacyProjectApiKey => _projectApiKey is not null;
 
+    internal (string? ProjectToken, string? ProjectApiKey) GetProjectKeyState() =>
+        (_projectToken, _projectApiKey);
+
+    internal void RestoreProjectKeyState(
+        (string? ProjectToken, string? ProjectApiKey) state,
+        bool restoreProjectToken,
+        bool restoreProjectApiKey)
+    {
+        if (restoreProjectToken)
+        {
+            _projectToken = state.ProjectToken;
+        }
+        if (restoreProjectApiKey)
+        {
+            _projectApiKey = state.ProjectApiKey;
+        }
+    }
+
     internal void Normalize()
     {
         _projectToken = _projectToken.NullIfEmpty();

--- a/tests/UnitTests.AspNetCore/RegistrationTests.cs
+++ b/tests/UnitTests.AspNetCore/RegistrationTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PostHog;
 using PostHog.Config;
@@ -39,6 +40,26 @@ public class TheAddPostHogMethod
         Assert.Equal("fake-not-so-secret", options.ProjectToken);
         Assert.Equal(new Uri("https://test-host.com"), options.HostUrl);
         Assert.Equal(TimeSpan.FromSeconds(10), options.FeatureFlagPollInterval);
+    }
+
+    [Fact]
+    public void DoesNotLogLegacyWarningWhenOnlyProjectTokenIsConfigured()
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["PostHog:ProjectToken"] = "fake-not-so-secret",
+        });
+        using var logger = new FakeLoggerProvider();
+        builder.Services.AddSingleton<ILoggerFactory>(logger);
+
+        builder.AddPostHog();
+
+        using var provider = builder.Services.BuildServiceProvider();
+        Assert.NotNull(provider.GetRequiredService<IPostHogClient>());
+        Assert.DoesNotContain(
+            logger.GetAllEvents(minimumLevel: LogLevel.Warning),
+            log => log.Message?.Contains("ProjectApiKey is deprecated", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -81,12 +102,18 @@ public class TheAddPostHogMethod
         {
             ["PostHog:ProjectApiKey"] = "fake-not-so-secret",
         });
+        using var logger = new FakeLoggerProvider();
+        services.AddSingleton<ILoggerFactory>(logger);
 
         builder.AddPostHog();
 
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetRequiredService<IPostHogClient>());
         var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
         Assert.Equal("fake-not-so-secret", options.ProjectToken);
+        Assert.Contains(
+            logger.GetAllEvents(minimumLevel: LogLevel.Warning),
+            log => log.Message?.Contains("ProjectApiKey is deprecated", StringComparison.Ordinal) == true);
     }
 
     [Fact]

--- a/tests/UnitTests/Config/RegistrationTests.cs
+++ b/tests/UnitTests/Config/RegistrationTests.cs
@@ -156,6 +156,29 @@ public class TheAddPostHogMethod
     }
 
     [Fact]
+    public void LaterConfigurationSectionOverridesLegacyProjectApiKey()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["First:ProjectApiKey"] = "first-project-api-key",
+                ["Second:ProjectApiKey"] = "second-project-api-key",
+            })
+            .Build();
+        services.AddPostHog(options =>
+        {
+            options.UseConfigurationSection(configuration.GetSection("First"));
+            options.UseConfigurationSection(configuration.GetSection("Second"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<PostHogOptions>>().Value;
+
+        Assert.Equal("second-project-api-key", options.ProjectToken);
+    }
+
+    [Fact]
     public void ProjectApiKeyAliasMirrorsProjectToken()
     {
         var options = new PostHogOptions


### PR DESCRIPTION
## :bulb: Motivation and Context

Configuring only `ProjectToken` through `IConfiguration` caused `ConfigurationBinder` to write the alias getter value back through the absent `ProjectApiKey` property. That made the SDK incorrectly report that the deprecated option was used.

Fixes https://github.com/PostHog/posthog-dotnet/issues/264.

The configuration binding now snapshots the raw project-key state and restores backing values for keys absent from each configuration section. This prevents synthetic alias writes while preserving explicit legacy configuration, later-section precedence, options reload behavior, and the public alias getter contract.

The blocked workflow placeholder also contained invalid control characters that caused Semgrep's strict YAML parser to fail. Those corrupted characters were replaced with plain ASCII without changing the workflow behavior.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --framework net8.0 --no-restore` — 960 passed, 2 skipped
- `dotnet test tests/UnitTests.AspNetCore/UnitTests.AspNetCore.csproj --no-restore` — 50 passed
- `dotnet test tests/UnitTests/UnitTests.csproj --framework netcoreapp3.1 --filter FullyQualifiedName~RegistrationTests` — 9 passed
- `dotnet build src/PostHog/PostHog.csproj --no-restore` — all supported targets succeeded with no warnings
- `bin/fmt --check`
- Verified `.github/workflows/call-flags-project-board.yml` contains no control/replacement characters and parses successfully with PyYAML

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check README.md#publishing-releases -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and independently reviewed with Pi's reviewer subagent. A value-equality setter workaround was rejected because it suppressed warnings for explicit legacy usage; the final binding-scoped snapshot/restore approach preserves the public alias contract and configuration-source ordering. The session was retained locally and was not published.
