### PR TITLE
chore(deps): update diagnostics Entity Framework Core to 9.0.18

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
   <!-- Sample packages -->
   <ItemGroup>
     <PackageVersion Include="dotenv.net" Version="3.2.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.18" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.18" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.18" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />

--- a/samples/HogTied.Web/packages.lock.json
+++ b/samples/HogTied.Web/packages.lock.json
@@ -4,11 +4,11 @@
     "net9.0": {
       "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": {
         "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "iWGrOsmmgz7wKc27SzC/rWrTuzl/jqWKIl/+YP7OL3mrDcADS/W5WFtmGkfQCAVGv0aZyck4CVfAVdjZLyyY8w==",
+        "requested": "[9.0.18, )",
+        "resolved": "9.0.18",
+        "contentHash": "/rIil4fhGyyq0UcZKOjq+kJw4xTxcTBqCXqI6NVdIST8W+EL+XjObCMxcYPcplHROMTulxyOvIEKjbs2merbCg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "9.0.0"
+          "Microsoft.EntityFrameworkCore.Relational": "9.0.18"
         }
       },
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot closed #281 after incorrectly reporting that `Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore` was no longer updatable. The HogTied.Web sample still declared and resolved version 9.0.0.

This updates the sample dependency to 9.0.18 and keeps the lockfile changes limited to that package.

## :green_heart: How did you test it?

- `dotnet restore --locked-mode`
- `dotnet build --configuration Release --no-restore --nologo`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent made the scoped dependency and lockfile update after confirming that the original Dependabot PR was closed incorrectly. The bundled autoreview checked the final branch diff and reported no actionable findings.
