### PR TITLE
fix: preserve async exception stack trace frames

### DIFF
--- a/.changeset/async-stack-traces.md
+++ b/.changeset/async-stack-traces.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Fix async exception stack trace frames.

--- a/.changeset/async-stack-traces.md
+++ b/.changeset/async-stack-traces.md
@@ -1,5 +1,6 @@
 ---
 "PostHog": patch
+"PostHog.AspNetCore": patch
 ---
 
 Fix async exception stack trace frames.

--- a/src/PostHog/ErrorTracking/ExceptionPropertiesBuilder.cs
+++ b/src/PostHog/ErrorTracking/ExceptionPropertiesBuilder.cs
@@ -1,5 +1,7 @@
 ﻿using PostHog.Library;
 using PostHog.Versioning;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -102,6 +104,17 @@ internal class ExceptionPropertiesBuilder
             }
 
             var method = frame.GetMethod();
+            if (IsStackTraceHidden(method))
+            {
+                continue;
+            }
+
+            var displayMethod = GetDisplayMethod(method);
+            if (displayMethod != method && IsStackTraceHidden(displayMethod))
+            {
+                continue;
+            }
+
             var fileName = frame.GetFileName();
             var lineNumber = frame.GetFileLineNumber();
             var columnNumber = frame.GetFileColumnNumber();
@@ -112,8 +125,8 @@ internal class ExceptionPropertiesBuilder
                 ["lang"] = "dotnet",
                 ["filename"] = Path.GetFileName(fileName) ?? "",
                 ["abs_path"] = fileName ?? "",
-                ["function"] = method?.Name ?? "",
-                ["module"] = method?.DeclaringType?.FullName ?? "",
+                ["function"] = displayMethod?.Name ?? "",
+                ["module"] = displayMethod?.DeclaringType?.FullName ?? "",
                 ["lineno"] = lineNumber,
                 ["colno"] = columnNumber
             };
@@ -136,6 +149,80 @@ internal class ExceptionPropertiesBuilder
 
         return stackFrames;
     }
+
+    private static MethodBase? GetDisplayMethod(MethodBase? method)
+    {
+        if (method?.Name != nameof(IAsyncStateMachine.MoveNext))
+        {
+            return method;
+        }
+
+        var stateMachineType = method?.DeclaringType;
+        if (stateMachineType is null ||
+            !stateMachineType.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false))
+        {
+            return method;
+        }
+
+        var isAsyncStateMachine = typeof(IAsyncStateMachine).IsAssignableFrom(stateMachineType);
+        var declaringType = stateMachineType.DeclaringType;
+        if (declaringType is null)
+        {
+            return method;
+        }
+
+        foreach (var sourceMethod in declaringType.GetMethods(
+                     BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                     BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+        {
+            var asyncStateMachine = sourceMethod.GetCustomAttribute<AsyncStateMachineAttribute>();
+            if (isAsyncStateMachine && IsStateMachineType(asyncStateMachine?.StateMachineType, stateMachineType))
+            {
+                return sourceMethod;
+            }
+
+            if (HasAsyncIteratorStateMachineAttribute(sourceMethod, stateMachineType))
+            {
+                return sourceMethod;
+            }
+
+            var iteratorStateMachine = sourceMethod.GetCustomAttribute<IteratorStateMachineAttribute>();
+            if (IsStateMachineType(iteratorStateMachine?.StateMachineType, stateMachineType))
+            {
+                return sourceMethod;
+            }
+        }
+
+        return method;
+    }
+
+    private static bool HasAsyncIteratorStateMachineAttribute(MethodInfo sourceMethod, Type stateMachineType)
+    {
+        foreach (var attribute in sourceMethod.GetCustomAttributesData())
+        {
+            if (attribute.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute" &&
+                attribute.ConstructorArguments.FirstOrDefault().Value is Type attributedType &&
+                IsStateMachineType(attributedType, stateMachineType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsStateMachineType(Type? attributedType, Type stateMachineType)
+        => attributedType == stateMachineType ||
+           (attributedType?.IsGenericType == true && stateMachineType.IsGenericType &&
+            attributedType.GetGenericTypeDefinition() == stateMachineType.GetGenericTypeDefinition());
+
+    private static bool IsStackTraceHidden(MethodBase? method)
+        => method is not null &&
+           (HasStackTraceHiddenAttribute(method) || HasStackTraceHiddenAttribute(method.DeclaringType));
+
+    private static bool HasStackTraceHiddenAttribute(MemberInfo? member)
+        => member?.GetCustomAttributesData().Any(attribute =>
+            attribute.AttributeType.FullName == "System.Diagnostics.StackTraceHiddenAttribute") == true;
 
     private static SourceCodeContext BuildSourceCodeContext(
         string absolutePath,

--- a/tests/UnitTests/PostHogClientTests.cs
+++ b/tests/UnitTests/PostHogClientTests.cs
@@ -1314,6 +1314,60 @@ public class TheCaptureExceptionMethod
     }
 
     [Fact]
+    public async Task CaptureExceptionUsesLogicalAsyncMethodName()
+    {
+        var (_, requestHandler, client) = CreateClient();
+        var exception = await CreateExceptionAfterAwaitAsync();
+
+        client.CaptureException(exception, "some-distinct-id");
+        await client.FlushAsync();
+
+        var (_, _, properties) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: false));
+        var frames = GetStackFrames(GetFirstException(properties));
+
+        Assert.Contains(frames, frame =>
+            frame.GetProperty("function").GetString() == nameof(CreateExceptionAfterAwaitAsync) &&
+            frame.GetProperty("module").GetString() == typeof(TheCaptureExceptionMethod).FullName);
+        Assert.DoesNotContain(frames, frame => frame.GetProperty("function").GetString() == "MoveNext");
+    }
+
+    [Fact]
+    public async Task CaptureExceptionUsesLogicalAsyncIteratorMethodName()
+    {
+        var (_, requestHandler, client) = CreateClient();
+        var exception = await CreateExceptionFromAsyncIteratorAsync();
+
+        client.CaptureException(exception, "some-distinct-id");
+        await client.FlushAsync();
+
+        var (_, _, properties) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: false));
+        var frames = GetStackFrames(GetFirstException(properties));
+
+        Assert.Contains(frames, frame =>
+            frame.GetProperty("function").GetString() == nameof(ThrowFromAsyncIteratorAfterAwait) &&
+            frame.GetProperty("module").GetString() == typeof(TheCaptureExceptionMethod).FullName);
+        Assert.DoesNotContain(frames, frame => frame.GetProperty("function").GetString() == "MoveNext");
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public async Task CaptureExceptionOmitsStackTraceHiddenFrames()
+    {
+        var (_, requestHandler, client) = CreateClient();
+        var exception = CreateExceptionThroughHiddenMethod();
+
+        client.CaptureException(exception, "some-distinct-id");
+        await client.FlushAsync();
+
+        var (_, _, properties) = ParseSingleEvent(requestHandler.GetReceivedRequestBody(indented: false));
+        var frames = GetStackFrames(GetFirstException(properties));
+
+        Assert.DoesNotContain(frames, frame =>
+            frame.GetProperty("function").GetString() == nameof(ThrowFromHiddenMethod));
+    }
+#endif
+
+    [Fact]
     public async Task CaptureExceptionWithAggregateException()
     {
         var (container, requestHandler, client) = CreateClient();
@@ -1570,6 +1624,65 @@ public class TheCaptureExceptionMethod
             }
         }
     }
