### PR TITLE
fix: fall back for requested flags missing locally

### DIFF
--- a/.changeset/fallback-for-missing-local-flags.md
+++ b/.changeset/fallback-for-missing-local-flags.md
@@ -3,4 +3,4 @@
 "PostHog.AspNetCore": minor
 ---
 
-Fall back to remote evaluation when a requested feature flag is missing from local definitions. This changes scoped calls from omitting the key without a request to making one `/flags` fallback per configured cache entry.
+Fall back to remote evaluation when a requested feature flag is missing from local definitions. This changes scoped calls from omitting the key without a request to making one direct `/flags` fallback per `EvaluateFlagsAsync` call.

--- a/.changeset/fallback-for-missing-local-flags.md
+++ b/.changeset/fallback-for-missing-local-flags.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Fall back to remote evaluation when a requested feature flag is missing from local definitions.

--- a/.changeset/fallback-for-missing-local-flags.md
+++ b/.changeset/fallback-for-missing-local-flags.md
@@ -1,6 +1,6 @@
 ---
-"PostHog": patch
-"PostHog.AspNetCore": patch
+"PostHog": minor
+"PostHog.AspNetCore": minor
 ---
 
-Fall back to remote evaluation when a requested feature flag is missing from local definitions.
+Fall back to remote evaluation when a requested feature flag is missing from local definitions. This changes scoped calls from omitting the key without a request to making one `/flags` fallback per configured cache entry.

--- a/.changeset/fallback-for-missing-local-flags.md
+++ b/.changeset/fallback-for-missing-local-flags.md
@@ -1,5 +1,6 @@
 ---
 "PostHog": patch
+"PostHog.AspNetCore": patch
 ---
 
 Fall back to remote evaluation when a requested feature flag is missing from local definitions.

