### PR TITLE
feat: support starts_with and ends_with operators in local evaluation

### DIFF
--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -1,0 +1,5 @@
+---
+"PostHog": minor
+---
+
+Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fail local evaluation.

--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -3,3 +3,5 @@
 ---
 
 Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fail local evaluation.
+
+Property filter operators this SDK version doesn't recognize now deserialize as `ComparisonOperator.Unknown` instead of failing the entire local evaluation response, so only the affected flag falls back to remote evaluation.

--- a/src/PostHog/Api/ComparisonOperator.cs
+++ b/src/PostHog/Api/ComparisonOperator.cs
@@ -6,7 +6,7 @@ namespace PostHog.Api;
 /// <summary>
 /// An enumeration representing the comparison types that can be used in a filter.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumMemberNameJsonConverter<ComparisonOperator>))]
+[JsonConverter(typeof(ComparisonOperatorJsonConverter))]
 public enum ComparisonOperator
 {
     /// <summary>
@@ -181,5 +181,11 @@ public enum ComparisonOperator
     /// Matches if the value does not end with the filter value, ignoring case differences.
     /// </summary>
     [JsonStringEnumMemberName("not_ends_with")]
-    NotEndsWith
+    NotEndsWith,
+
+    /// <summary>
+    /// An operator this version of the SDK doesn't recognize. Flags using such an operator can't be evaluated
+    /// locally and fall back to remote evaluation.
+    /// </summary>
+    Unknown
 }

--- a/src/PostHog/Api/ComparisonOperator.cs
+++ b/src/PostHog/Api/ComparisonOperator.cs
@@ -157,5 +157,29 @@ public enum ComparisonOperator
     /// Matches if the version matches the wildcard pattern (e.g., "1.2.*" means >=1.2.0 and &lt;1.3.0).
     /// </summary>
     [JsonStringEnumMemberName("semver_wildcard")]
-    SemverWildcard
+    SemverWildcard,
+
+    /// <summary>
+    /// Matches if the value starts with the filter value, ignoring case differences.
+    /// </summary>
+    [JsonStringEnumMemberName("starts_with")]
+    StartsWith,
+
+    /// <summary>
+    /// Matches if the value does not start with the filter value, ignoring case differences.
+    /// </summary>
+    [JsonStringEnumMemberName("not_starts_with")]
+    NotStartsWith,
+
+    /// <summary>
+    /// Matches if the value ends with the filter value, ignoring case differences.
+    /// </summary>
+    [JsonStringEnumMemberName("ends_with")]
+    EndsWith,
+
+    /// <summary>
+    /// Matches if the value does not end with the filter value, ignoring case differences.
+    /// </summary>
+    [JsonStringEnumMemberName("not_ends_with")]
+    NotEndsWith
 }

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -30,6 +30,8 @@ internal sealed class LocalEvaluator
     readonly ReadOnlyDictionary<long, FilterSet> _cohortFilters;
     readonly ReadOnlyDictionary<long, string> _groupTypeMapping;
 
+    const double LongScale = 0xFFFFFFFFFFFFFFF;
+
     /// <summary>
     /// Constructs a <see cref="LocalEvaluator"/> with the specified flags.
     /// </summary>
@@ -671,6 +673,10 @@ internal sealed class LocalEvaluator
             ComparisonOperator.LessThanOrEquals => value >= overrideValue,
             ComparisonOperator.ContainsIgnoreCase => value.IsContainedBy(overrideValue, StringComparison.OrdinalIgnoreCase),
             ComparisonOperator.DoesNotContainIgnoreCase => !value.IsContainedBy(overrideValue, StringComparison.OrdinalIgnoreCase),
