### PR TITLE
fix(flags): handle empty evaluation key scopes

### DIFF
--- a/.changeset/empty-evaluation-key-scopes.md
+++ b/.changeset/empty-evaluation-key-scopes.md
@@ -1,5 +1,5 @@
 ---
-"PostHog": patch
+"PostHog": minor
 "PostHog.AspNetCore": patch
 ---
 

--- a/.changeset/empty-evaluation-key-scopes.md
+++ b/.changeset/empty-evaluation-key-scopes.md
@@ -1,0 +1,6 @@
+---
+"PostHog": patch
+"PostHog.AspNetCore": patch
+---
+
+Return an empty feature flag snapshot without evaluation work when `FlagKeysToEvaluate` is explicitly empty.

--- a/src/PostHog/Features/FeatureFlagEvaluations.cs
+++ b/src/PostHog/Features/FeatureFlagEvaluations.cs
@@ -190,7 +190,10 @@ public sealed class FeatureFlagEvaluations
     /// <c>EvaluateFlagsAsync</c> is called without a usable distinct id, or when remote evaluation
     /// is quota-limited.
     /// </summary>
-    internal static FeatureFlagEvaluations Empty(IFeatureFlagEvaluationsHost host, string distinctId)
+    internal static FeatureFlagEvaluations Empty(
+        IFeatureFlagEvaluationsHost host,
+        string distinctId,
+        GroupCollection? groups = null)
         => new(
             host,
             distinctId,
@@ -198,7 +201,7 @@ public sealed class FeatureFlagEvaluations
             requestId: null,
             evaluatedAt: null,
             flagDefinitionsLoadedAt: null,
-            groups: null,
+            groups,
             errors: null);
 
     EvaluatedFlagRecord? RecordAccess(string key)

--- a/src/PostHog/Features/FeatureFlagOptions.cs
+++ b/src/PostHog/Features/FeatureFlagOptions.cs
@@ -48,15 +48,17 @@ public class AllFeatureFlagsOptions
     public GroupCollection? Groups { get; init; }
 
     /// <summary>
-    /// The set of flag keys to evaluate in this request. If not specified, all flags are evaluated.
+    /// The set of flag keys to evaluate in this request. If omitted or <c>null</c>, all flags are evaluated.
+    /// An empty list evaluates no flags.
     /// </summary>
     /// <remarks>
-    /// This scopes local evaluation, the <c>/flags</c> request, and the returned result. A requested
+    /// This scopes local evaluation, the <c>/flags</c> request, and the returned result. An empty list
+    /// returns an empty snapshot without consulting caches, local definitions, or <c>/flags</c>. A requested
     /// key missing from local definitions triggers remote fallback unless <see cref="OnlyEvaluateLocally"/>
     /// is <c>true</c>. When <c>EvaluateFlagsAsync</c> falls back with a non-empty scope, it bypasses
     /// the general feature flag cache, so a key absent remotely costs one request per call.
     /// </remarks>
-    public IReadOnlyList<string> FlagKeysToEvaluate { get; init; } = [];
+    public IReadOnlyList<string>? FlagKeysToEvaluate { get; init; }
 
     /// <summary>
     /// Whether to disable GeoIP enrichment for the feature flag request. Defaults to <c>false</c>.

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -1061,6 +1061,11 @@ public sealed class PostHogClient : IPostHogClient
             return FeatureFlagEvaluations.Empty(_evaluationsHost, resolvedDistinctId ?? string.Empty);
         }
 
+        if (options?.FlagKeysToEvaluate is { Count: 0 })
+        {
+            return FeatureFlagEvaluations.Empty(_evaluationsHost, resolvedDistinctId ?? string.Empty);
+        }
+
         if (RequiresMissingPersonalApiKey(options, nameof(EvaluateFlagsAsync)))
         {
             return FeatureFlagEvaluations.Empty(_evaluationsHost, resolvedDistinctId ?? string.Empty);

--- a/src/PostHog/PostHogClient.cs
+++ b/src/PostHog/PostHogClient.cs
@@ -1063,7 +1063,10 @@ public sealed class PostHogClient : IPostHogClient
 
         if (options?.FlagKeysToEvaluate is { Count: 0 })
         {
-            return FeatureFlagEvaluations.Empty(_evaluationsHost, resolvedDistinctId ?? string.Empty);
+            return FeatureFlagEvaluations.Empty(
+                _evaluationsHost,
+                resolvedDistinctId ?? string.Empty,
+                options.Groups);
         }
 
         if (RequiresMissingPersonalApiKey(options, nameof(EvaluateFlagsAsync)))

--- a/src/PostHog/PublicAPI.Shipped.txt
+++ b/src/PostHog/PublicAPI.Shipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 PostHog.AllFeatureFlagsOptions
 PostHog.AllFeatureFlagsOptions.AllFeatureFlagsOptions() -> void
-PostHog.AllFeatureFlagsOptions.FlagKeysToEvaluate.get -> System.Collections.Generic.IReadOnlyList<string!>!
+PostHog.AllFeatureFlagsOptions.FlagKeysToEvaluate.get -> System.Collections.Generic.IReadOnlyList<string!>?
 PostHog.AllFeatureFlagsOptions.FlagKeysToEvaluate.init -> void
 PostHog.AllFeatureFlagsOptions.Groups.get -> PostHog.GroupCollection?
 PostHog.AllFeatureFlagsOptions.Groups.init -> void

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -78,17 +78,28 @@ public class TheEvaluateFlagsAsyncMethod
             """{"flags": [{"id": 1, "key": "local-flag", "active": true}]}""");
         var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
             """{"featureFlags": {"remote-flag": true}}""");
