### PR TITLE
refactor: share feature flag event enrichment

### DIFF
--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -24,6 +24,10 @@ public sealed class PostHogClient : IPostHogClient
     readonly MemoryCache _featureFlagCalledEventCache;
     static readonly ApiResult NoOpApiResult = new(0);
     static readonly IReadOnlyDictionary<string, FeatureFlag> EmptyFeatureFlags = new Dictionary<string, FeatureFlag>(0);
+    static readonly Func<FeatureFlag, object> FeatureFlagResponseSelector = flag => flag.ToResponseObject();
+    static readonly Func<FeatureFlag, bool> FeatureFlagEnabledSelector = flag => (bool)flag;
+    static readonly Func<EvaluatedFlagRecord, object> EvaluatedFlagResponseSelector = record => record.Flag.ToResponseObject();
+    static readonly Func<EvaluatedFlagRecord, bool> EvaluatedFlagEnabledSelector = record => record.Enabled;
 
     // Strict allowlist for minimal $feature_flag_called events, shared across PostHog SDKs.
     // Everything else — including super properties, context properties, the $feature/<key>
@@ -581,28 +585,34 @@ public sealed class PostHogClient : IPostHogClient
     static CapturedEvent AddFeatureFlagsToCapturedEvent(
         CapturedEvent capturedEvent,
         IReadOnlyDictionary<string, FeatureFlag> flags)
-    {
-        capturedEvent.Properties.Merge(flags.ToDictionary(
-            f => $"$feature/{f.Key}",
-            f => f.Value.ToResponseObject()));
-        capturedEvent.Properties["$active_feature_flags"] = flags
-            .Where(f => (bool)f.Value)
-            .Select(kvp => kvp.Key)
-            .ToArray();
-        return capturedEvent;
-    }
+        => AddFeatureFlagsToCapturedEvent(
+            capturedEvent,
+            flags,
+            FeatureFlagResponseSelector,
+            FeatureFlagEnabledSelector);
 
     static CapturedEvent AddFeatureFlagsToCapturedEvent(
         CapturedEvent capturedEvent,
         FeatureFlagEvaluations flags)
+        => AddFeatureFlagsToCapturedEvent(
+            capturedEvent,
+            flags.Records,
+            EvaluatedFlagResponseSelector,
+            EvaluatedFlagEnabledSelector);
+
+    static CapturedEvent AddFeatureFlagsToCapturedEvent<TFlag>(
+        CapturedEvent capturedEvent,
+        IReadOnlyDictionary<string, TFlag> flags,
+        Func<TFlag, object> responseSelector,
+        Func<TFlag, bool> enabledSelector)
     {
         // Single-pass: per-flag $feature/<key> property + $active_feature_flags collection in one
-        // enumeration of the records dictionary. Runs per captured event, so worth keeping tight.
-        var active = new List<string>(flags.Records.Count);
-        foreach (var (key, record) in flags.Records)
+        // enumeration. The selectors are cached statically so this hot path does not allocate delegates.
+        var active = new List<string>(flags.Count);
+        foreach (var (key, flag) in flags)
         {
-            capturedEvent.Properties[$"$feature/{key}"] = record.Flag.ToResponseObject();
-            if (record.Enabled)
+            capturedEvent.Properties[$"$feature/{key}"] = responseSelector(flag);
+            if (enabledSelector(flag))
             {
                 active.Add(key);
             }

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -505,6 +505,44 @@ public class TheSnapshotFilterMethods
 public class TheCaptureWithFlagsSnapshotMethod
 {
     [Fact]
+    public async Task LegacyAndSnapshotInputsProduceIdenticalFeatureFlagProperties()
+    {
+        const string response =
+            """{"featureFlags": {"flag-a": true, "flag-b": false, "flag-c": "variant-x"}}""";
+        var container = new TestContainer();
+        container.FakeHttpMessageHandler.AddRepeatedFlagsResponse(2, response);
+        var batchHandler = container.FakeHttpMessageHandler.AddBatchResponse();
+        var client = container.Activate<PostHogClient>();
+
+        var snapshot = await client.EvaluateFlagsAsync("user-1", options: null, CancellationToken.None);
+        client.Capture("user-1", "snapshot", properties: null, groups: null, flags: snapshot);
+#pragma warning disable CS0618
+        client.Capture("user-1", "legacy", properties: null, groups: null, sendFeatureFlags: true);
+#pragma warning restore CS0618
+        await client.FlushAsync();
+
+        using var doc = JsonDocument.Parse(batchHandler.GetReceivedRequestBody(indented: false));
+        var events = doc.RootElement.GetProperty("batch").EnumerateArray().ToArray();
+        var snapshotProperties = events.Single(e => e.GetProperty("event").GetString() == "snapshot")
+            .GetProperty("properties");
+        var legacyProperties = events.Single(e => e.GetProperty("event").GetString() == "legacy")
+            .GetProperty("properties");
+
+        foreach (var propertyName in new[]
+                 {
+                     "$feature/flag-a",
+                     "$feature/flag-b",
+                     "$feature/flag-c",
+                     "$active_feature_flags"
+                 })
+        {
+            Assert.Equal(
+                legacyProperties.GetProperty(propertyName).GetRawText(),
+                snapshotProperties.GetProperty(propertyName).GetRawText());
+        }
+    }
+
+    [Fact]
     public async Task AttachesFeatureFlagPropertiesAndActiveFeatureFlagsFromSnapshot()
     {
         var container = new TestContainer();


### PR DESCRIPTION
## :bulb: Motivation and Context

Feature flag event enrichment had separate implementations for legacy flag dictionaries and evaluation snapshots. Both implementations add `$feature/<key>` properties and `$active_feature_flags`, so future changes could update one path without updating the other.

Both representations now use one private, single-pass implementation. Representation-specific selectors remain cached, and the snapshot path continues to use `EvaluatedFlagRecord.Enabled`.

## :green_heart: How did you test it?

- Added a parity test that captures equivalent legacy and snapshot flag results and compares all generated feature flag properties.
- `dotnet test tests/UnitTests/UnitTests.csproj -f net8.0 --filter 'FullyQualifiedName~FeatureFlagEvaluationsTests.TheCaptureWithFlagsSnapshotMethod'`
- `dotnet test tests/UnitTests/UnitTests.csproj -f net8.0 --no-restore`
- `dotnet build src/PostHog/PostHog.csproj --no-restore`
- `bin/fmt --check`
- `git diff --check`
- Autoreview against `origin/main`

The full `net8.0` unit suite passed with 1,057 tests passing and two existing tests skipped. The PostHog project built for all target frameworks with no warnings or errors.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the refactor in a dedicated worktree with a worker subagent and ran the autoreview skill. The shared implementation remains single-pass and avoids temporary dictionaries or per-event selector allocation.