+            ComparisonOperator.StartsWith => value.IsPrefixOf(overrideValue, StringComparison.OrdinalIgnoreCase),
+            ComparisonOperator.NotStartsWith => !value.IsPrefixOf(overrideValue, StringComparison.OrdinalIgnoreCase),
+            ComparisonOperator.EndsWith => value.IsSuffixOf(overrideValue, StringComparison.OrdinalIgnoreCase),
+            ComparisonOperator.NotEndsWith => !value.IsSuffixOf(overrideValue, StringComparison.OrdinalIgnoreCase),
             ComparisonOperator.Regex => value.IsRegexMatch(overrideValue),
             ComparisonOperator.NotRegex => !value.IsRegexMatch(overrideValue),
             ComparisonOperator.IsDateBefore => value.IsDateBefore(overrideValue, _timeProvider.GetUtcNow()),
@@ -876,8 +882,6 @@ internal sealed class LocalEvaluator
 
         return hashVal / LongScale;
     }
-
-    const double LongScale = 0xFFFFFFFFFFFFFFF;
 }
 
 internal static partial class LocalEvaluatorLoggerExtensions

--- a/src/PostHog/Json/ComparisonOperatorJsonConverter.cs
+++ b/src/PostHog/Json/ComparisonOperatorJsonConverter.cs
@@ -1,0 +1,16 @@
+using PostHog.Api;
+
+namespace PostHog.Json;
+
+/// <summary>
+/// Converts <see cref="ComparisonOperator"/> values to and from their JSON wire names. Operator names this
+/// version of the SDK doesn't recognize map to <see cref="ComparisonOperator.Unknown"/> so that a new
+/// server-side operator makes only the affected flag inconclusive instead of failing deserialization of the
+/// entire local evaluation response.
+/// </summary>
+internal sealed class ComparisonOperatorJsonConverter : JsonStringEnumMemberNameJsonConverter<ComparisonOperator>
+{
+    public ComparisonOperatorJsonConverter() : base(ComparisonOperator.Unknown)
+    {
+    }
+}

--- a/src/PostHog/Json/JsonStringEnumMemberNameJsonConverter.cs
+++ b/src/PostHog/Json/JsonStringEnumMemberNameJsonConverter.cs
@@ -14,6 +14,22 @@ internal class JsonStringEnumMemberNameJsonConverter<TEnum> : JsonConverter<TEnu
     private static readonly Dictionary<string, TEnum> StringToEnum = CreateStringToEnumMapping();
     private static readonly Dictionary<TEnum, string> EnumToString = CreateEnumToStringMapping();
 
+    private readonly TEnum? _fallbackValue;
+
+    public JsonStringEnumMemberNameJsonConverter()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a converter that maps unrecognized strings to <paramref name="fallbackValue"/>
+    /// instead of throwing a <see cref="JsonException"/>.
+    /// </summary>
+    /// <param name="fallbackValue">The value to return for strings that don't map to an enum member.</param>
+    protected JsonStringEnumMemberNameJsonConverter(TEnum fallbackValue)
+    {
+        _fallbackValue = fallbackValue;
+    }
+
     private static Dictionary<string, TEnum> CreateStringToEnumMapping()
     {
         var mapping = new Dictionary<string, TEnum>();
@@ -60,6 +76,10 @@ internal class JsonStringEnumMemberNameJsonConverter<TEnum> : JsonConverter<TEnu
             if (stringValue != null && StringToEnum.TryGetValue(stringValue, out var enumValue))
             {
                 return enumValue;
+            }
+            if (_fallbackValue is { } fallbackValue)
+            {
+                return fallbackValue;
             }
             throw new JsonException($"Unable to convert \"{stringValue}\" to {typeof(TEnum).Name}.");
         }

--- a/src/PostHog/Json/PropertyFilterValue.cs
+++ b/src/PostHog/Json/PropertyFilterValue.cs
@@ -140,6 +140,28 @@ public class PropertyFilterValue
         && comparandString.Contains(StringValue, stringComparison);
 
     /// <summary>