+
+    private static async Task<InvalidOperationException> CreateExceptionAfterAwaitAsync()
+    {
+        try
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("Async exception");
+        }
+        catch (InvalidOperationException exception)
+        {
+            return exception;
+        }
+    }
+
+    private static async Task<InvalidOperationException> CreateExceptionFromAsyncIteratorAsync()
+    {
+        try
+        {
+            await foreach (var _ in ThrowFromAsyncIteratorAfterAwait())
+            {
+            }
+
+            throw new InvalidOperationException("Unreachable");
+        }
+        catch (InvalidOperationException exception)
+        {
+            return exception;
+        }
+    }
+
+    private static async IAsyncEnumerable<int> ThrowFromAsyncIteratorAfterAwait()
+    {
+        await Task.Yield();
+        if (DateTime.UtcNow.Year == 1)
+        {
+            yield return 0;
+        }
+
+        throw new InvalidOperationException("Async iterator exception");
+    }
+
+#if NET8_0_OR_GREATER
+    private static InvalidOperationException CreateExceptionThroughHiddenMethod()
+    {
+        try
+        {
+            ThrowFromHiddenMethod();
+            throw new InvalidOperationException("Unreachable");
+        }
+        catch (InvalidOperationException exception)
+        {
+            return exception;
+        }
+    }
+
+    [System.Diagnostics.StackTraceHidden]
+    private static void ThrowFromHiddenMethod()
+        => throw new InvalidOperationException("Hidden exception");
+#endif
 
     // This test is pretty expensive because it dynamically compiles and loads an assembly.
     // Consider alternatives.


### PR DESCRIPTION
Fixes #166.

## Summary
- map compiler-generated async and iterator state-machine frames to their source methods
- omit StackTraceHidden frames while preserving source locations from the original StackFrame
- cover async method names and hidden frames in exception-capture tests

## Testing
- `dotnet test tests/UnitTests/UnitTests.csproj --filter "FullyQualifiedName~TheCaptureExceptionMethod.CaptureExceptionUsesLogicalAsyncMethodName|FullyQualifiedName~TheCaptureExceptionMethod.CaptureExceptionOmitsStackTraceHiddenFrames" -p:TreatWarningsAsErrors=false`
  - net8.0: 2 passed
  - netcoreapp3.1: 1 passed (StackTraceHidden test is net8.0-only)