### PR TITLE
fix: normalize SDK timestamps to UTC

### DIFF
--- a/.changeset/fuzzy-clocks-convert.md
+++ b/.changeset/fuzzy-clocks-convert.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Normalize captured event timestamps to the equivalent UTC instant.

--- a/.changeset/fuzzy-clocks-convert.md
+++ b/.changeset/fuzzy-clocks-convert.md
@@ -1,5 +1,6 @@
 ---
 "PostHog": patch
+"PostHog.AspNetCore": patch
 ---
 
 Normalize captured event timestamps to the equivalent UTC instant.

--- a/src/PostHog/Api/CapturedEvent.cs
+++ b/src/PostHog/Api/CapturedEvent.cs
@@ -15,7 +15,7 @@ public class CapturedEvent
     /// <param name="eventName">The name of the event.</param>
     /// <param name="distinctId">The identifier for the user.</param>
     /// <param name="properties">The properties to associate with the event.</param>
-    /// <param name="timestamp">The ISO 8601 timestamp.</param>
+    /// <param name="timestamp">The ISO 8601 timestamp. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     public CapturedEvent(
         string eventName,
         string distinctId,
@@ -25,7 +25,7 @@ public class CapturedEvent
         Uuid = Guid.NewGuid().ToString();
         EventName = eventName;
         DistinctId = distinctId;
-        Timestamp = timestamp;
+        Timestamp = timestamp.ToUniversalTime();
 
         Properties = properties?.Copy() ?? new Dictionary<string, object>();
 