+    /// Returns a value indicating whether this instance is a prefix of the specified <paramref name="other"/> instance.
+    /// </summary>
+    /// <param name="other">The other value to compare to this one.</param>
+    /// <param name="stringComparison">The type of comparison if these are strings.</param>
+    /// <returns><c>true</c> if the other value starts with this instance.</returns>
+    public bool IsPrefixOf(object? other, StringComparison stringComparison) =>
+        other?.ToString() is { } comparandString
+        && StringValue is not null
+        && comparandString.StartsWith(StringValue, stringComparison);
+
+    /// <summary>
+    /// Returns a value indicating whether this instance is a suffix of the specified <paramref name="other"/> instance.
+    /// </summary>
+    /// <param name="other">The other value to compare to this one.</param>
+    /// <param name="stringComparison">The type of comparison if these are strings.</param>
+    /// <returns><c>true</c> if the other value ends with this instance.</returns>
+    public bool IsSuffixOf(object? other, StringComparison stringComparison) =>
+        other?.ToString() is { } comparandString
+        && StringValue is not null
+        && comparandString.EndsWith(StringValue, stringComparison);
+
+    /// <summary>
     /// Determines whether the specified <paramref name="overrideValue"/> is an "exact" match for this instance.
     /// If this instance is an array, then it's checking to see if the value is in the array.
     /// </summary>

--- a/src/PostHog/PublicAPI.Unshipped.txt
+++ b/src/PostHog/PublicAPI.Unshipped.txt
@@ -1,10 +1,16 @@
 #nullable enable
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.get -> bool
 PostHog.AllFeatureFlagsOptions.DisableGeoIp.init -> void
+PostHog.Api.ComparisonOperator.EndsWith = 27 -> PostHog.Api.ComparisonOperator
+PostHog.Api.ComparisonOperator.NotEndsWith = 28 -> PostHog.Api.ComparisonOperator
+PostHog.Api.ComparisonOperator.NotStartsWith = 26 -> PostHog.Api.ComparisonOperator
+PostHog.Api.ComparisonOperator.StartsWith = 25 -> PostHog.Api.ComparisonOperator
 PostHog.Api.FlagsResult.MinimalFlagCalledEvents.get -> bool
 PostHog.Api.FlagsResult.MinimalFlagCalledEvents.init -> void
 PostHog.Features.FeatureFlag.HasExperiment.get -> bool?
 PostHog.Features.FeatureFlag.HasExperiment.init -> void
+PostHog.Json.PropertyFilterValue.IsPrefixOf(object? other, System.StringComparison stringComparison) -> bool
+PostHog.Json.PropertyFilterValue.IsSuffixOf(object? other, System.StringComparison stringComparison) -> bool
 PostHog.PostHogOptions.BeforeSend.get -> System.Func<PostHog.Api.CapturedEvent!, PostHog.Api.CapturedEvent?>?
 PostHog.PostHogOptions.BeforeSend.set -> void
 PostHog.PostHogOptions.FeatureFlagRequestMaxRetries.get -> int

--- a/src/PostHog/PublicAPI.Unshipped.txt
+++ b/src/PostHog/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ PostHog.Api.ComparisonOperator.EndsWith = 27 -> PostHog.Api.ComparisonOperator
 PostHog.Api.ComparisonOperator.NotEndsWith = 28 -> PostHog.Api.ComparisonOperator
 PostHog.Api.ComparisonOperator.NotStartsWith = 26 -> PostHog.Api.ComparisonOperator
 PostHog.Api.ComparisonOperator.StartsWith = 25 -> PostHog.Api.ComparisonOperator
+PostHog.Api.ComparisonOperator.Unknown = 29 -> PostHog.Api.ComparisonOperator
 PostHog.Api.FlagsResult.MinimalFlagCalledEvents.get -> bool
 PostHog.Api.FlagsResult.MinimalFlagCalledEvents.init -> void
 PostHog.Features.FeatureFlag.HasExperiment.get -> bool?

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -837,8 +837,10 @@ public class TheEvaluateFeatureFlagMethod
         });
     }
 