+        var batchHandler = container.FakeHttpMessageHandler.AddBatchResponse();
         var cache = Substitute.For<IFeatureFlagCache>();
         var client = container.Activate<PostHogClient>(cache);
 
         var snapshot = await client.EvaluateFlagsAsync(
             "user-1",
-            new AllFeatureFlagsOptions { FlagKeysToEvaluate = [] },
+            new AllFeatureFlagsOptions
+            {
+                FlagKeysToEvaluate = [],
+                Groups = new GroupCollection { { "company", "acme" } }
+            },
             CancellationToken.None);
 
         Assert.Empty(snapshot.Keys);
         Assert.Null(snapshot.RequestId);
         Assert.Null(snapshot.EvaluatedAt);
+        Assert.False(snapshot.IsEnabled("missing-flag"));
+        await client.FlushAsync();
+
+        using var doc = JsonDocument.Parse(batchHandler.GetReceivedRequestBody(indented: false));
+        var properties = doc.RootElement.GetProperty("batch").EnumerateArray().Single().GetProperty("properties");
+        Assert.Equal("acme", properties.GetProperty("$groups").GetProperty("company").GetString());
         Assert.Empty(cache.ReceivedCalls());
         Assert.Empty(localHandler.ReceivedRequests);
         Assert.Empty(flagsHandler.ReceivedRequests);

--- a/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
+++ b/tests/UnitTests/Features/FeatureFlagEvaluationsTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NSubstitute;
 using PostHog;
 using PostHog.Features;
 using UnitTests.Fakes;
@@ -18,8 +19,10 @@ public class TheEvaluateFlagsAsyncMethod
             ]}
             """);
 
-    [Fact]
-    public async Task ReturnsSnapshotWithRichMetadataFromOneFlagsRequest()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task NullOptionsAndOmittedFlagKeysReturnSnapshotFromOneFlagsRequest(bool passOptions)
     {
         var container = new TestContainer();
         var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
@@ -45,7 +48,8 @@ public class TheEvaluateFlagsAsyncMethod
             """);
         var client = container.Activate<PostHogClient>();
 
-        var snapshot = await client.EvaluateFlagsAsync("user-1", options: null, CancellationToken.None);
+        var options = passOptions ? new AllFeatureFlagsOptions() : null;
+        var snapshot = await client.EvaluateFlagsAsync("user-1", options, CancellationToken.None);
 
         Assert.Equal(2, snapshot.Keys.Count);
         Assert.Equal("the-request-id", snapshot.RequestId);
@@ -63,6 +67,30 @@ public class TheEvaluateFlagsAsyncMethod
         var snapshot = await client.EvaluateFlagsAsync(string.Empty, options: null, CancellationToken.None);
 
         Assert.Empty(snapshot.Keys);
+        Assert.Empty(flagsHandler.ReceivedRequests);
+    }
+
+    [Fact]
+    public async Task ExplicitEmptyFlagKeysReturnEmptySnapshotWithoutEvaluationWork()
+    {
+        var container = new TestContainer(personalApiKey: "fake-personal-api-key");
+        var localHandler = container.FakeHttpMessageHandler.AddLocalEvaluationResponse(
+            """{"flags": [{"id": 1, "key": "local-flag", "active": true}]}""");
+        var flagsHandler = container.FakeHttpMessageHandler.AddFlagsResponse(
+            """{"featureFlags": {"remote-flag": true}}""");
+        var cache = Substitute.For<IFeatureFlagCache>();
+        var client = container.Activate<PostHogClient>(cache);
+
+        var snapshot = await client.EvaluateFlagsAsync(
+            "user-1",
+            new AllFeatureFlagsOptions { FlagKeysToEvaluate = [] },
+            CancellationToken.None);
+
+        Assert.Empty(snapshot.Keys);
+        Assert.Null(snapshot.RequestId);
+        Assert.Null(snapshot.EvaluatedAt);
+        Assert.Empty(cache.ReceivedCalls());
+        Assert.Empty(localHandler.ReceivedRequests);
         Assert.Empty(flagsHandler.ReceivedRequests);
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The evaluate-flags specification now distinguishes an omitted key scope from an explicitly empty scope. This implements [sdk-specs PR #47](https://github.com/PostHog/sdk-specs/pull/47) for the .NET SDK.

When `FlagKeysToEvaluate` is omitted or null, `EvaluateFlagsAsync` evaluates all available flags as before. When it is explicitly empty, the method returns an empty snapshot without consulting the cache, loading local definitions, or calling `/flags`, while retaining group context for subsequent `$feature_flag_called` events. A non-empty list continues to scope local evaluation, remote evaluation, and the returned snapshot to those keys.

The nullable public API baseline update is intentional. It preserves the difference between an omitted or null scope and an explicitly empty scope.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj -c Release -f net8.0 --filter 'FullyQualifiedName~TheEvaluateFlagsAsyncMethod' --no-restore` - passed 21 tests with 0 failures.
- `dotnet test tests/UnitTests/UnitTests.csproj -c Release -f netcoreapp3.1 --filter 'FullyQualifiedName~TheEvaluateFlagsAsyncMethod' --no-restore` - passed 21 tests with 0 failures.
- `dotnet build src/PostHog/PostHog.csproj -c Release --no-restore` - built all three target frameworks with 0 warnings and 0 errors.
- `bin/fmt --check` - passed.
- `git diff --check` - passed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi worker agent followed the PR workflow and used the bundled Pi autoreview skill. Autoreview flagged the change from a non-null default collection to a nullable property as a compatibility concern. The change was kept because the accepted SDK specification requires .NET to preserve the difference between an omitted or null scope and an explicitly empty scope. The public API baseline and XML documentation make that intentional contract visible to reviewers.