--- a/src/PostHog/Capture/CaptureExtensions.cs
+++ b/src/PostHog/Capture/CaptureExtensions.cs
@@ -76,7 +76,7 @@ public static class CaptureExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
     public static bool Capture(
         this IPostHogClient client,
@@ -97,7 +97,7 @@ public static class CaptureExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
     public static bool Capture(
@@ -120,7 +120,7 @@ public static class CaptureExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="groups">A set of groups to send with the event. The groups are identified by their group_type and group_key.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
     public static bool Capture(
@@ -143,7 +143,7 @@ public static class CaptureExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <param name="groups">Optional: Context of what groups are related to this event, example: { ["company"] = "id:5" }. Can be used to analyze companies instead of users.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
@@ -168,7 +168,7 @@ public static class CaptureExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="sendFeatureFlags">If <c>true</c>, feature flags are sent with the captured event.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
     [Obsolete("Prefer Capture(..., flags: snapshot, timestamp: timestamp) using a FeatureFlagEvaluations snapshot from EvaluateFlagsAsync. This overload will be removed in a future major version.", error: false)]
@@ -194,7 +194,7 @@ public static class CaptureExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="eventName">Human friendly name of the event. Recommended format [object] [verb] such as "Project created" or "User signed up".</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <param name="groups">Optional: Context of what groups are related to this event, example: { ["company"] = "id:5" }. Can be used to analyze companies instead of users.</param>
     /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>

--- a/src/PostHog/ErrorTracking/CaptureExceptionExtensions.cs
+++ b/src/PostHog/ErrorTracking/CaptureExceptionExtensions.cs
@@ -76,7 +76,7 @@ public static class CaptureExceptionExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="exception">The exception object that you want to capture.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <returns><c>true</c> if the exception event was successfully enqueued. Otherwise <c>false</c>.</returns>
     public static bool CaptureException(
         this IPostHogClient client,
@@ -97,7 +97,7 @@ public static class CaptureExceptionExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="exception">The exception object that you want to capture.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <returns><c>true</c> if the exception event was successfully enqueued. Otherwise <c>false</c>.</returns>
     public static bool CaptureException(
@@ -120,7 +120,7 @@ public static class CaptureExceptionExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="exception">The exception object that you want to capture.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="groups">A set of groups to send with the event. The groups are identified by their group_type and group_key.</param>
     /// <returns><c>true</c> if the exception event was successfully enqueued. Otherwise <c>false</c>.</returns>
     public static bool CaptureException(
@@ -143,7 +143,7 @@ public static class CaptureExceptionExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="exception">The exception object that you want to capture.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <param name="groups">Optional: A set of groups to send with the event. The groups are identified by their group_type and group_key.</param>
     /// <returns><c>true</c> if the exception event was successfully enqueued. Otherwise <c>false</c>.</returns>
@@ -168,7 +168,7 @@ public static class CaptureExceptionExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="exception">The exception object that you want to capture.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>
     /// <returns><c>true</c> if the exception event was successfully enqueued. Otherwise <c>false</c>.</returns>
     [Obsolete("Prefer CaptureException(..., flags: snapshot, timestamp: timestamp) using a FeatureFlagEvaluations snapshot from EvaluateFlagsAsync. This overload will be removed in a future major version.", error: false)]
@@ -194,7 +194,7 @@ public static class CaptureExceptionExtensions
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="exception">The exception object that you want to capture.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
-    /// <param name="timestamp">The timestamp when the event occurred.</param>
+    /// <param name="timestamp">The timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <param name="groups">Optional: A set of groups to send with the event. The groups are identified by their group_type and group_key.</param>
     /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>

--- a/src/PostHog/IPostHogClient.cs
+++ b/src/PostHog/IPostHogClient.cs
@@ -93,7 +93,7 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <param name="groups">Optional: Context of what groups are related to this event, example: { ["company"] = "id:5" }. Can be used to analyze companies instead of users.</param>
     /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>
-    /// <param name="timestamp">Optional: Custom timestamp when the event occurred. If not provided, uses current time.</param>
+    /// <param name="timestamp">Optional: Custom timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant. If not provided, uses current time.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
     [Obsolete("Prefer Capture(..., flags: snapshot, ...) using a FeatureFlagEvaluations snapshot from EvaluateFlagsAsync — same payload, no extra /flags request. This overload will be removed in a future major version.", error: false)]
     bool Capture(
@@ -115,7 +115,7 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <param name="groups">Optional: Context of what groups are related to this event, example: { ["company"] = "id:5" }. Can be used to analyze companies instead of users.</param>
     /// <param name="flags">A snapshot of feature flag evaluations. When non-null, <c>$feature/&lt;key&gt;</c> and <c>$active_feature_flags</c> are attached from the snapshot — no <c>/flags</c> call is made.</param>
-    /// <param name="timestamp">Optional: Custom timestamp when the event occurred. If not provided, uses current time.</param>
+    /// <param name="timestamp">Optional: Custom timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant. If not provided, uses current time.</param>
     /// <returns><c>true</c> if the event was successfully enqueued. Otherwise <c>false</c>.</returns>
     bool Capture(
         string distinctId,
@@ -139,7 +139,7 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <param name="groups">Optional: Context of what groups are related to this event, example: { ["company"] = "id:5" }. Can be used to analyze companies instead of users.</param>
     /// <param name="sendFeatureFlags">Default: <c>false</c>. If <c>true</c>, feature flags are sent with the captured event.</param>
-    /// <param name="timestamp">Optional: Custom timestamp when the event occurred. If not provided, uses current time</param>
+    /// <param name="timestamp">Optional: Custom timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant. If not provided, uses current time.</param>
     /// <returns><c>true</c> if the exception event was successfully enqueued. Otherwise <c>false</c>.</returns>
     [Obsolete("Prefer CaptureException(..., flags: snapshot, ...) using a FeatureFlagEvaluations snapshot from EvaluateFlagsAsync — same payload, no extra /flags request. This overload will be removed in a future major version.", error: false)]
     bool CaptureException(
@@ -158,7 +158,7 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="properties">Optional: The properties to send along with the event.</param>
     /// <param name="groups">Optional: Context of what groups are related to this event.</param>
     /// <param name="flags">A snapshot of feature flag evaluations. When non-null, <c>$feature/&lt;key&gt;</c> and <c>$active_feature_flags</c> are attached from the snapshot — no <c>/flags</c> call is made.</param>
-    /// <param name="timestamp">Optional: Custom timestamp when the event occurred.</param>
+    /// <param name="timestamp">Optional: Custom timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <returns><c>true</c> if the exception event was successfully enqueued. Otherwise <c>false</c>.</returns>
     bool CaptureException(
         Exception exception,

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -338,12 +338,6 @@ public sealed class PostHogClient : IPostHogClient
 
         capturedEvent.Properties.Merge(_options.Value.SuperProperties);
 
-        // Stamp a custom timestamp last so a super property can't override the typed value.
-        if (timestamp.HasValue)
-        {
-            AddTimestampToProperties(capturedEvent.Properties, timestamp.Value);
-        }
-
         if (hasGeoIpDisableOverride)
         {
             capturedEvent.Properties[PostHogProperties.GeoIpDisable] = geoIpDisableOverride!;

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -315,6 +315,7 @@ public sealed class PostHogClient : IPostHogClient
         // If custom timestamp provided, add it to properties
         if (timestamp.HasValue)
         {
+            timestamp = timestamp.Value.ToUniversalTime();
             properties = AddTimestampToProperties(properties, timestamp.Value);
         }
 
@@ -336,6 +337,12 @@ public sealed class PostHogClient : IPostHogClient
         }
 
         capturedEvent.Properties.Merge(_options.Value.SuperProperties);
+
+        // Stamp a custom timestamp last so a super property can't override the typed value.
+        if (timestamp.HasValue)
+        {
+            AddTimestampToProperties(capturedEvent.Properties, timestamp.Value);
+        }
 
         if (hasGeoIpDisableOverride)
         {

--- a/src/PostHog/PostHogSdk.cs
+++ b/src/PostHog/PostHogSdk.cs
@@ -89,7 +89,7 @@ public static class PostHogSdk
     /// <param name="properties">Optional properties to send along with the event.</param>
     /// <param name="groups">Optional groups related to this event.</param>
     /// <param name="sendFeatureFlags">Whether to send feature flag data with the event.</param>
-    /// <param name="timestamp">Optional timestamp when the event occurred.</param>
+    /// <param name="timestamp">Optional timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <returns><c>true</c> if the event was successfully enqueued; otherwise <c>false</c>.</returns>
 #pragma warning disable CS0618
     public static bool Capture(
@@ -119,7 +119,7 @@ public static class PostHogSdk
     /// <param name="properties">Optional properties to send along with the event.</param>
     /// <param name="groups">Optional groups related to this event.</param>
     /// <param name="sendFeatureFlags">Whether to send feature flag data with the event.</param>
-    /// <param name="timestamp">Optional timestamp when the event occurred.</param>
+    /// <param name="timestamp">Optional timestamp when the event occurred. UTC is preferred; non-UTC input is converted to the equivalent UTC instant.</param>
     /// <returns><c>true</c> if the exception event was successfully enqueued; otherwise <c>false</c>.</returns>
 #pragma warning disable CS0618
     public static bool CaptureException(

--- a/tests/UnitTests/Api/CapturedEventTests.cs
+++ b/tests/UnitTests/Api/CapturedEventTests.cs
@@ -59,6 +59,7 @@ public class TheConstructor
         var capturedEvent = new CapturedEvent("test-event", "user-1", null, timestamp);
 
         Assert.Equal(new DateTimeOffset(2024, 6, 15, 5, 0, 0, TimeSpan.Zero), capturedEvent.Timestamp);
+        Assert.Equal(TimeSpan.Zero, capturedEvent.Timestamp.Offset);
         Assert.Equal(timestamp.UtcTicks, capturedEvent.Timestamp.UtcTicks);
     }
 

--- a/tests/UnitTests/Api/CapturedEventTests.cs
+++ b/tests/UnitTests/Api/CapturedEventTests.cs
@@ -53,12 +53,13 @@ public class TheConstructor
     }
 
     [Fact]
-    public void SetsTimestamp()
+    public void ConvertsTimestampToUtcWithoutChangingTheInstant()
     {
-        var timestamp = new DateTimeOffset(2024, 6, 15, 10, 30, 0, TimeSpan.Zero);
+        var timestamp = new DateTimeOffset(2024, 6, 15, 10, 30, 0, TimeSpan.FromHours(5.5));
         var capturedEvent = new CapturedEvent("test-event", "user-1", null, timestamp);
 
-        Assert.Equal(timestamp, capturedEvent.Timestamp);
+        Assert.Equal(new DateTimeOffset(2024, 6, 15, 5, 0, 0, TimeSpan.Zero), capturedEvent.Timestamp);
+        Assert.Equal(timestamp.UtcTicks, capturedEvent.Timestamp.UtcTicks);
     }
 
     [Fact]

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -711,12 +711,9 @@ public class TheCaptureMethod
     }
 
     [Fact]
-    public async Task CaptureWithCustomTimestampWinsOverConflictingSuperPropertyAndConvertsToUtc()
+    public async Task CaptureWithCustomTimestampConvertsToUtc()
     {
-        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
-        {
-            options.SuperProperties["timestamp"] = "1999-12-31T23:59:59-07:00";
-        }));
+        var container = new TestContainer();
         container.FakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 21, 19, 08, 23, TimeSpan.Zero));
         var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
@@ -749,25 +746,6 @@ public class TheCaptureMethod
                        ]
                      }
                      """, received);
-    }
-
-    [Fact]
-    public async Task CaptureWithoutCustomTimestampPreservesTimestampSuperProperty()
-    {
-        const string superTimestamp = "1999-12-31T23:59:59-07:00";
-        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
-        {
-            options.SuperProperties["timestamp"] = superTimestamp;
-        }));
-        var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
-        var client = container.Activate<PostHogClient>();
-
-        client.Capture("test-user", "super-timestamp-event");
-        await client.FlushAsync();
-
-        using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
-        var timestamp = document.RootElement.GetProperty("batch")[0].GetProperty("properties").GetProperty("timestamp");
-        Assert.Equal(superTimestamp, timestamp.GetString());
     }
 
     [Fact]

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -711,14 +711,17 @@ public class TheCaptureMethod
     }
 
     [Fact]
-    public async Task CaptureWithCustomTimestampUsesProvidedTimestamp()
+    public async Task CaptureWithCustomTimestampWinsOverConflictingSuperPropertyAndConvertsToUtc()
     {
-        var container = new TestContainer();
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SuperProperties["timestamp"] = "1999-12-31T23:59:59-07:00";
+        }));
         container.FakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 21, 19, 08, 23, TimeSpan.Zero));
         var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var client = container.Activate<PostHogClient>();
 
-        var customTimestamp = new DateTimeOffset(2023, 12, 25, 10, 30, 45, TimeSpan.Zero);
+        var customTimestamp = new DateTimeOffset(2023, 12, 25, 10, 30, 45, TimeSpan.FromHours(5.5));
         client.Capture("test-user", "custom-timestamp-event", customTimestamp);
         await client.FlushAsync();
 
@@ -734,18 +737,37 @@ public class TheCaptureMethod
                            "event": "custom-timestamp-event",
                            "distinct_id": "test-user",
                            "properties": {
-                             "timestamp": "2023-12-25T10:30:45\u002B00:00",
+                             "timestamp": "2023-12-25T05:00:45\u002B00:00",
                              "distinct_id": "test-user",
                              "$lib": "posthog-dotnet",
                              "$lib_version": "{{VersionConstants.Version}}",
                              "$geoip_disable": true,
                              "$is_server": true
                            },
-                           "timestamp": "2023-12-25T10:30:45\u002B00:00"
+                           "timestamp": "2023-12-25T05:00:45\u002B00:00"
                          }
                        ]
                      }
                      """, received);
+    }
+
+    [Fact]
+    public async Task CaptureWithoutCustomTimestampPreservesTimestampSuperProperty()
+    {
+        const string superTimestamp = "1999-12-31T23:59:59-07:00";
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SuperProperties["timestamp"] = superTimestamp;
+        }));
+        var requestHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        client.Capture("test-user", "super-timestamp-event");
+        await client.FlushAsync();
+
+        using var document = JsonDocument.Parse(requestHandler.GetReceivedRequestBody(indented: false));
+        var timestamp = document.RootElement.GetProperty("batch")[0].GetProperty("properties").GetProperty("timestamp");
+        Assert.Equal(superTimestamp, timestamp.GetString());
     }
 
     [Fact]