-    [Fact]
-    public void ThrowsInconclusiveMatchExceptionWhenUnknownOperator()
+    [Theory]
+    [InlineData((ComparisonOperator)999)]
+    [InlineData(ComparisonOperator.Unknown)]
+    public void ThrowsInconclusiveMatchExceptionWhenUnknownOperator(ComparisonOperator comparison)
     {
         var properties = new Dictionary<string, object?>
         {
@@ -852,7 +854,7 @@ public class TheEvaluateFeatureFlagMethod
                     Type = FilterType.Person,
                     Key = "join_date",
                     Value = new PropertyFilterValue("2025-01-01"),
-                    Operator = (ComparisonOperator)999
+                    Operator = comparison
                 }
             ]
         );

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -401,6 +401,59 @@ public class TheEvaluateFeatureFlagMethod
     }
 
     [Theory]
+    [InlineData("value", ComparisonOperator.StartsWith, "\"Val\"", true)]
+    [InlineData("VALUE", ComparisonOperator.StartsWith, "\"Val\"", true)]
+    [InlineData("vaLue4", ComparisonOperator.StartsWith, "\"Val\"", true)]
+    [InlineData("prevalue", ComparisonOperator.StartsWith, "\"Val\"", false)]
+    [InlineData("Alakazam", ComparisonOperator.StartsWith, "\"Val\"", false)]
+    [InlineData(323, ComparisonOperator.StartsWith, "\"3\"", true)]
+    [InlineData(123, ComparisonOperator.StartsWith, "\"3\"", false)]
+    [InlineData("value", ComparisonOperator.NotStartsWith, "\"Val\"", false)]
+    [InlineData("VALUE", ComparisonOperator.NotStartsWith, "\"Val\"", false)]
+    [InlineData("prevalue", ComparisonOperator.NotStartsWith, "\"Val\"", true)]
+    [InlineData("Alakazam", ComparisonOperator.NotStartsWith, "\"Val\"", true)]
+    [InlineData("value", ComparisonOperator.EndsWith, "\"lUe\"", true)]
+    [InlineData("VALUE", ComparisonOperator.EndsWith, "\"lUe\"", true)]
+    [InlineData("343tfvalue", ComparisonOperator.EndsWith, "\"lUe\"", true)]
+    [InlineData("value2", ComparisonOperator.EndsWith, "\"lUe\"", false)]
+    [InlineData("Alakazam", ComparisonOperator.EndsWith, "\"lUe\"", false)]
+    [InlineData(323, ComparisonOperator.EndsWith, "\"3\"", true)]
+    [InlineData(13, ComparisonOperator.EndsWith, "\"3\"", true)]
+    [InlineData(321, ComparisonOperator.EndsWith, "\"3\"", false)]
+    [InlineData("value", ComparisonOperator.NotEndsWith, "\"lUe\"", false)]
+    [InlineData("VALUE", ComparisonOperator.NotEndsWith, "\"lUe\"", false)]
+    [InlineData("value2", ComparisonOperator.NotEndsWith, "\"lUe\"", true)]
+    [InlineData("Alakazam", ComparisonOperator.NotEndsWith, "\"lUe\"", true)]
+    public void HandlesStartsWithAndEndsWithComparisons(object overrideValue, ComparisonOperator comparison, string filterValueJson, bool expected)
+    {
+        var flags = CreateFlags(
+            key: "bio",
+            properties:
+            [
+                new PropertyFilter
+                {
+                    Type = FilterType.Person,
+                    Key = "bio",
+                    Value = PropertyFilterValue.Create(JsonDocument.Parse(filterValueJson).RootElement)!,
+                    Operator = comparison
+                }
+            ]
+        );
+        var properties = new Dictionary<string, object?>
+        {
+            ["bio"] = overrideValue
+        };
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "bio",
+            distinctId: "distinct-id",
+            personProperties: properties);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
     [InlineData(22, ComparisonOperator.GreaterThan, "\"21\"", true)]
     [InlineData(22, ComparisonOperator.GreaterThanOrEquals, "\"21\"", true)]
     [InlineData("22", ComparisonOperator.GreaterThan, "\"21\"", true)]

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -454,6 +454,74 @@ public class TheEvaluateFeatureFlagMethod
     }
 
     [Theory]
