### PR TITLE
fix(flags): align presence operator semantics

### DIFF
--- a/.changeset/calm-flags-align.md
+++ b/.changeset/calm-flags-align.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Align local `is_set` and `is_not_set` evaluation with partial property context.

--- a/.changeset/calm-flags-align.md
+++ b/.changeset/calm-flags-align.md
@@ -1,5 +1,6 @@
 ---
 "PostHog": patch
+"PostHog.AspNetCore": patch
 ---
 
 Align local `is_set` and `is_not_set` evaluation with partial property context.

--- a/src/PostHog/Features/LocalEvaluator.cs
+++ b/src/PostHog/Features/LocalEvaluator.cs
@@ -610,7 +610,6 @@ internal sealed class LocalEvaluator
     /// </summary>
     /// <remarks>
     /// Only looks for matches where the key exists in properties.
-    /// Doesn't support the operator <c>is_not_set</c>.
     /// </remarks>
     /// <param name="propertyFilter">The <see cref="PropertyFilter"/> to evaluate.</param>
     /// <param name="distinctId">The identifier you use for the user.</param>
@@ -623,11 +622,6 @@ internal sealed class LocalEvaluator
         {
             // Flag dependencies can't be evaluated from this context, throw inconclusive
             throw new InconclusiveMatchException($"Flag dependency '{propertyFilter.Key}' cannot be evaluated without evaluation context");
-        }
-
-        if (propertyFilter.Operator is ComparisonOperator.IsNotSet)
-        {
-            throw new InconclusiveMatchException("Can't match properties with operator is_not_set");
         }
 
         var key = NotNull(propertyFilter.Key);
@@ -654,9 +648,9 @@ internal sealed class LocalEvaluator
             throw new InconclusiveMatchException("Can't match properties without a given property value");
         }
 
-        if (propertyFilter.Operator is ComparisonOperator.IsSet)
+        if (propertyFilter.Operator is ComparisonOperator.IsSet or ComparisonOperator.IsNotSet)
         {
-            return overrideValue is not null;
+            return propertyFilter.Operator is ComparisonOperator.IsSet;
         }
 
         if (propertyFilter.Value is not { } value)

--- a/tests/UnitTests/Features/LocalEvaluatorTests.cs
+++ b/tests/UnitTests/Features/LocalEvaluatorTests.cs
@@ -238,11 +238,19 @@ public class TheEvaluateFeatureFlagMethod
         Assert.Equal(expected, result);
     }
 
+    public static IEnumerable<object?[]> PresentPropertyValues =>
+    [
+        ["null", null],
+        ["false", false],
+        ["zero", 0],
+        ["empty string", ""],
+        ["empty list", new List<object?>()],
+        ["empty object", new Dictionary<string, object?>()]
+    ];
+
     [Theory]
-    [InlineData("test@posthog.com", true)]
-    [InlineData("", true)]
-    [InlineData(null, false)]
-    public void HandlesIsSet(string? email, bool expected)
+    [MemberData(nameof(PresentPropertyValues))]
+    public void IsSetReturnsTrueWhenPropertyIsPresent(string _, object? propertyValue)
     {
         var flags = CreateFlags(
             key: "email",
@@ -257,7 +265,7 @@ public class TheEvaluateFeatureFlagMethod
         );
         var properties = new Dictionary<string, object?>
         {
-            ["email"] = email
+            ["email"] = propertyValue
         };
         var localEvaluator = new LocalEvaluator(flags);
 
@@ -266,14 +274,12 @@ public class TheEvaluateFeatureFlagMethod
             distinctId: "1234",
             personProperties: properties);
 
-        Assert.Equal(expected, result);
+        Assert.True(result.Value);
     }
 
     [Theory]
-    [InlineData("test@posthog.com")]
-    [InlineData("")]
-    [InlineData(null)]
-    public void ThrowsInconclusiveMatchExceptionWhenOperatorIsIsNotSet(string? email)
+    [MemberData(nameof(PresentPropertyValues))]
+    public void IsNotSetReturnsFalseWhenPropertyIsPresent(string _, object? propertyValue)
     {
         var flags = CreateFlags(
             key: "email",
@@ -288,18 +294,22 @@ public class TheEvaluateFeatureFlagMethod
         );
         var properties = new Dictionary<string, object?>
         {
-            ["email"] = email
+            ["email"] = propertyValue
         };
         var localEvaluator = new LocalEvaluator(flags);
 
-        Assert.Throws<InconclusiveMatchException>(() => localEvaluator.EvaluateFeatureFlag(
+        var result = localEvaluator.EvaluateFeatureFlag(
             key: "email",
             distinctId: "1234",
-            personProperties: properties));
+            personProperties: properties);
+
+        Assert.False(result.Value);
     }
 
-    [Fact]
-    public void ThrowsInconclusiveMatchExceptionWhenKeyDoesNotMatch()
+    [Theory]
+    [InlineData(ComparisonOperator.IsSet)]
+    [InlineData(ComparisonOperator.IsNotSet)]
+    public void ThrowsInconclusiveMatchExceptionWhenPropertyKeyIsMissing(ComparisonOperator comparison)
     {
         var flags = CreateFlags(
             key: "email",
@@ -308,20 +318,12 @@ public class TheEvaluateFeatureFlagMethod
                 {
                     Type = FilterType.Person,
                     Key = "email",
-                    Value = new PropertyFilterValue("is_set"),
-                    Operator = ComparisonOperator.IsSet
+                    Operator = comparison
                 }
             ]
         );
         var localEvaluator = new LocalEvaluator(flags);
 
-        Assert.Throws<InconclusiveMatchException>(() => localEvaluator.EvaluateFeatureFlag(
-            key: "email",
-            distinctId: "1234",
-            personProperties: new()
-            {
-                ["not-email"] = "anything"
-            }));
         Assert.Throws<InconclusiveMatchException>(() => localEvaluator.EvaluateFeatureFlag(
             key: "email",
             distinctId: "1234",


### PR DESCRIPTION
## :bulb: Motivation and Context

[sdk-specs PR #49](https://github.com/PostHog/sdk-specs/pull/49) defines presence operators using property-key presence and partial property context. The .NET local evaluator treated a present null value as not set and could not resolve `is_not_set` when the key was present. This could disagree with remote flag evaluation.

This change makes every present key match `is_set` and not match `is_not_set`, including null and other falsey values. An omitted key remains inconclusive so remote evaluation stays eligible.

## :green_heart: How did you test it?

- `dotnet test tests/UnitTests/UnitTests.csproj --filter FullyQualifiedName~LocalEvaluatorTests`
- `dotnet build tests/UnitTests/UnitTests.csproj --configuration Release --no-restore --nologo`
- `bin/fmt --check`
- `pnpm changeset status` (patches `PostHog` and `PostHog.AspNetCore`)
- Autoreview completed on commit `2f93275` with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent worker subagents implemented and validated the focused change. The bundled autoreview tool reviewed the final committed diff against `origin/main`.
