### PR TITLE
refactor: share HTTP response deserialization

### DIFF
--- a/src/PostHog/Library/HttpClientExtensions.cs
+++ b/src/PostHog/Library/HttpClientExtensions.cs
@@ -39,6 +39,13 @@ internal static class HttpClientExtensions
 
         await response.EnsureSuccessfulApiCall(cancellationToken);
 
+        return await DeserializeResponseAsync<TBody>(response, cancellationToken);
+    }
+
+    static async Task<TBody?> DeserializeResponseAsync<TBody>(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
         var result = await response.Content.ReadAsStreamAsync(cancellationToken);
         return await JsonSerializerHelper.DeserializeFromCamelCaseJsonAsync<TBody>(
             result,
@@ -154,10 +161,7 @@ internal static class HttpClientExtensions
 
                 await response.EnsureSuccessfulApiCall(cancellationToken);
 
-                var result = await response.Content.ReadAsStreamAsync(cancellationToken);
-                return await JsonSerializerHelper.DeserializeFromCamelCaseJsonAsync<TBody>(
-                    result,
-                    cancellationToken: cancellationToken);
+                return await DeserializeResponseAsync<TBody>(response, cancellationToken);
             }
         }
     }
@@ -241,10 +245,7 @@ internal static class HttpClientExtensions
             {
                 if (response.IsSuccessStatusCode)
                 {
-                    var result = await response.Content.ReadAsStreamAsync(cancellationToken);
-                    return await JsonSerializerHelper.DeserializeFromCamelCaseJsonAsync<TBody>(
-                        result,
-                        cancellationToken: cancellationToken);
+                    return await DeserializeResponseAsync<TBody>(response, cancellationToken);
                 }
 
                 if (!ShouldRetry(response.StatusCode) || attempt > maxRetries)


### PR DESCRIPTION
## :bulb: Motivation and Context

The HTTP helpers repeated the same response stream reading and JSON deserialization code. Keeping three copies makes it easier for their response handling to drift even though their retry policies are intentionally different.

This extracts only the shared deserialization step. Retry status handling, circuit breaker behavior, compression, delays, cancellation, exception ordering, and response disposal remain unchanged.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --filter 'FullyQualifiedName~HttpClientExtensionsTests'`
- `bin/fmt --check`
- `git diff --check`
- Autoreview against `origin/main`

The focused tests passed on both target frameworks: 62 tests on `netcoreapp3.1` and 65 tests on `net8.0`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the refactor in a dedicated worktree with a worker subagent and ran the autoreview skill. The change deliberately shares only response deserialization instead of combining the two different retry policies.