@@ -1234,6 +1256,26 @@ public class TheCaptureExceptionMethod
         var (_, _, capturedProperties) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: false));
         Assert.Equal("test", capturedProperties.GetProperty("source").GetString());
         Assert.Equal("System.InvalidOperationException", capturedProperties.GetProperty("$exception_type").GetString());
+    }
+
+    [Fact]
+    public async Task CaptureExceptionWithCustomTimestampConvertsItToUtc()
+    {
+        var (_, requestHandler, client) = CreateClient();
+        var customTimestamp = new DateTimeOffset(2023, 12, 25, 10, 30, 45, TimeSpan.FromHours(-7));
+
+        client.CaptureException(
+            new InvalidOperationException("boom"),
+            "some-distinct-id",
+            properties: null,
+            groups: null,
+            flags: null,
+            timestamp: customTimestamp);
+        await client.FlushAsync();
+
+        var (_, batchItem, properties) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: false));
+        Assert.Equal("2023-12-25T17:30:45+00:00", batchItem.GetProperty("timestamp").GetString());
+        Assert.Equal("2023-12-25T17:30:45+00:00", properties.GetProperty("timestamp").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## :bulb: Motivation and Context

Custom `DateTimeOffset` values could keep their original offset in captured event payloads instead of being sent as UTC.

This change converts explicit capture and exception timestamps to the same instant at offset `+00:00` and stores the normalized value on the captured event. The normalized timestamp is added to event properties before super properties are merged, preserving the existing super-property precedence: a configured `timestamp` super property can override `properties.timestamp`, while the top-level event timestamp remains the normalized explicit value. Captures without an explicit timestamp also continue to preserve an existing `timestamp` super property.

## :green_heart: How did you test it?

- `CapturedEventTests.TheConstructor` verifies that a `+05:30` timestamp becomes the equivalent UTC value, explicitly has a zero offset, and retains the same UTC ticks.
- `PostHogClientTests.TheCaptureMethod` verifies that a `+05:30` custom timestamp is UTC in both payload locations when no conflicting timestamp super property is configured.
- `PostHogClientTests.TheCaptureExceptionMethod` verifies that a `-07:00` exception timestamp is UTC in both payload locations.
- `DOTNET_ROLL_FORWARD=Major dotnet test tests/UnitTests/UnitTests.csproj --framework net8.0 --configuration Release --nologo --filter 'FullyQualifiedName~CapturedEventTests|FullyQualifiedName~PostHogClientTests.TheCaptureMethod|FullyQualifiedName~PostHogClientTests.TheCaptureExceptionMethod'` passed all 40 focused tests.
- `bin/fmt --check` passed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to prepare the existing implementation for this pull request and run the isolated autoreview workflow. The change keeps normalization at the captured event boundary while preserving the existing super-property merge precedence. A patch changeset was added for the `PostHog` package.
