### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    cooldown:
-      default-days: 7
+  - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: weekly
-    reviewers:
-      - "PostHog/team-client-libraries"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers:
+      - "PostHog/team-client-libraries"


### PR DESCRIPTION
## :bulb: Motivation and Context

The SDK's dependencies are managed by NuGet through `Directory.Packages.props`, root release tooling is managed by npm through `package.json`, and workflow dependencies are managed as GitHub Actions. This configures Dependabot for all three ecosystems at the repository root with a weekly schedule and a seven-day cooldown.

The configuration intentionally has no explicit `reviewers` fields. The repository-wide `CODEOWNERS` rule continues to assign `@PostHog/team-client-libraries` to Dependabot changes.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` with Ruby's YAML parser and asserted the exact ecosystem order (`nuget`, `npm`, `github-actions`), root directories, weekly schedules, seven-day cooldowns, allowed keys, and absence of reviewers.
- Verified `Directory.Packages.props`, root `package.json`, and `pnpm-lock.yaml` are present and confirmed the repository has no configured YAML formatter or lint script.
- Ran `git diff --check`.
- Ran branch autoreview against `origin/main`; no actionable findings were reported for `ae715c03a0527153f582c97e62d6782f81b50494`.

No automated tests were added because this change only updates Dependabot configuration.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi agent used the autoreview and check-pr workflows to update and validate the configuration. The configuration follows the requested dependency-manager boundaries without adding groups, labels, update limits, secondary directories, or extra ecosystems.
