### PR TITLE
fix: avoid mutating caller property dictionaries

### DIFF
--- a/.changeset/calm-hedgehogs-copy.md
+++ b/.changeset/calm-hedgehogs-copy.md
@@ -1,5 +1,7 @@
 ---
 "PostHog": patch
+"PostHog.AspNetCore": patch
+"PostHog.AI": patch
 ---
 
 Avoid mutating caller-provided property dictionaries when capturing events, capturing exceptions, and using identify, group identify, page view, screen view, or survey capture helpers.

--- a/.changeset/calm-hedgehogs-copy.md
+++ b/.changeset/calm-hedgehogs-copy.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Avoid mutating caller-provided property dictionaries when capturing events, capturing exceptions, and using identify, group identify, page view, screen view, or survey capture helpers.

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -1,4 +1,4 @@
-# � SECURITY PLACEHOLDER - DO NOT USE THIS WORKFLOW NAME �
+# WARNING: SECURITY PLACEHOLDER - DO NOT USE THIS WORKFLOW NAME
 #
 # This workflow previously existed and was compromised. This placeholder file
 # exists to allow blocking this workflow name in GitHub's branch protection rules.
@@ -21,5 +21,5 @@ jobs:
     steps:
       - name: This workflow is blocked
         run: |
-          echo "� A workflow with this name was previously compromised and is now blocked."
+          echo "WARNING: A workflow with this name was previously compromised and is now blocked."
           exit 1

--- a/src/PostHog/Api/CapturedEvent.cs
+++ b/src/PostHog/Api/CapturedEvent.cs
@@ -27,7 +27,9 @@ public class CapturedEvent
         DistinctId = distinctId;
         Timestamp = timestamp;
 
-        Properties = properties ?? new Dictionary<string, object>();
+        Properties = properties is null
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object>(properties);
 
         // Every event has to have these properties.
         Properties[PostHogProperties.DistinctId] = distinctId; // See `get_distinct_id` in PostHog/posthog api/capture.py line 321

--- a/src/PostHog/Api/CapturedEvent.cs
+++ b/src/PostHog/Api/CapturedEvent.cs
@@ -27,9 +27,7 @@ public class CapturedEvent
         DistinctId = distinctId;
         Timestamp = timestamp;
 
-        Properties = properties is null
-            ? new Dictionary<string, object>()
-            : new Dictionary<string, object>(properties);
+        Properties = properties?.Copy() ?? new Dictionary<string, object>();
 
         // Every event has to have these properties.
         Properties[PostHogProperties.DistinctId] = distinctId; // See `get_distinct_id` in PostHog/posthog api/capture.py line 321