+    [InlineData(ComparisonOperator.StartsWith)]
+    [InlineData(ComparisonOperator.NotStartsWith)]
+    [InlineData(ComparisonOperator.EndsWith)]
+    [InlineData(ComparisonOperator.NotEndsWith)]
+    public void ReturnsFalseWhenPropertyValueIsNullForStartsWithAndEndsWithComparisons(ComparisonOperator comparison)
+    {
+        var flags = CreateFlags(
+            key: "bio",
+            properties:
+            [
+                new PropertyFilter
+                {
+                    Type = FilterType.Person,
+                    Key = "bio",
+                    Value = new PropertyFilterValue("Val"),
+                    Operator = comparison
+                }
+            ]
+        );
+        var properties = new Dictionary<string, object?>
+        {
+            ["bio"] = null
+        };
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(
+            key: "bio",
+            distinctId: "distinct-id",
+            personProperties: properties);
+
+        // A null property value fails the comparison for both the positive and not_ variants.
+        Assert.False(result.Value);
+    }
+
+    [Theory]
+    [InlineData(ComparisonOperator.StartsWith)]
+    [InlineData(ComparisonOperator.NotStartsWith)]
+    [InlineData(ComparisonOperator.EndsWith)]
+    [InlineData(ComparisonOperator.NotEndsWith)]
+    public void ThrowsInconclusiveMatchExceptionWhenPropertyKeyMissingForStartsWithAndEndsWithComparisons(ComparisonOperator comparison)
+    {
+        var flags = CreateFlags(
+            key: "bio",
+            properties:
+            [
+                new PropertyFilter
+                {
+                    Type = FilterType.Person,
+                    Key = "bio",
+                    Value = new PropertyFilterValue("Val"),
+                    Operator = comparison
+                }
+            ]
+        );
+        var properties = new Dictionary<string, object?>
+        {
+            ["other_property"] = "value"
+        };
+        var localEvaluator = new LocalEvaluator(flags);
+
+        Assert.Throws<InconclusiveMatchException>(() =>
+            localEvaluator.EvaluateFeatureFlag(
+                key: "bio",
+                distinctId: "distinct-id",
+                personProperties: properties));
+    }
+
+    [Theory]
     [InlineData(22, ComparisonOperator.GreaterThan, "\"21\"", true)]
     [InlineData(22, ComparisonOperator.GreaterThanOrEquals, "\"21\"", true)]
     [InlineData("22", ComparisonOperator.GreaterThan, "\"21\"", true)]

--- a/tests/UnitTests/Json/FilterSerializationTests.cs
+++ b/tests/UnitTests/Json/FilterSerializationTests.cs
@@ -61,6 +61,44 @@ public class TheDeserializeAsyncMethod
             propertyFilter);
     }
 
+    [Theory]
+    [InlineData("starts_with", ComparisonOperator.StartsWith)]
+    [InlineData("not_starts_with", ComparisonOperator.NotStartsWith)]
+    [InlineData("ends_with", ComparisonOperator.EndsWith)]
+    [InlineData("not_ends_with", ComparisonOperator.NotEndsWith)]
+    public async Task CanDeserializeStartsWithAndEndsWithOperators(string wireName, ComparisonOperator expected)
+    {
+        var json = $$"""
+                   {
+                       "key": "email",
+                       "type": "person",
+                       "value": "posthog",
+                       "operator": "{{wireName}}"
+                   }
+                   """;
+        var result = await JsonSerializerHelper.DeserializeFromCamelCaseJsonStringAsync<Filter>(json);
+
+        var propertyFilter = Assert.IsType<PropertyFilter>(result);
+        Assert.Equal(expected, propertyFilter.Operator);
+    }
+
+    [Fact]
+    public async Task DeserializesUnrecognizedOperatorAsUnknown()
+    {
+        var json = """
+                   {
+                       "key": "email",
+                       "type": "person",
+                       "value": "posthog",
+                       "operator": "future_operator"
+                   }
+                   """;
+        var result = await JsonSerializerHelper.DeserializeFromCamelCaseJsonStringAsync<Filter>(json);
+
+        var propertyFilter = Assert.IsType<PropertyFilter>(result);
+        Assert.Equal(ComparisonOperator.Unknown, propertyFilter.Operator);
+    }
+
     [Fact]
     public async Task CanDeserializeFilterGroup()
     {

--- a/tests/UnitTests/Json/JsonSerializerHelperTests.cs
+++ b/tests/UnitTests/Json/JsonSerializerHelperTests.cs
@@ -425,6 +425,67 @@ public class TheDeserializeFromCamelCaseJsonMethod
         }, properties[1]);
         Assert.Equal(["0", "3.14"], properties[2].Value!.ListOfStrings);
     }
