### PR TITLE
fix: support fractional rollout percentages in local evaluation

### DIFF
--- a/.changeset/fractional-rollout-percentages.md
+++ b/.changeset/fractional-rollout-percentages.md
@@ -1,0 +1,6 @@
+---
+"PostHog": patch
+"PostHog.AspNetCore": patch
+---
+
+Support fractional rollout percentages when evaluating feature flags locally.

--- a/src/PostHog/Api/LocalEvaluationApiResult.cs
+++ b/src/PostHog/Api/LocalEvaluationApiResult.cs
@@ -219,10 +219,10 @@ internal record FeatureFlagGroup
     public string? Variant { get; init; }
 
     /// <summary>
-    /// Optional percentage (0-100) for gradual rollouts. Defaults to 100.
+    /// Optional percentage (0-100) for gradual rollouts. May be fractional (e.g. 0.5). Defaults to 100.
     /// </summary>
     [JsonPropertyName("rollout_percentage")]
-    public int? RolloutPercentage { get; init; } = 100;
+    public double? RolloutPercentage { get; init; } = 100;
 
     /// <summary>
     /// Optional per-condition aggregation override used by mixed-targeting flags.

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -904,6 +904,88 @@ public class TheEvaluateFeatureFlagMethod
                 personProperties: properties);
         });
     }
+
+    // A fractional rollout such as 0.1% has to survive deserialization and bucketing.
+    // `user-2912` hashes to ~0.0000142 (inside 0.1%) and `user-212` to ~0.0042866
+    // (outside 0.1%, but inside 0.5%). Truncating the percentage to an integer would
+    // put both users outside the bucket.
+    [Theory]
+    [InlineData("0.1", "user-2912", true)]
+    [InlineData("0.1", "user-212", false)]
+    [InlineData("0.5", "user-212", true)]
+    public void MatchesFractionalRolloutPercentage(string rolloutPercentage, string distinctId, bool expected)
+    {
+        var json = $$"""
+        {
+            "flags": [
+                {
+                    "id": 42,
+                    "team_id": 23,
+                    "name": "fractional-rollout-feature-flag",
+                    "key": "fractional-rollout",
+                    "active": true,
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [],
+                                "rollout_percentage": {{rolloutPercentage}}
+                            }
+                        ]
+                    }
+                }
+            ],
+            "group_type_mapping": {}
+        }
+        """;
+        var flags = JsonSerializer.Deserialize<LocalEvaluationApiResult>(json, JsonSerializerHelper.Options)!;
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(key: "fractional-rollout", distinctId: distinctId);
+
+        Assert.Equal(expected, result);
+    }
+
+    // The boundaries have to keep behaving after widening the percentage to a double:
+    // 100.0 lets everybody through, 0.0 lets nobody through, and an explicit null is
+    // treated as an unbounded rollout.
+    [Theory]
+    [InlineData("100.0", "user-2912", true)]
+    [InlineData("100.0", "user-212", true)]
+    [InlineData("0.0", "user-2912", false)]
+    [InlineData("0.0", "user-212", false)]
+    [InlineData("null", "user-2912", true)]
+    [InlineData("null", "user-212", true)]
+    public void MatchesBoundaryRolloutPercentage(string rolloutPercentage, string distinctId, bool expected)
+    {
+        var json = $$"""
+        {
+            "flags": [
+                {
+                    "id": 42,
+                    "team_id": 23,
+                    "name": "boundary-rollout-feature-flag",
+                    "key": "boundary-rollout",
+                    "active": true,
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [],
+                                "rollout_percentage": {{rolloutPercentage}}
+                            }
+                        ]
+                    }
+                }
+            ],
+            "group_type_mapping": {}
+        }
+        """;
+        var flags = JsonSerializer.Deserialize<LocalEvaluationApiResult>(json, JsonSerializerHelper.Options)!;
+        var localEvaluator = new LocalEvaluator(flags);
+
+        var result = localEvaluator.EvaluateFeatureFlag(key: "boundary-rollout", distinctId: distinctId);
+
+        Assert.Equal(expected, result);
+    }
 }
 
 public class TheMixedTargetingEvaluation


### PR DESCRIPTION
Fixes #291.

Currently, the rollout_percentage value is a decimal. Seemingly since a few days ago, newly created and updated flags now return the decimal equivalent i.e. 100.0 instead of 100. This causes all current versions of the .net posthog SDK to fail with a deserialisation exception