--- a/src/PostHog/Capture/CaptureExtensions.cs
+++ b/src/PostHog/Capture/CaptureExtensions.cs
@@ -263,9 +263,11 @@ public static class CaptureExtensions
         Dictionary<string, object> personPropertiesToSet,
         Dictionary<string, object> personPropertiesToSetOnce)
     {
-        properties ??= new Dictionary<string, object>();
-        properties["$set"] = personPropertiesToSet;
-        properties["$set_once"] = personPropertiesToSetOnce;
+        properties = properties is null
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object>(properties);
+        properties["$set"] = new Dictionary<string, object>(personPropertiesToSet);
+        properties["$set_once"] = new Dictionary<string, object>(personPropertiesToSetOnce);
 
         return NotNull(client).Capture(
             distinctId,
@@ -474,7 +476,9 @@ public static class CaptureExtensions
         IReadOnlyList<string> surveyResponses,
         Dictionary<string, object>? properties)
     {
-        properties ??= new Dictionary<string, object>();
+        properties = properties is null
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object>(properties);
         properties["$survey_id"] = surveyId;
 
         if (NotNull(surveyResponses).Count > 0)
@@ -542,7 +546,9 @@ public static class CaptureExtensions
         Dictionary<string, object>? properties,
         bool sendFeatureFlags = false)
     {
-        properties ??= new Dictionary<string, object>();
+        properties = properties is null
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object>(properties);
         properties[eventPropertyName] = eventPropertyValue;
         if (!sendFeatureFlags)
         {

--- a/src/PostHog/Capture/CaptureExtensions.cs
+++ b/src/PostHog/Capture/CaptureExtensions.cs
@@ -263,11 +263,9 @@ public static class CaptureExtensions
         Dictionary<string, object> personPropertiesToSet,
         Dictionary<string, object> personPropertiesToSetOnce)
     {
-        properties = properties is null
-            ? new Dictionary<string, object>()
-            : new Dictionary<string, object>(properties);
-        properties["$set"] = new Dictionary<string, object>(personPropertiesToSet);
-        properties["$set_once"] = new Dictionary<string, object>(personPropertiesToSetOnce);
+        properties = properties?.Copy() ?? new Dictionary<string, object>();
+        properties["$set"] = personPropertiesToSet.Copy();
+        properties["$set_once"] = personPropertiesToSetOnce.Copy();
 
         return NotNull(client).Capture(
             distinctId,
@@ -476,9 +474,7 @@ public static class CaptureExtensions
         IReadOnlyList<string> surveyResponses,
         Dictionary<string, object>? properties)
     {
-        properties = properties is null
-            ? new Dictionary<string, object>()
-            : new Dictionary<string, object>(properties);
+        properties = properties?.Copy() ?? new Dictionary<string, object>();
         properties["$survey_id"] = surveyId;
 
         if (NotNull(surveyResponses).Count > 0)
@@ -546,9 +542,7 @@ public static class CaptureExtensions
         Dictionary<string, object>? properties,
         bool sendFeatureFlags = false)
     {
-        properties = properties is null
-            ? new Dictionary<string, object>()
-            : new Dictionary<string, object>(properties);
+        properties = properties?.Copy() ?? new Dictionary<string, object>();
         properties[eventPropertyName] = eventPropertyValue;
         if (!sendFeatureFlags)
         {

--- a/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
+++ b/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
@@ -141,7 +141,9 @@ public static class GroupIdentifyAsyncExtensions
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
     {
-        properties ??= new Dictionary<string, object>();
+        properties = properties is null
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object>(properties);
         properties["name"] = name;
 
         return distinctId is null

--- a/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
+++ b/src/PostHog/Extensions/GroupIdentifyAsyncExtensions.cs
@@ -1,5 +1,6 @@
 using PostHog.Api;
 using PostHog.Json;
+using PostHog.Library;
 using static PostHog.Library.Ensure;
 
 namespace PostHog; // Intentionally put in the root namespace.
@@ -141,9 +142,7 @@ public static class GroupIdentifyAsyncExtensions
         Dictionary<string, object>? properties,
         CancellationToken cancellationToken)
     {
-        properties = properties is null
-            ? new Dictionary<string, object>()
-            : new Dictionary<string, object>(properties);
+        properties = properties?.Copy() ?? new Dictionary<string, object>();
         properties["name"] = name;
 
         return distinctId is null

--- a/src/PostHog/Extensions/IdentifyPersonAsyncExtensions.cs
+++ b/src/PostHog/Extensions/IdentifyPersonAsyncExtensions.cs
@@ -1,4 +1,5 @@
 using PostHog.Api;
+using PostHog.Library;
 using static PostHog.Library.Ensure;
 
 namespace PostHog; // Intentionally put in the root namespace.
@@ -194,9 +195,7 @@ public static class IdentifyPersonAsyncExtensions
     {
         if (email is not null || name is not null)
         {
-            var enrichedProperties = personPropertiesToSet is null
-                ? new Dictionary<string, object>()
-                : new Dictionary<string, object>(personPropertiesToSet);
+            var enrichedProperties = personPropertiesToSet?.Copy() ?? new Dictionary<string, object>();
 
             if (email is not null)
             {

--- a/src/PostHog/Extensions/IdentifyPersonAsyncExtensions.cs
+++ b/src/PostHog/Extensions/IdentifyPersonAsyncExtensions.cs
@@ -192,16 +192,23 @@ public static class IdentifyPersonAsyncExtensions
         Dictionary<string, object>? personPropertiesToSetOnce,
         CancellationToken cancellationToken)
     {
-        if (email is not null)
+        if (email is not null || name is not null)
         {
-            personPropertiesToSet ??= new Dictionary<string, object>();
-            personPropertiesToSet["email"] = email;
-        }
+            var enrichedProperties = personPropertiesToSet is null
+                ? new Dictionary<string, object>()
+                : new Dictionary<string, object>(personPropertiesToSet);
 
-        if (name is not null)
-        {
-            personPropertiesToSet ??= new Dictionary<string, object>();
-            personPropertiesToSet["name"] = name;
+            if (email is not null)
+            {
+                enrichedProperties["email"] = email;
+            }
+
+            if (name is not null)
+            {
+                enrichedProperties["name"] = name;
+            }
+
+            personPropertiesToSet = enrichedProperties;
         }
 
         return await NotNull(client).IdentifyAsync(distinctId,

--- a/src/PostHog/Library/CollectionExtensions.cs
+++ b/src/PostHog/Library/CollectionExtensions.cs
@@ -38,6 +38,17 @@ internal static class CollectionExtensions
         => new ReadOnlyDictionary<TKey, TValue>(enumerable.ToDictionary(keySelector, valueSelector));
 
     /// <summary>
+    /// Creates a shallow copy of a dictionary.
+    /// </summary>
+    /// <param name="dictionary">The dictionary to copy.</param>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <returns>A new dictionary containing the same keys and values.</returns>
+    public static Dictionary<TKey, TValue> Copy<TKey, TValue>(
+        this IReadOnlyDictionary<TKey, TValue> dictionary) where TKey : notnull
+        => new(dictionary);
+
+    /// <summary>
     /// Similar to Python's hash merging, this method merges the contents of one dictionary into another.
     /// The values of the other dictionary will overwrite the values of the original dictionary.
     /// </summary>

--- a/src/PostHog/Library/CollectionExtensions.cs
+++ b/src/PostHog/Library/CollectionExtensions.cs
@@ -46,7 +46,7 @@ internal static class CollectionExtensions
     /// <returns>A new dictionary containing the same keys and values.</returns>
     public static Dictionary<TKey, TValue> Copy<TKey, TValue>(
         this IReadOnlyDictionary<TKey, TValue> dictionary) where TKey : notnull
-        => new(dictionary);
+        => dictionary.ToDictionary(pair => pair.Key, pair => pair.Value);
 
     /// <summary>
     /// Similar to Python's hash merging, this method merges the contents of one dictionary into another.

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -310,6 +310,10 @@ public sealed class PostHogClient : IPostHogClient
             return false;
         }
 
+        properties = properties is null
+            ? null
+            : new Dictionary<string, object>(properties);
+
         // If custom timestamp provided, add it to properties
         if (timestamp.HasValue)
         {
@@ -513,7 +517,9 @@ public sealed class PostHogClient : IPostHogClient
         try
         {
             var host = _options.Value.HostUrl.ToString().TrimEnd('/').Replace(".i.", ".", StringComparison.Ordinal);
-            properties ??= [];
+            properties = properties is null
+                ? []
+                : new Dictionary<string, object>(properties);
             var identity = PostHogContextHelper.ResolveIdentity(distinctId, PostHogContext.Current);
             if (identity.IsPersonless && !properties.ContainsKey(PostHogProperties.ProcessPersonProfile))
             {

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -310,9 +310,7 @@ public sealed class PostHogClient : IPostHogClient
             return false;
         }
 
-        properties = properties is null
-            ? null
-            : new Dictionary<string, object>(properties);
+        properties = properties?.Copy();
 
         // If custom timestamp provided, add it to properties
         if (timestamp.HasValue)
@@ -517,9 +515,7 @@ public sealed class PostHogClient : IPostHogClient
         try
         {
             var host = _options.Value.HostUrl.ToString().TrimEnd('/').Replace(".i.", ".", StringComparison.Ordinal);
-            properties = properties is null
-                ? []
-                : new Dictionary<string, object>(properties);
+            properties = properties?.Copy() ?? [];
             var identity = PostHogContextHelper.ResolveIdentity(distinctId, PostHogContext.Current);
             if (identity.IsPersonless && !properties.ContainsKey(PostHogProperties.ProcessPersonProfile))
             {

--- a/tests/UnitTests/Api/CapturedEventTests.cs
+++ b/tests/UnitTests/Api/CapturedEventTests.cs
@@ -71,6 +71,10 @@ public class TheConstructor
         };
         var capturedEvent = new CapturedEvent("test-event", "user-1", properties, DateTimeOffset.UtcNow);
 
+        Assert.NotSame(properties, capturedEvent.Properties);
+        Assert.Equal(2, properties.Count);
+        Assert.Equal("custom_value", properties["custom_prop"]);
+        Assert.Equal(42, properties["number_prop"]);
         Assert.Equal("custom_value", capturedEvent.Properties["custom_prop"]);
         Assert.Equal(42, capturedEvent.Properties["number_prop"]);
     }

--- a/tests/UnitTests/CaptureExtensionsTests.cs
+++ b/tests/UnitTests/CaptureExtensionsTests.cs
@@ -1,0 +1,97 @@
+using NSubstitute;
+using PostHog;
+using PostHog.Features;
+
+namespace CaptureExtensionsTests;
+
+public class TheCaptureExtensions
+{
+    [Fact]
+    public void CaptureWithPersonPropertiesDoesNotMutateProvidedProperties()
+    {
+        var client = Substitute.For<IPostHogClient>();
+        var properties = new Dictionary<string, object> { ["source"] = "test" };
+        var personPropertiesToSet = new Dictionary<string, object> { ["name"] = "Max" };
+        var personPropertiesToSetOnce = new Dictionary<string, object> { ["initial_url"] = "/blog" };
+
+        client.Capture(
+            "distinct-id",
+            "event",
+            properties,
+            personPropertiesToSet,
+            personPropertiesToSetOnce);
+
+        Assert.Equal(new Dictionary<string, object> { ["source"] = "test" }, properties);
+        client.Received(1).Capture(
+            "distinct-id",
+            "event",
+            Arg.Is<Dictionary<string, object>>(captured => HasCopiedPersonProperties(
+                captured,
+                properties,
+                personPropertiesToSet,
+                personPropertiesToSetOnce)),
+            groups: null,
+            flags: (FeatureFlagEvaluations?)null,
+            timestamp: null);
+    }
+
+    [Fact]
+    public void CapturePageViewDoesNotMutateProvidedProperties()
+    {
+        var client = Substitute.For<IPostHogClient>();
+        var properties = new Dictionary<string, object> { ["source"] = "test" };
+
+        client.CapturePageView("distinct-id", "/pricing", properties);
+
+        Assert.Equal(new Dictionary<string, object> { ["source"] = "test" }, properties);
+        client.Received(1).Capture(
+            "distinct-id",
+            "$pageview",
+            Arg.Is<Dictionary<string, object>>(captured =>
+                !ReferenceEquals(captured, properties)
+                && (string)captured["source"] == "test"
+                && (string)captured["$current_url"] == "/pricing"),
+            groups: null,
+            flags: (FeatureFlagEvaluations?)null,
+            timestamp: null);
+    }
+
+    [Fact]
+    public void CaptureSurveyResponsesDoesNotMutateProvidedProperties()
+    {
+        var client = Substitute.For<IPostHogClient>();
+        var properties = new Dictionary<string, object> { ["source"] = "test" };
+
+        client.CaptureSurveyResponses(
+            "distinct-id",
+            "survey-id",
+            ["first", "second"],
+            properties);
+
+        Assert.Equal(new Dictionary<string, object> { ["source"] = "test" }, properties);
+        client.Received(1).Capture(
+            "distinct-id",
+            "survey sent",
+            Arg.Is<Dictionary<string, object>>(captured =>
+                !ReferenceEquals(captured, properties)
+                && (string)captured["$survey_id"] == "survey-id"
+                && (string)captured["$survey_response"] == "first"
+                && (string)captured["survey_response_1"] == "second"),
+            groups: null,
+            flags: (FeatureFlagEvaluations?)null,
+            timestamp: null);
+    }
+
+    static bool HasCopiedPersonProperties(
+        Dictionary<string, object> captured,
+        Dictionary<string, object> properties,
+        Dictionary<string, object> personPropertiesToSet,
+        Dictionary<string, object> personPropertiesToSetOnce)
+        => !ReferenceEquals(captured, properties)
+           && captured["$set"] is Dictionary<string, object> set
+           && !ReferenceEquals(set, personPropertiesToSet)
+           && (string)set["name"] == "Max"
+           && captured["$set_once"] is Dictionary<string, object> setOnce
+           && !ReferenceEquals(setOnce, personPropertiesToSetOnce)
+           && (string)setOnce["initial_url"] == "/blog";
+}

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -127,16 +127,20 @@ public class TheIdentifyPersonAsyncMethod
         container.FakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 21, 19, 08, 23, TimeSpan.Zero));
         var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
         var client = container.Activate<PostHogClient>();
+        var personPropertiesToSet = new Dictionary<string, object> { ["age"] = 36 };
+        var personPropertiesToSetOnce = new Dictionary<string, object> { ["join_date"] = "2024-01-21" };
 
         var result = await client.IdentifyAsync(
             distinctId: "some-distinct-id",
             email: "wildling-lover@example.com",
             name: "Jon Snow",
-            personPropertiesToSet: new() { ["age"] = 36 },
-            personPropertiesToSetOnce: new() { ["join_date"] = "2024-01-21" },
+            personPropertiesToSet,
+            personPropertiesToSetOnce,
             CancellationToken.None);
 
         Assert.Equal(1, result.Status);
+        Assert.Equal(new Dictionary<string, object> { ["age"] = 36 }, personPropertiesToSet);
+        Assert.Equal(new Dictionary<string, object> { ["join_date"] = "2024-01-21" }, personPropertiesToSetOnce);
         var received = requestHandler.GetReceivedRequestBody(indented: true);
         Assert.Equal($$"""
                        {
@@ -245,7 +249,7 @@ public class TheIdentifyGroupAsyncMethod
     }
 
     [Fact]
-    public async Task CancellationTokenOverloadOverwritesNameProperty()
+    public async Task CancellationTokenOverloadDoesNotOverwriteInputNameProperty()
     {
         var container = new TestContainer();
         var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
@@ -264,7 +268,7 @@ public class TheIdentifyGroupAsyncMethod
             CancellationToken.None);
 
         Assert.Equal(1, result.Status);
-        Assert.Equal("PostHog", properties["name"]);
+        Assert.Equal("Old Name", properties["name"]);
         using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
         var root = document.RootElement;
         var groupSet = root.GetProperty("properties").GetProperty("$group_set");
@@ -274,7 +278,7 @@ public class TheIdentifyGroupAsyncMethod
     }
 
     [Fact]
-    public async Task DistinctIdCancellationTokenOverloadOverwritesNameProperty()
+    public async Task DistinctIdCancellationTokenOverloadDoesNotOverwriteInputNameProperty()
     {
         var container = new TestContainer();
         var requestHandler = container.FakeHttpMessageHandler.AddCaptureResponse();
@@ -294,7 +298,7 @@ public class TheIdentifyGroupAsyncMethod
             CancellationToken.None);
 
         Assert.Equal(1, result.Status);
-        Assert.Equal("PostHog", properties["name"]);
+        Assert.Equal("Old Name", properties["name"]);
         using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
         var root = document.RootElement;
         var groupSet = root.GetProperty("properties").GetProperty("$group_set");
@@ -416,6 +420,34 @@ public class TheCapturePageViewMethod
 public class TheCaptureMethod
 {
     [Fact]
+    public async Task DoesNotMutateOrRetainProvidedProperties()
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SuperProperties["super"] = "property";
+        }));
+        var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+        var timestamp = new DateTimeOffset(2024, 1, 21, 19, 8, 23, TimeSpan.Zero);
+        var properties = new Dictionary<string, object> { ["source"] = "before" };
+        var groups = new GroupCollection { new Group("company", "acme") };
+
+        Assert.True(client.Capture("test-user", "test-event", properties, groups, flags: null, timestamp));
+        Assert.Equal(new Dictionary<string, object> { ["source"] = "before" }, properties);
+
+        properties["source"] = "after";
+        await client.FlushAsync();
+
+        using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
+        var capturedProperties = document.RootElement.GetProperty("batch")[0].GetProperty("properties");
+        Assert.Equal("before", capturedProperties.GetProperty("source").GetString());
+        Assert.Equal("property", capturedProperties.GetProperty("super").GetString());
+        Assert.Equal("acme", capturedProperties.GetProperty("$groups").GetProperty("company").GetString());
+        Assert.True(capturedProperties.GetProperty("$is_server").GetBoolean());
+        Assert.Equal(timestamp, capturedProperties.GetProperty("timestamp").GetDateTimeOffset());
+    }
+
+    [Fact]
     public async Task BeforeSendCanModifyFullyEnrichedEventBeforeUpload()
     {
         var sawFullyEnrichedEvent = false;
@@ -436,12 +468,12 @@ public class TheCaptureMethod
         }));
         var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
+        var inputProperties = new Dictionary<string, object> { ["secret"] = "remove-me" };
 
-        client.Capture(
-            "test-user",
-            "before-send-event",
-            new Dictionary<string, object> { ["secret"] = "remove-me" });
+        client.Capture("test-user", "before-send-event", inputProperties);
         await client.FlushAsync();
+
+        Assert.Equal("remove-me", inputProperties["secret"]);
 
         using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
         var properties = document.RootElement
@@ -1183,6 +1215,27 @@ public class TheCaptureMethod
 
 public class TheCaptureExceptionMethod
 {
+    [Fact]
+    public async Task DoesNotMutateProvidedProperties()
+    {
+        var (_, requestHandler, client) = CreateClient();
+        var properties = new Dictionary<string, object> { ["source"] = "test" };
+
+        Assert.True(client.CaptureException(
+            new InvalidOperationException("boom"),
+            "some-distinct-id",
+            properties,
+            groups: null,
+            flags: null,
+            timestamp: DateTimeOffset.UtcNow));
+        Assert.Equal(new Dictionary<string, object> { ["source"] = "test" }, properties);
+
+        await client.FlushAsync();
+        var (_, _, capturedProperties) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: false));
+        Assert.Equal("test", capturedProperties.GetProperty("source").GetString());
+        Assert.Equal("System.InvalidOperationException", capturedProperties.GetProperty("$exception_type").GetString());
+    }
+
     [Fact]
     public async Task CaptureExceptionWithDivideByZeroException() // based on PostHog/posthog-python test_exception_capture
     {


### PR DESCRIPTION
## :bulb: Motivation and Context

`Capture` and several convenience APIs enriched caller-provided property dictionaries in place. Besides the surprising side effect, the batch queue retained the same dictionary, so caller changes after `Capture` could alter the eventual event payload.

The affected core behavior is consumed by `PostHog.AspNetCore` and `PostHog.AI`, so the changeset includes patch releases for all three packages.

Fixes #266.

## :green_heart: How did you test it?

- `dotnet test -f net8.0 --no-restore --verbosity quiet`
  - 965 unit tests passed, 2 skipped
  - 50 ASP.NET Core tests passed
  - 19 AI tests passed
- `dotnet pack src/PostHog/PostHog.csproj --configuration Release --no-restore --nologo /p:GeneratePackageOnBuild=false`
  - Built `netstandard2.0`, `netstandard2.1`, and `net8.0`
- `bin/fmt --check`
- `pnpm changeset status`
- Bundle-isolated autoreview after the final compatibility fix: no actionable or blocking findings

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. Read-only scout and reviewer subagents audited public APIs that accept property dictionaries, and the bundle-isolated autoreview helper performed the final review. The implementation uses a shared helper for shallow copies at mutation and ownership boundaries; arbitrary nested mutable values are intentionally not deep-cloned.