--- a/src/PostHog.AspNetCore/Tracing/PostHogRequestContextExtensions.cs
+++ b/src/PostHog.AspNetCore/Tracing/PostHogRequestContextExtensions.cs
@@ -97,7 +97,7 @@ public static class PostHogRequestContextExtensions
     /// authorization context. Pass an authenticated distinct ID explicitly for security-sensitive server branching.
     /// </remarks>
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
-    /// <param name="options">Options used to control feature flag evaluation. <see cref="AllFeatureFlagsOptions.FlagKeysToEvaluate"/> scopes the underlying <c>/flags</c> request body.</param>
+    /// <param name="options">Options used to control feature flag evaluation. <see cref="AllFeatureFlagsOptions.FlagKeysToEvaluate"/> scopes local evaluation, the <c>/flags</c> request, and the returned snapshot. Missing local definitions trigger fallback unless <see cref="AllFeatureFlagsOptions.OnlyEvaluateLocally"/> is <c>true</c>.</param>
     /// <returns>A snapshot of feature flag evaluations.</returns>
     public static Task<FeatureFlagEvaluations> EvaluateFlagsAsync(
         this IPostHogClient client,

--- a/src/PostHog/Features/FeatureFlagExtensions.cs
+++ b/src/PostHog/Features/FeatureFlagExtensions.cs
@@ -292,7 +292,7 @@ public static class FeatureFlagExtensions
     /// </summary>
     /// <param name="client">The <see cref="IPostHogClient"/>.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
-    /// <param name="options">Options used to control feature flag evaluation. <see cref="AllFeatureFlagsOptions.FlagKeysToEvaluate"/> scopes the underlying <c>/flags</c> request body.</param>
+    /// <param name="options">Options used to control feature flag evaluation. <see cref="AllFeatureFlagsOptions.FlagKeysToEvaluate"/> scopes local evaluation, the <c>/flags</c> request, and the returned snapshot. Missing local definitions trigger fallback unless <see cref="AllFeatureFlagsOptions.OnlyEvaluateLocally"/> is <c>true</c>.</param>
     /// <returns>A snapshot of feature flag evaluations.</returns>
     public static Task<FeatureFlagEvaluations> EvaluateFlagsAsync(
         this IPostHogClient client,

--- a/src/PostHog/Features/FeatureFlagOptions.cs
+++ b/src/PostHog/Features/FeatureFlagOptions.cs
@@ -53,8 +53,8 @@ public class AllFeatureFlagsOptions
     /// <remarks>
     /// This scopes local evaluation, the <c>/flags</c> request, and the returned result. A requested
     /// key missing from local definitions triggers remote fallback unless <see cref="OnlyEvaluateLocally"/>
-    /// is <c>true</c>. If the key is also absent remotely, a configured feature flag cache can reuse
-    /// the empty response for the same identity and evaluation inputs during its cache window.
+    /// is <c>true</c>. When <c>EvaluateFlagsAsync</c> falls back with a non-empty scope, it bypasses
+    /// the general feature flag cache, so a key absent remotely costs one request per call.
     /// </remarks>
     public IReadOnlyList<string> FlagKeysToEvaluate { get; init; } = [];
 

--- a/src/PostHog/Features/FeatureFlagOptions.cs
+++ b/src/PostHog/Features/FeatureFlagOptions.cs
@@ -22,10 +22,12 @@ public class FeatureFlagOptions : AllFeatureFlagsOptions
 public class AllFeatureFlagsOptions
 {
     /// <summary>
-    /// Whether to only evaluate the flag locally. Defaults to <c>false</c>.
+    /// Whether to only evaluate flags locally. Defaults to <c>false</c>.
     /// </summary>
     /// <remarks>
-    /// Local evaluation requires that <see cref="PostHogOptions.SecretKey"/> is set.
+    /// Local evaluation requires that <see cref="PostHogOptions.SecretKey"/> is set. When this is
+    /// <c>true</c>, no <c>/flags</c> request is made and flags that cannot be resolved locally are
+    /// absent from the result.
     /// </remarks>
     public bool OnlyEvaluateLocally { get; init; }
 
@@ -48,6 +50,12 @@ public class AllFeatureFlagsOptions
     /// <summary>
     /// The set of flag keys to evaluate in this request. If not specified, all flags are evaluated.
     /// </summary>
+    /// <remarks>
+    /// This scopes local evaluation, the <c>/flags</c> request, and the returned result. A requested
+    /// key missing from local definitions triggers remote fallback unless <see cref="OnlyEvaluateLocally"/>
+    /// is <c>true</c>. If the key is also absent remotely, a configured feature flag cache can reuse
+    /// the empty response for the same identity and evaluation inputs during its cache window.
+    /// </remarks>
     public IReadOnlyList<string> FlagKeysToEvaluate { get; init; } = [];
 
     /// <summary>

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -128,7 +128,8 @@ internal sealed class LocalEvaluator
         string distinctId,
         GroupCollection? groups = null,
         Dictionary<string, object?>? personProperties = null,
-        bool warnOnUnknownGroups = true)
+        bool warnOnUnknownGroups = true,
+        IReadOnlyCollection<string>? flagKeysToEvaluate = null)
     {
         Dictionary<string, FeatureFlag> results = new();
 
@@ -138,8 +139,15 @@ internal sealed class LocalEvaluator
         }
 
         var fallbackToRemote = false;
+        IEnumerable<LocalFeatureFlag> flagsToEvaluate = LocalEvaluationApiResult.Flags;
+        if (flagKeysToEvaluate is { Count: > 0 })
+        {
+            var requestedFlagKeys = new HashSet<string>(flagKeysToEvaluate, StringComparer.Ordinal);
+            fallbackToRemote = requestedFlagKeys.Any(key => !_localFeatureFlags.ContainsKey(key));
+            flagsToEvaluate = flagsToEvaluate.Where(flag => requestedFlagKeys.Contains(flag.Key));
+        }
 
-        foreach (var flag in LocalEvaluationApiResult.Flags)
+        foreach (var flag in flagsToEvaluate)
         {
             try
             {

--- a/src/PostHog/IPostHogClient.cs
+++ b/src/PostHog/IPostHogClient.cs
@@ -242,17 +242,18 @@ public interface IPostHogClient : IDisposable, IAsyncDisposable
     /// <param name="distinctId">The identifier you use for the user.</param>
     /// <param name="options">
     /// Optional: Options used to control feature flag evaluation. <see cref="AllFeatureFlagsOptions.FlagKeysToEvaluate"/>
-    /// scopes the underlying <c>/flags</c> request body — distinct from
+    /// scopes local evaluation, the underlying <c>/flags</c> request, and the returned snapshot. This differs from
     /// <see cref="FeatureFlagEvaluations.Only(System.Collections.Generic.IEnumerable{string})"/>, which
     /// filters in memory.
     /// </param>
     /// <param name="cancellationToken">The cancellation token that can be used to cancel the operation.</param>
     /// <returns>A snapshot of feature flag evaluations.</returns>
     /// <remarks>
-    /// <see cref="AllFeatureFlagsOptions.FlagKeysToEvaluate"/> scopes the underlying <c>/flags</c>
-    /// request body. <see cref="FeatureFlagEvaluations.Only(System.Collections.Generic.IEnumerable{string})"/>
-    /// filters an already-evaluated snapshot in memory. Use <c>FlagKeysToEvaluate</c> to reduce
-    /// network and server work; use <c>Only(...)</c> to scope an existing snapshot for capture.
+    /// <see cref="AllFeatureFlagsOptions.FlagKeysToEvaluate"/> scopes local evaluation, the underlying
+    /// <c>/flags</c> request, and the returned snapshot. Requested keys missing from local definitions
+    /// trigger remote fallback unless <see cref="AllFeatureFlagsOptions.OnlyEvaluateLocally"/> is
+    /// <c>true</c>. <see cref="FeatureFlagEvaluations.Only(System.Collections.Generic.IEnumerable{string})"/>
+    /// filters an already-evaluated snapshot in memory.
     /// </remarks>
     Task<FeatureFlagEvaluations> EvaluateFlagsAsync(
         string distinctId,

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -1130,7 +1130,12 @@ public sealed class PostHogClient : IPostHogClient
         {
             try
             {
-                var flagsResult = await FetchFlagsAsync(resolvedDistinctId, options, cancellationToken);
+                // Scoped requests bypass the general cache because its public key contract does not
+                // include FlagKeysToEvaluate. This guarantees the caller's original scope is probed
+                // instead of reusing a differently scoped or inconclusive cached response.
+                var flagsResult = requestedFlagKeys is null
+                    ? await FetchFlagsAsync(resolvedDistinctId, options, cancellationToken)
+                    : await FetchFlagsDirectAsync(resolvedDistinctId, options, cancellationToken);
                 requestId = flagsResult.RequestId;
                 evaluatedAt = flagsResult.EvaluatedAt;
 
@@ -1273,6 +1278,27 @@ public sealed class PostHogClient : IPostHogClient
         AllFeatureFlagsOptions? options,
         CancellationToken cancellationToken) =>
         await FetchFlagsAsync(_featureFlagsCache, distinctId, options, cancellationToken);
+
+    async Task<FlagsResult> FetchFlagsDirectAsync(
+        string distinctId,
+        AllFeatureFlagsOptions? options,
+        CancellationToken cancellationToken)
+    {
+        var result = await _apiClient.GetFeatureFlagsAsync(
+            distinctId,
+            options?.PersonProperties,
+            options?.Groups,
+            options?.FlagKeysToEvaluate,
+            options?.DisableGeoIp ?? false,
+            cancellationToken);
+        var flagsResult = result.ToFlagsResult();
+        if (flagsResult.QuotaLimited.Contains("feature_flags"))
+        {
+            _logger.LogWarningQuotaExceeded();
+            return new FlagsResult { QuotaLimited = flagsResult.QuotaLimited };
+        }
+        return flagsResult;
+    }
 
     async Task<FlagsResult> FetchFlagsAsync(
         IFeatureFlagCache cache,

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -1065,6 +1065,9 @@ public sealed class PostHogClient : IPostHogClient
         }
 
         var records = new Dictionary<string, EvaluatedFlagRecord>(StringComparer.Ordinal);
+        var requestedFlagKeys = options?.FlagKeysToEvaluate is { Count: > 0 } flagKeys
+            ? new HashSet<string>(flagKeys, StringComparer.Ordinal)
+            : null;
         var errors = new List<string>();
         string? requestId = null;
         long? evaluatedAt = null;
@@ -1084,7 +1087,8 @@ public sealed class PostHogClient : IPostHogClient
                         resolvedDistinctId,
                         options?.Groups,
                         options?.PersonProperties,
-                        warnOnUnknownGroups: false);
+                        warnOnUnknownGroups: false,
+                        flagKeysToEvaluate: requestedFlagKeys);
 
                     foreach (var (key, flag) in locallyEvaluated)
                     {
@@ -1142,6 +1146,11 @@ public sealed class PostHogClient : IPostHogClient
 
                 foreach (var (key, flag) in flagsResult.Flags)
                 {
+                    if (requestedFlagKeys is not null && !requestedFlagKeys.Contains(key))
+                    {
+                        continue;
+                    }
+
                     // Local-wins merge: keep the locally-evaluated record (which carries
                     // locally_evaluated=true and $feature_flag_definitions_loaded_at) and only fill
                     // in keys the local pass couldn't resolve. Differs from GetAllFeatureFlagsAsync,

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -184,6 +184,62 @@ public class TheEvaluateFlagsAsyncMethod
     }
 
     [Fact]
+    public async Task EmptyRemoteResultForMissingKeyIsCachedForSameInputs()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {"flags": [
+                {"id": 1, "key": "local-flag", "active": true,
+                 "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}}
+            ]}
+            """);
+        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {}}""");
+        using var cache = new MemoryFeatureFlagCache(container.FakeTimeProvider, 100, 0.2);
+        var client = container.Activate<PostHogClient>(cache);
+        var options = new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag", "missing-flag"] };
+
+        var first = await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
+        var second = await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
+
+        Assert.True(first.IsEnabled("local-flag"));
+        Assert.DoesNotContain("missing-flag", first.Keys);
+        Assert.True(second.IsEnabled("local-flag"));
+        Assert.DoesNotContain("missing-flag", second.Keys);
+        Assert.Single(flagsHandler.ReceivedRequests);
+    }
+
+    [Fact]
+    public async Task SuccessfulFallbackKeepsRawRemoteResultInCache()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {"flags": [
+                {"id": 1, "key": "local-flag", "active": true,
+                 "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+                {"id": 2, "key": "unrequested-flag", "active": true,
+                 "filters": {"groups": [{"properties": [{"key": "country", "type": "person", "value": "US", "operator": "exact"}],
+                                          "rollout_percentage": 100}]}}
+            ]}
+            """);
+        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
+            """{"featureFlags": {"local-flag": false, "remote-flag": true}}""");
+        using var cache = new MemoryFeatureFlagCache(container.FakeTimeProvider, 100, 0.2);
+        var client = container.Activate<PostHogClient>(cache);
+        var options = new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag", "remote-flag"] };
+
+        var snapshot = await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
+        var rawFlags = await client.GetAllFeatureFlagsAsync("user-1", options, CancellationToken.None);
+
+        Assert.True(snapshot.IsEnabled("local-flag"));
+        Assert.True(snapshot.IsEnabled("remote-flag"));
+        Assert.False(rawFlags["local-flag"].IsEnabled);
+        Assert.True(rawFlags["remote-flag"].IsEnabled);
+        Assert.Single(flagsHandler.ReceivedRequests);
+    }
+
+    [Fact]
     public async Task RequestedLocalFlagIgnoresUnrequestedInconclusiveDefinition()
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -9,6 +9,15 @@ namespace FeatureFlagEvaluationsTests;
 
 public class TheEvaluateFlagsAsyncMethod
 {
+    static void AddResolvableLocalFlag(TestContainer container) =>
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {"flags": [
+                {"id": 1, "key": "local-flag", "active": true,
+                 "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}}
+            ]}
+            """);
+
     [Fact]
     public async Task ReturnsSnapshotWithRichMetadataFromOneFlagsRequest()
     {
@@ -184,17 +193,12 @@ public class TheEvaluateFlagsAsyncMethod
     }
 
     [Fact]
-    public async Task EmptyRemoteResultForMissingKeyIsCachedForSameInputs()
+    public async Task EmptyRemoteResultForMissingKeyIsRetriedForSameInputs()
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");
-        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
-            """
-            {"flags": [
-                {"id": 1, "key": "local-flag", "active": true,
-                 "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}}
-            ]}
-            """);
-        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {}}""");
+        AddResolvableLocalFlag(container);
+        var firstFlagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {}}""");
+        var secondFlagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse("""{"featureFlags": {}}""");
         using var cache = new MemoryFeatureFlagCache(container.FakeTimeProvider, 100, 0.2);
         var client = container.Activate<PostHogClient>(cache);
         var options = new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag", "missing-flag"] };
