### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,27 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      release-tooling:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## :bulb: Motivation and Context
Dependabot currently opens separate pull requests for updates in each configured package ecosystem. Grouping updates keeps routine dependency maintenance easier to review and manage.

This adds a wildcard group to each existing update entry:
- `nuget-dependencies` for NuGet packages
- `release-tooling` for npm packages
- `github-actions` for GitHub Actions

## :green_heart: How did you test it?

Parsed `.github/dependabot.yml` with Ruby's YAML parser and verified that all three update entries contain the requested group with `patterns: ["*"]`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The Pi agent made this repository administration change from the user's requested group names and wildcard patterns. Autoreview was skipped because the diff only changes Dependabot repository configuration and does not affect SDK code, tests, build output, packaging, or runtime behavior.
