### PR TITLE
chore(deps): update dotenv.net to 4.0.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
 
   <!-- Sample packages -->
   <ItemGroup>
-    <PackageVersion Include="dotenv.net" Version="3.2.1" />
+    <PackageVersion Include="dotenv.net" Version="4.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.18" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.18" />

--- a/samples/PostHog.Example.Console/packages.lock.json
+++ b/samples/PostHog.Example.Console/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0": {
       "dotenv.net": {
         "type": "Direct",
-        "requested": "[3.2.1, )",
-        "resolved": "3.2.1",
-        "contentHash": "2fc2s5PH6wAoWQ8bpyVgz28y9qMs/t8ToiCKqSM6mWpjgg4QQSPtZ0nia0x/OebGLSDbxyOelVH+fULZH7N4mA=="
+        "requested": "[4.0.2, )",
+        "resolved": "4.0.2",
+        "contentHash": "6xpiqKV1aKWIkSSDP7J+60GEKUitiDweD4yOsn9giCMysSfCghJQuYfXQwbzgdmt0Bsv/2ajUCbjvemGavqItA=="
       },
       "Microsoft.Extensions.Logging.Console": {
         "type": "Direct",


### PR DESCRIPTION
## :bulb: Motivation and Context

The console sample still uses `dotenv.net` 3.2.1. The previous update in #280 also removed lock-file entries for the PostHog project's `netstandard2.0` and `netstandard2.1` targets, which caused locked restores to fail.

This updates `dotenv.net` to 4.0.2 and regenerates only the console sample's dependency entry. The PostHog project lock file and its target-framework entries remain unchanged.

## :green_heart: How did you test it?

- `dotnet restore samples/PostHog.Example.Console/PostHog.Example.Console.csproj --force-evaluate`
- `dotnet restore --locked-mode`
- `dotnet build --configuration Release --no-restore --nologo`
- `dotnet test --logger "trx;LogFileName=test-results.trx" --configuration Release --no-restore --nologo`
- `bin/fmt --check`
- Confirmed the generated PostHog packages do not include a `dotenv.net` dependency.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi updated the centrally managed dependency and regenerated the lock file from the console sample project. The diff was kept to the dependency declaration and its matching console sample lock entry. Autoreview found no actionable issues.