+    [Fact]
+    public async Task CanDeserializeLocalEvaluationApiResultWithUnrecognizedOperator()
+    {
+        var json = """
+                   {
+                       "flags": [
+                           {
+                               "id": 1,
+                               "team_id": 2,
+                               "name": "A flag using an operator this SDK doesn't know yet",
+                               "key": "future-flag",
+                               "filters": {
+                                   "groups": [
+                                       {
+                                           "properties": [
+                                               {
+                                                   "key": "email",
+                                                   "type": "person",
+                                                   "value": "posthog",
+                                                   "operator": "future_operator"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           },
+                           {
+                               "id": 2,
+                               "team_id": 2,
+                               "name": "A flag using a known operator",
+                               "key": "known-flag",
+                               "filters": {
+                                   "groups": [
+                                       {
+                                           "properties": [
+                                               {
+                                                   "key": "email",
+                                                   "type": "person",
+                                                   "value": "posthog",
+                                                   "operator": "icontains"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           }
+                       ]
+                   }
+                   """;
+
+        var result = await JsonSerializerHelper.DeserializeFromCamelCaseJsonStringAsync<LocalEvaluationApiResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Flags.Count);
+        Assert.Equal(
+            ComparisonOperator.Unknown,
+            result.Flags[0].Filters?.Groups?[0].Properties?[0].Operator);
+        Assert.Equal(
+            ComparisonOperator.ContainsIgnoreCase,
+            result.Flags[1].Filters?.Groups?[0].Properties?[0].Operator);
+    }
 
     [Fact]
     public async Task ShouldDeserializeApiResult()


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog/posthog#72992 added four case-insensitive property filter operators — `starts_with`, `not_starts_with`, `ends_with`, `not_ends_with` — across HogQL, the flags service, and the UI. The UI surface is gated behind a feature flag until server-side SDKs can evaluate these operators locally; on SDK versions without support, flags using them fall back to remote evaluation.

This adds local evaluation support for the four operators, mirroring `icontains`: both sides are stringified and lowercased, and the `not_` variants are exact negations. Filter values are single strings — server-side validation rejects list values for these operators, matching the flags service behavior.

New `ComparisonOperator` members are appended after the existing ones so shipped enum members keep their numeric identity, and the additions are recorded in `PublicAPI.Unshipped.txt` along with the new `PropertyFilterValue.IsPrefixOf`/`IsSuffixOf` methods (modeled on `IsContainedBy`).

## :green_heart: How did you test it?

New unit tests mirror the flags service's own test matrix for these operators: case-insensitive anchored matching, mid-string non-matches (`prevalue` does not match `starts_with: "Val"`), numeric stringification (`323` matches `starts_with: "3"`, `123` does not), negation inverses, and missing-key inconclusive behavior.

`dotnet test tests/UnitTests --filter "FullyQualifiedName~LocalEvaluatorTests"` passes locally on net8.0 (318 tests, including the 23 new inline cases); the netcoreapp3.1 target needs an x64 runtime not available on this arm64 machine, so CI covers it. `dotnet build src/PostHog` compiles all target frameworks and `dotnet format --verify-no-changes` is clean.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a changeset file (minor, `PostHog` package)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code as part of rolling out local evaluation for these operators across all server-side SDKs. The implementation deliberately mirrors the existing `icontains` branch in this repo (same string coercion and case folding) and the reference behavior in the Rust flags service (`rust/feature-flags/src/properties/property_matching.rs` in PostHog/posthog). The changeset file was written by hand following the repo's existing format.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