@@ -206,11 +210,93 @@ public class TheEvaluateFlagsAsyncMethod
         Assert.DoesNotContain("missing-flag", first.Keys);
         Assert.True(second.IsEnabled("local-flag"));
         Assert.DoesNotContain("missing-flag", second.Keys);
-        Assert.Single(flagsHandler.ReceivedRequests);
+        Assert.Single(firstFlagsHandler.ReceivedRequests);
+        Assert.Single(secondFlagsHandler.ReceivedRequests);
     }
 
     [Fact]
-    public async Task SuccessfulFallbackKeepsRawRemoteResultInCache()
+    public async Task ScopedFallbackBypassesDifferentlyScopedWarmCache()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {"flags": [
+                {"id": 1, "key": "local-flag", "active": true,
+                 "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+                {"id": 2, "key": "needs-server", "active": true,
+                 "filters": {"groups": [{"properties": [
+                     {"key": "country", "type": "person", "value": "US", "operator": "exact"}
+                 ], "rollout_percentage": 100}]}}
+            ]}
+            """);
+        var warmCacheHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
+            """{"featureFlags": {"warm-only": true}}""");
+        var scopedHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
+            """{"featureFlags": {"remote-flag": true}}""");
+        using var cache = new MemoryFeatureFlagCache(container.FakeTimeProvider, 100, 0.2);
+        var client = container.Activate<PostHogClient>(cache);
+
+        await client.GetAllFeatureFlagsAsync("user-1", options: null, CancellationToken.None);
+        var snapshot = await client.EvaluateFlagsAsync(
+            "user-1",
+            new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag", "remote-flag"] },
+            CancellationToken.None);
+
+        Assert.True(snapshot.IsEnabled("local-flag"));
+        Assert.True(snapshot.IsEnabled("remote-flag"));
+        Assert.DoesNotContain("warm-only", snapshot.Keys);
+        Assert.Single(warmCacheHandler.ReceivedRequests);
+        Assert.Single(scopedHandler.ReceivedRequests);
+    }
+
+    [Theory]
+    [InlineData("{\"featureFlags\": {}, \"quotaLimited\": [\"feature_flags\"]}")]
+    [InlineData("{\"featureFlags\": {}, \"errorsWhileComputingFlags\": true}")]
+    public async Task InconclusiveRemoteResultForMissingKeyIsRetried(string responseBody)
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        AddResolvableLocalFlag(container);
+        var firstFlagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(responseBody);
+        var secondFlagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(responseBody);
+        using var cache = new MemoryFeatureFlagCache(container.FakeTimeProvider, 100, 0.2);
+        var client = container.Activate<PostHogClient>(cache);
+        var options = new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag", "missing-flag"] };
+
+        await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
+        await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
+
+        Assert.Single(firstFlagsHandler.ReceivedRequests);
+        Assert.Single(secondFlagsHandler.ReceivedRequests);
+    }
+
+    [Fact]
+    public async Task FailedRemoteResultForMissingKeyIsRetried()
+    {
+        var container = new TestContainer(services => services.Configure<PostHogOptions>(options =>
+        {
+            options.SecretKey = "fake-personal-api-key";
+            options.FeatureFlagRequestMaxRetries = 0;
+        }));
+        AddResolvableLocalFlag(container);
+        var failedHandler = container.FakeHttpMessageHandler.AddFlagsResponseException(
+            new HttpRequestException("Network error"));
+        var successfulHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
+            """{"featureFlags": {"missing-flag": true}}""");
+        using var cache = new MemoryFeatureFlagCache(container.FakeTimeProvider, 100, 0.2);
+        var client = container.Activate<PostHogClient>(cache);
+        var options = new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag", "missing-flag"] };
+
+        var first = await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
+        var second = await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
+
+        Assert.DoesNotContain("missing-flag", first.Keys);
+        Assert.True(second.IsEnabled("missing-flag"));
+        Assert.Single(failedHandler.ReceivedRequests);
+        Assert.Single(successfulHandler.ReceivedRequests);
+    }
+
+    [Fact]
+    public async Task UnscopedSuccessfulFallbackKeepsRawRemoteResultInCache()
     {
         var container = new TestContainer(personalApiKey: "fake-personal-api-key");
         container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
@@ -227,10 +313,8 @@ public class TheEvaluateFlagsAsyncMethod
             """{"featureFlags": {"local-flag": false, "remote-flag": true}}""");
         using var cache = new MemoryFeatureFlagCache(container.FakeTimeProvider, 100, 0.2);
         var client = container.Activate<PostHogClient>(cache);
-        var options = new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag", "remote-flag"] };
-
-        var snapshot = await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
-        var rawFlags = await client.GetAllFeatureFlagsAsync("user-1", options, CancellationToken.None);
+        var snapshot = await client.EvaluateFlagsAsync("user-1", options: null, CancellationToken.None);
+        var rawFlags = await client.GetAllFeatureFlagsAsync("user-1", options: null, CancellationToken.None);
 
         Assert.True(snapshot.IsEnabled("local-flag"));
         Assert.True(snapshot.IsEnabled("remote-flag"));

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -132,10 +132,82 @@ public class TheEvaluateFlagsAsyncMethod
 
         var snapshot = await client.EvaluateFlagsAsync(
             "user-1",
-            new AllFeatureFlagsOptions { OnlyEvaluateLocally = true },
+            new AllFeatureFlagsOptions
+            {
+                OnlyEvaluateLocally = true,
+                FlagKeysToEvaluate = ["flag-a", "missing-flag"]
+            },
             CancellationToken.None);
 
         Assert.True(snapshot.IsEnabled("flag-a"));
+        Assert.Single(snapshot.Keys);
+        Assert.Empty(flagsHandler.ReceivedRequests);
+    }
+
+    [Fact]
+    public async Task MissingRequestedKeyFallsBackWithOriginalScopeAndKeepsLocalValues()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {"flags": [
+                {"id": 1, "key": "local-flag", "active": true,
+                 "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+                {"id": 2, "key": "unrequested-flag", "active": true,
+                 "filters": {"groups": [{"properties": [{"key": "country", "type": "person", "value": "US", "operator": "exact"}],
+                                          "rollout_percentage": 100}]}}
+            ]}
+            """);
+        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
+            """{"featureFlags": {"local-flag": false, "remote-flag": true, "extra-flag": true}}""");
+        var client = container.Activate<PostHogClient>();
+
+        var snapshot = await client.EvaluateFlagsAsync(
+            "user-1",
+            new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag", "remote-flag"] },
+            CancellationToken.None);
+
+        Assert.Equal(2, snapshot.Keys.Count);
+        Assert.True(snapshot.IsEnabled("local-flag"));
+        Assert.True(snapshot.IsEnabled("remote-flag"));
+        Assert.DoesNotContain("extra-flag", snapshot.Keys);
+        Assert.DoesNotContain("unrequested-flag", snapshot.Keys);
+
+        var request = flagsHandler.ReceivedRequests.Single();
+        var body = await request.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var flagKeys = doc.RootElement.GetProperty("flag_keys_to_evaluate")
+            .EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty)
+            .ToArray();
+        Assert.Equal(new[] { "local-flag", "remote-flag" }, flagKeys);
+    }
+
+    [Fact]
+    public async Task RequestedLocalFlagIgnoresUnrequestedInconclusiveDefinition()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """
+            {"flags": [
+                {"id": 1, "key": "local-flag", "active": true,
+                 "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+                {"id": 2, "key": "unrequested-flag", "active": true,
+                 "filters": {"groups": [{"properties": [{"key": "country", "type": "person", "value": "US", "operator": "exact"}],
+                                          "rollout_percentage": 100}]}}
+            ]}
+            """);
+        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
+            """{"featureFlags": {"unrequested-flag": true}}""");
+        var client = container.Activate<PostHogClient>();
+
+        var snapshot = await client.EvaluateFlagsAsync(
+            "user-1",
+            new AllFeatureFlagsOptions { FlagKeysToEvaluate = ["local-flag"] },
+            CancellationToken.None);
+
+        Assert.True(snapshot.IsEnabled("local-flag"));
+        Assert.Single(snapshot.Keys);
         Assert.Empty(flagsHandler.ReceivedRequests);
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

`EvaluateFlagsAsync` could silently omit a requested flag when local definitions were loaded but did not contain that key. The local evaluator only visited definitions it knew about, so a newly created or stale key did not trigger `/flags`.

The [cross-SDK discussion](https://github.com/PostHog/posthog-android/pull/678#issuecomment-5341493624) identified this difference. The [agreed behavior](https://github.com/PostHog/posthog-android/pull/678#issuecomment-5341879578) is to fall back remotely for missing requested keys unless local-only evaluation was requested. [sdk-specs#44](https://github.com/PostHog/sdk-specs/pull/44) now defines the canonical contract, including safe optional suppression of repeated missing-key probes.

This change scopes local evaluation to `FlagKeysToEvaluate` and treats requested keys missing from local definitions as unresolved. The fallback sends the caller's original key list. The returned snapshot stays scoped to that list, and locally resolved values remain authoritative if the server returns a conflicting value.

Scoped `EvaluateFlagsAsync` fallbacks bypass the general feature-flag cache because its public key contract does not include `FlagKeysToEvaluate`. This ensures a differently scoped, empty, quota-limited, computation-error, or failed cached result cannot suppress the required probe. Consequently, a key absent both locally and remotely costs one direct request per scoped `EvaluateFlagsAsync` call. Negative suppression is optional in the canonical specification.

Strict local-only calls still make no `/flags` request and omit missing keys. Unscoped and legacy feature-flag operations retain their existing cache behavior. The public `IFeatureFlagCache` interface remains unchanged.

Public XML documentation now describes this behavior. Minor changesets are included for both `PostHog` and `PostHog.AspNetCore` because scoped calls can now make a request where they previously omitted the key.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --filter 'FullyQualifiedName~FeatureFlagEvaluationsTests' --no-restore` — 34/34 passed on both net8.0 and netcoreapp3.1.
- `dotnet build --configuration Release --no-restore --nologo` — succeeded with 0 warnings and 0 errors.
- `bin/fmt --check`
- `git diff --check`
- Autoreview against `origin/main` — no actionable findings.

The focused tests cover original request scope forwarding, returned snapshot scoping, local-wins merging, local-only behavior, empty-response retries, differently scoped warm caches, quota-limited and computation-error retries, transport-failure retries, and preservation of unscoped raw-response caching.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi worker agent implemented and tested the change under human direction. The implementation follows the canonical SDK specification while deliberately avoiding a public `IFeatureFlagCache` API expansion.
